### PR TITLE
chore(ci): migrate actions runtime to Node 24

### DIFF
--- a/.github/workflows/deploy-v3.yml
+++ b/.github/workflows/deploy-v3.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: v3-deployment
     env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/deploy-v3.yml
+++ b/.github/workflows/deploy-v3.yml
@@ -9,17 +9,19 @@ jobs:
   deploy-v3:
     runs-on: ubuntu-latest
     environment: v3-deployment
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
       - name: Install yarn
         run: npm install -g yarn
       - name: Restore cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             .next/cache

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,19 +11,21 @@ jobs:
     if: github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     environment: preview-deployment
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
       - name: Install yarn
         run: npm install -g yarn
       - name: Restore cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             .next/cache

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: preview-deployment
     env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Upgrade workflow actions to Node 24-compatible versions.
- Set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` in deployment workflows.
- Quote env value explicitly as `"true"` for YAML clarity.

## Files
- .github/workflows/deploy.yml
- .github/workflows/deploy-v3.yml
