### PR TITLE
fix(mask-text): fix text-foreground repetition

### DIFF
--- a/animata/text/mask-text.tsx
+++ b/animata/text/mask-text.tsx
@@ -27,7 +27,7 @@ export default function MaskText({
   return (
     <div className={cn("relative h-screen", className)} ref={containerRef}>
       <motion.div
-        className={cn(common, "absolute bg-black text-foreground")}
+        className={cn(common, "absolute bg-black")}
         style={{
           maskImage: "url(/circle.svg)",
           maskRepeat: "no-repeat",


### PR DESCRIPTION
Removed redundant `className` as `text-foreground` is already defined in the `common` styles.