### PR TITLE
a11y: improve heading hierarchy in StatsBento component

### DIFF
--- a/app/(main)/_landing/stats-bento.tsx
+++ b/app/(main)/_landing/stats-bento.tsx
@@ -313,9 +313,9 @@ export default function StatsBento() {
             <div className="flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
               {/* Left — statement */}
               <div>
-                <h3 className="font-[family-name:var(--font-display)] text-[clamp(1.5rem,4vw,2.25rem)] leading-[1.1] text-foreground">
+                <h2 className="font-[family-name:var(--font-display)] text-[clamp(1.5rem,4vw,2.25rem)] leading-[1.1] text-foreground">
                   We did the hard part.
-                </h3>
+                </h2>
                 <p className="mt-1 text-[clamp(1.5rem,4vw,2.25rem)] leading-[1.1] text-muted-foreground font-[family-name:var(--font-display)]">
                   So you don&apos;t have to.
                 </p>


### PR DESCRIPTION
Updated the heading levels in the `StatsBento` component to ensure a proper semantic structure.

**Changes**
Changed the `<h3>` tag for the text *"We did the hard part."* to an `<h2>`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved semantic HTML structure in stats display for enhanced accessibility and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->