### PR TITLE
Update swap-text-card.mdx

### DIFF
--- a/content/docs/card/swap-text-card.mdx
+++ b/content/docs/card/swap-text-card.mdx
@@ -12,7 +12,7 @@ labels: ["requires interaction", "hover"]
 <Steps>
 <Step>Install dependencies</Step>
 
-This uses [SwapText](/docs/card/swap-text) for the text. Install it by following the instructions [here](/docs/swap/wave-text#installation).
+This uses [SwapText](/docs/text/swap-text) for the text. Install it by following the instructions [here](/docs/text/swap-text#installation).
 
 <Step>Run the following command</Step>
 


### PR DESCRIPTION
Fix incorrect URL in documentation, updating the link to point to the correct text-swap documentation.