### PR TITLE
Fix typo in button label from 'Aloglia' to 'Algolia'

### DIFF
--- a/animata/button/algolia-blue-button.tsx
+++ b/animata/button/algolia-blue-button.tsx
@@ -15,7 +15,7 @@ export default function AlgoliaBlueButton() {
           box-shadow: #3c4fe0 0 3px 7px inset;
         }
       `}</style>
-      Aloglia Blue
+      Algolia Blue
     </button>
   );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the spelling of a button label text from "Aloglia Blue" to "Algolia Blue".

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/codse/animata/pull/460)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->