### PR TITLE
Fix text-flip.mdx

### DIFF
--- a/content/docs/text/text-flip.mdx
+++ b/content/docs/text/text-flip.mdx
@@ -22,7 +22,7 @@ module.exports = {
         foreground: "hsl(var(--foreground))",
       },
       keyframes: {
-        flipWords: {
+        "flip-words": {
           "10%": { transform: "translateY(-112%)" },
           "25%": { transform: "translateY(-100%)" },
           "35%": { transform: "translateY(-212%)" },
@@ -34,7 +34,7 @@ module.exports = {
         },
       },
       animation: {
-        flipWords: "flipWords 8s infinite",
+        "flip-words": "flip-words 8s infinite",
       },
     },
   },


### PR DESCRIPTION
text-flip not working. Reason is that naming is not matching between tailwind.config.ts and text-flip.tsx. Differing names: flip-words & flipWords. Renamed to flip-words as that is coherent with the naming standard of Animata.