### PR TITLE
feat: Card Stack, Split Reveal, and photographer portfolio demo

### DIFF
--- a/animata/card/card-stack.stories.tsx
+++ b/animata/card/card-stack.stories.tsx
@@ -1,0 +1,132 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ArrowRight, Heart, MessageCircle } from "lucide-react";
+import CardStack, { CARD_STACK_MASK_IDS, type CardStackItem } from "@/animata/card/card-stack";
+
+const demoCards: CardStackItem[] = [
+  {
+    id: "hari",
+    image:
+      "https://assets.lummi.ai/assets/QmPyqQgSM8sDVrcQxRwUA6fTDaeXkLMvpf6Z3Kx4aCg3pU?auto=format&w=500",
+    title: "Hari Lamichhane",
+    tagline: "Software Engineer",
+    counts: { like: 142, comment: 23 },
+    maskId: CARD_STACK_MASK_IDS[0],
+  },
+  {
+    id: "sudha",
+    image:
+      "https://assets.lummi.ai/assets/QmVDPTUj31YYC4ycLmn3r1FhuSZDHBdK4d3Pk4gdbyB5MZ?auto=format&w=200",
+    title: "Sudha Shrestha",
+    tagline: "ML Engineer",
+    counts: { like: 98, comment: 17 },
+    maskId: CARD_STACK_MASK_IDS[1],
+  },
+  {
+    id: "sofia",
+    image:
+      "https://assets.lummi.ai/assets/QmXp6StB1i36XHbbmppop5AwtQgnyom8bYTZqPkLVNGJnk?auto=format&w=200",
+    title: "Sofia",
+    tagline: "Software Engineer",
+    counts: { like: 176, comment: 41 },
+    maskId: CARD_STACK_MASK_IDS[2],
+  },
+  {
+    id: "someone",
+    image:
+      "https://assets.lummi.ai/assets/QmWmYYozQAtxLohY8Hy1yopo4ds25KokJfNdtqybXnR5cw?auto=format&w=200",
+    title: "Someone",
+    tagline: "Doctor",
+    counts: { like: 64, comment: 12 },
+    maskId: CARD_STACK_MASK_IDS[3],
+  },
+  {
+    id: "ammy",
+    image:
+      "https://assets.lummi.ai/assets/QmdybQRQqnqUKugP2e9hTaQi9GUciQkBADkrMVJ6GERsS2?auto=format&w=200",
+    title: "Ammy",
+    tagline: "Pilot",
+    counts: { like: 211, comment: 33 },
+    maskId: CARD_STACK_MASK_IDS[0],
+  },
+  {
+    id: "bhagwati",
+    image:
+      "https://assets.lummi.ai/assets/QmaEVTC9eFZtSLTJmMVNpd2t9ctw1BXPzQKV4rhja62Y5z?auto=format&w=1500",
+    title: "Bhagwati",
+    tagline: "Pharmacist",
+    counts: { like: 87, comment: 9 },
+    maskId: CARD_STACK_MASK_IDS[1],
+  },
+];
+
+const meta = {
+  title: "Card/Card Stack",
+  component: CardStack,
+  parameters: {
+    layout: "fullscreen",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    items: { control: false },
+    depth: { control: { type: "number", min: 1, max: 3 } },
+  },
+} satisfies Meta<typeof CardStack>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: {
+    items: demoCards,
+    depth: 3,
+    children: null,
+  },
+  render: ({ items, depth }) => (
+    <div className="full-content w-full">
+      <CardStack items={items} depth={depth}>
+        <CardStack.Frame className="relative w-full max-w-sm mx-auto overflow-hidden">
+          <CardStack.Masks />
+
+          <div className="relative flex flex-col px-4 pb-10 pt-16 sm:px-6 sm:pt-20">
+            <CardStack.LiveRegion />
+
+            <CardStack.Trigger className="w-full drop-shadow-2xl">
+              <CardStack.Viewport>
+                <CardStack.List>
+                  {(item, index, layer) => (
+                    <CardStack.Card key={item.id} layer={layer} stackIndex={index}>
+                      <CardStack.Header>
+                        <CardStack.Avatar src={item.image} />
+                        <CardStack.Meta title={item.title} tagline={item.tagline} />
+                      </CardStack.Header>
+
+                      <CardStack.Media
+                        src={item.image}
+                        alt={`Portrait of ${item.title}`}
+                        maskId={item.maskId}
+                      />
+
+                      <CardStack.Footer>
+                        <CardStack.Metric icon={Heart} label="Likes" value={item.counts.like} />
+                        <CardStack.Metric
+                          icon={MessageCircle}
+                          label="Comments"
+                          value={item.counts.comment}
+                          className="ms-1"
+                        />
+                        <ArrowRight
+                          aria-hidden
+                          className="ml-auto size-6 shrink-0 text-muted-foreground"
+                        />
+                      </CardStack.Footer>
+                    </CardStack.Card>
+                  )}
+                </CardStack.List>
+              </CardStack.Viewport>
+            </CardStack.Trigger>
+          </div>
+        </CardStack.Frame>
+      </CardStack>
+    </div>
+  ),
+};

--- a/animata/card/card-stack.stories.tsx
+++ b/animata/card/card-stack.stories.tsx
@@ -107,11 +107,15 @@ export const Primary: Story = {
                       />
 
                       <CardStack.Footer>
-                        <CardStack.Metric icon={Heart} label="Likes" value={item.counts.like} />
+                        <CardStack.Metric
+                          icon={Heart}
+                          label="Likes"
+                          value={item.counts?.like ?? 0}
+                        />
                         <CardStack.Metric
                           icon={MessageCircle}
                           label="Comments"
-                          value={item.counts.comment}
+                          value={item.counts?.comment ?? 0}
                           className="ms-1"
                         />
                         <ArrowRight

--- a/animata/card/card-stack.tsx
+++ b/animata/card/card-stack.tsx
@@ -21,10 +21,10 @@ import { CardStackMaskDefs } from "@/components/shapes/card-stack-mask-defs";
 import { cn } from "@/lib/utils";
 
 export const CARD_STACK_MASK_IDS = [
-  "cs_mask_1_ellipse-1",
-  "cs_mask_1_flower-14",
-  "cs_mask_1_flower-1",
-  "cs_mask_1_misc-5",
+  "cardstack_mask_ellipse-1",
+  "cardstack_mask_flower-14",
+  "cardstack_mask_flower-1",
+  "cardstack_mask_misc-5",
 ] as const;
 
 export type CardStackMaskId = (typeof CARD_STACK_MASK_IDS)[number];
@@ -36,7 +36,7 @@ export interface CardStackItem {
   image: string;
   title: string;
   tagline: string;
-  counts: {
+  counts?: {
     like: number;
     comment: number;
   };
@@ -279,7 +279,11 @@ function CardStackRoot({
   children,
 }: CardStackRootProps) {
   const reducedMotion = usePrefersReducedMotion();
-  const layers = useMemo(() => getCardStackLayers(reducedMotion, depth), [reducedMotion, depth]);
+  const stackDepth = Math.min(Math.max(1, depth), STACK_LAYER_PRESETS.length);
+  const layers = useMemo(
+    () => getCardStackLayers(reducedMotion, stackDepth),
+    [reducedMotion, stackDepth],
+  );
   const [itemList, setItemList] = useState(items);
   const [isAnimating, setIsAnimating] = useState(false);
   const [pressActive, setPressActive] = useState(false);
@@ -289,7 +293,7 @@ function CardStackRoot({
   const autoplayTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const advanceRef = useRef<() => void>(() => {});
 
-  const visibleItems = itemList.slice(0, depth);
+  const visibleItems = itemList.slice(0, stackDepth);
   const activeItem = visibleItems[0];
 
   const clearStepTimer = useCallback(() => {
@@ -305,6 +309,14 @@ function CardStackRoot({
       autoplayTimerRef.current = null;
     }
   }, []);
+
+  useEffect(() => {
+    clearStepTimer();
+    clearAutoplayTimer();
+    isAnimatingRef.current = false;
+    setIsAnimating(false);
+    setItemList(items);
+  }, [items, clearStepTimer, clearAutoplayTimer]);
 
   const rotateOne = useCallback(() => {
     setItemList((current) => {
@@ -402,7 +414,7 @@ function CardStackRoot({
       items: itemList,
       visibleItems,
       activeItem,
-      depth,
+      depth: stackDepth,
       isAnimating,
       pressActive,
       setPressActive,
@@ -416,7 +428,7 @@ function CardStackRoot({
       itemList,
       visibleItems,
       activeItem,
-      depth,
+      stackDepth,
       isAnimating,
       pressActive,
       throwImpulse,

--- a/animata/card/card-stack.tsx
+++ b/animata/card/card-stack.tsx
@@ -4,10 +4,13 @@ import type { LucideIcon } from "lucide-react";
 import { AnimatePresence, type HTMLMotionProps, motion, type Transition } from "motion/react";
 import {
   type ComponentProps,
+  cloneElement,
   createContext,
+  isValidElement,
   type ReactNode,
   use,
   useCallback,
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -50,8 +53,51 @@ export interface CardStackLayerMotion {
 }
 
 const DEFAULT_STACK_DEPTH = 3;
+const DEFAULT_AUTOPLAY_INTERVAL = 4500;
+/** How long before the next click is accepted — decoupled from exit spring settle */
+const STEP_COOLDOWN_MS = 260;
 
-const easeOut: Transition["ease"] = [0, 0, 0.2, 1];
+/** Peek offsets as % of each card’s height so stacks scale with card size */
+const STACK_LAYER_PRESETS = [
+  { y: "0%", scale: 1, rotate: 0, zIndex: 20 },
+  { y: "-5%", scale: 0.84, rotate: -1, zIndex: 5 },
+  { y: "-7.5%", scale: 0.72, rotate: 1, zIndex: 0 },
+] as const;
+
+const PROMOTE_SPRING: Transition = {
+  type: "spring",
+  visualDuration: 0.22,
+  bounce: 0,
+};
+
+const THROW_SPRING: Transition = {
+  type: "spring",
+  visualDuration: 0.24,
+  bounce: 0.06,
+  restSpeed: 2,
+  restDelta: 0.001,
+};
+
+export interface CardStackThrowImpulse {
+  x: string;
+  rotate: number;
+  yVelocity: number;
+  rotateVelocity: number;
+}
+
+export function createCardStackThrowImpulse(): CardStackThrowImpulse {
+  const drift = Math.random() - 0.5;
+
+  return {
+    x: `${(drift * 7).toFixed(2)}%`,
+    rotate: drift * 6 + (Math.random() - 0.5) * 1.5,
+    yVelocity: 3.5 + Math.random() * 2.8,
+    rotateVelocity: drift * 10,
+  };
+}
+
+const CARD_STACK_STACK_ORIGIN = "50% 0%";
+const CARD_STACK_EXIT_Y = "200%";
 
 const CARD_STACK_MASK_STYLE = {
   maskSize: "cover",
@@ -84,42 +130,88 @@ export function getCardStackLayers(
   reducedMotion: boolean,
   depth = DEFAULT_STACK_DEPTH,
 ): CardStackLayerMotion[] {
-  const stackTransition: Transition = reducedMotion
-    ? { duration: 0 }
-    : { duration: 0.28, ease: easeOut };
+  const stackTransition: Transition = reducedMotion ? { duration: 0 } : PROMOTE_SPRING;
 
-  const layers: CardStackLayerMotion[] = [
-    {
-      className: "",
-      initial: { y: 90, rotate: 0, scale: 1, opacity: 1, zIndex: 20 },
-      animate: { y: 90, rotate: 0, scale: 1, opacity: 1, zIndex: 20 },
-      exit: reducedMotion
-        ? { y: 90, scale: 1, opacity: 1, zIndex: 20 }
-        : {
-            y: 420,
-            rotate: 0,
-            scale: 0.96,
-            opacity: 1,
-            zIndex: 30,
-            transition: stackTransition,
-          },
-      transition: stackTransition,
+  const layers: CardStackLayerMotion[] = STACK_LAYER_PRESETS.map((preset) => ({
+    className: "",
+    initial: {
+      y: preset.y,
+      rotate: preset.rotate,
+      scale: preset.scale,
+      opacity: 1,
+      zIndex: preset.zIndex,
     },
-    {
-      className: "",
-      initial: { y: 0, rotate: 0, scale: 0.75, opacity: 1, zIndex: 5 },
-      animate: { y: 40, rotate: -1, scale: 0.85, opacity: 1, zIndex: 5 },
-      transition: stackTransition,
+    animate: {
+      y: preset.y,
+      rotate: preset.rotate,
+      scale: preset.scale,
+      opacity: 1,
+      zIndex: preset.zIndex,
     },
-    {
-      className: "",
-      initial: { y: -40, rotate: 0, scale: 0.5, opacity: 1, zIndex: 0 },
-      animate: { y: 0, rotate: 1, scale: 0.7, opacity: 1, zIndex: 0 },
-      transition: stackTransition,
-    },
-  ];
+    exit: reducedMotion
+      ? {
+          y: preset.y,
+          scale: preset.scale,
+          opacity: 1,
+          zIndex: preset.zIndex,
+        }
+      : {
+          y: CARD_STACK_EXIT_Y,
+          rotate: 0,
+          scale: 0.93,
+          opacity: 0,
+          zIndex: 30,
+        },
+    transition: stackTransition,
+    style: { transformOrigin: CARD_STACK_STACK_ORIGIN },
+  }));
 
   return layers.slice(0, depth);
+}
+
+function getCardStackInitial(
+  stackIndex: number,
+  depth: number,
+  layer: CardStackLayerMotion,
+): HTMLMotionProps<"article">["initial"] {
+  if (stackIndex !== 0 && stackIndex !== depth - 1) {
+    return false;
+  }
+
+  return layer.initial;
+}
+
+function getCardStackExit(
+  stackIndex: number,
+  layer: CardStackLayerMotion,
+  reducedMotion: boolean,
+  throwImpulse: CardStackThrowImpulse | null,
+): HTMLMotionProps<"article">["exit"] {
+  if (stackIndex !== 0) {
+    return undefined;
+  }
+
+  if (reducedMotion) {
+    return layer.exit;
+  }
+
+  const impulse = throwImpulse ?? createCardStackThrowImpulse();
+
+  return {
+    y: CARD_STACK_EXIT_Y,
+    x: impulse.x,
+    rotate: impulse.rotate,
+    scale: 0.9,
+    opacity: 0,
+    zIndex: 30,
+    transition: {
+      y: { ...THROW_SPRING, velocity: impulse.yVelocity * 0.4 },
+      x: THROW_SPRING,
+      rotate: { ...THROW_SPRING, velocity: impulse.rotateVelocity * 0.35 },
+      scale: THROW_SPRING,
+      opacity: { type: "tween", duration: 0.16, ease: [0.4, 0, 1, 1] },
+    },
+  };
 }
 
 interface CardStackContextValue {
@@ -127,6 +219,8 @@ interface CardStackContextValue {
   visibleItems: CardStackItem[];
   activeItem: CardStackItem | undefined;
   depth: number;
+  isAnimating: boolean;
+  throwImpulse: CardStackThrowImpulse | null;
   advance: () => void;
   handleExitComplete: () => void;
   reducedMotion: boolean;
@@ -146,6 +240,8 @@ export function useCardStack() {
 interface CardStackRootProps {
   items: CardStackItem[];
   depth?: number;
+  autoplay?: boolean;
+  autoplayInterval?: number;
   onItemsChange?: (items: CardStackItem[]) => void;
   children: ReactNode;
 }
@@ -153,16 +249,37 @@ interface CardStackRootProps {
 function CardStackRoot({
   items,
   depth = DEFAULT_STACK_DEPTH,
+  autoplay = false,
+  autoplayInterval = DEFAULT_AUTOPLAY_INTERVAL,
   onItemsChange,
   children,
 }: CardStackRootProps) {
   const reducedMotion = usePrefersReducedMotion();
   const layers = useMemo(() => getCardStackLayers(reducedMotion, depth), [reducedMotion, depth]);
   const [itemList, setItemList] = useState(items);
+  const [isAnimating, setIsAnimating] = useState(false);
+  const [throwImpulse, setThrowImpulse] = useState<CardStackThrowImpulse | null>(null);
   const isAnimatingRef = useRef(false);
+  const stepTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const autoplayTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const advanceRef = useRef<() => void>(() => {});
 
   const visibleItems = itemList.slice(0, depth);
   const activeItem = visibleItems[0];
+
+  const clearStepTimer = useCallback(() => {
+    if (stepTimerRef.current !== null) {
+      clearTimeout(stepTimerRef.current);
+      stepTimerRef.current = null;
+    }
+  }, []);
+
+  const clearAutoplayTimer = useCallback(() => {
+    if (autoplayTimerRef.current !== null) {
+      clearTimeout(autoplayTimerRef.current);
+      autoplayTimerRef.current = null;
+    }
+  }, []);
 
   const rotateOne = useCallback(() => {
     setItemList((current) => {
@@ -174,22 +291,86 @@ function CardStackRoot({
     });
   }, [onItemsChange]);
 
+  const finishStep = useCallback(() => {
+    clearStepTimer();
+    if (!isAnimatingRef.current) return false;
+    isAnimatingRef.current = false;
+    setIsAnimating(false);
+    return true;
+  }, [clearStepTimer]);
+
+  const scheduleAutoplay = useCallback(() => {
+    clearAutoplayTimer();
+    if (!autoplay || reducedMotion || itemList.length <= 1) return;
+    if (document.hidden) return;
+
+    autoplayTimerRef.current = setTimeout(() => {
+      autoplayTimerRef.current = null;
+      advanceRef.current();
+    }, autoplayInterval);
+  }, [autoplay, autoplayInterval, clearAutoplayTimer, itemList.length, reducedMotion]);
+
+  const finishStepAndScheduleAutoplay = useCallback(() => {
+    if (finishStep()) {
+      scheduleAutoplay();
+    }
+  }, [finishStep, scheduleAutoplay]);
+
   const advance = useCallback(() => {
-    if (itemList.length <= 1) return;
-    if (isAnimatingRef.current) return;
+    if (itemList.length <= 1 || isAnimatingRef.current) return;
+
+    clearAutoplayTimer();
 
     if (reducedMotion) {
       rotateOne();
+      scheduleAutoplay();
       return;
     }
 
     isAnimatingRef.current = true;
+    setIsAnimating(true);
+    setThrowImpulse(createCardStackThrowImpulse());
+    clearStepTimer();
     rotateOne();
-  }, [itemList.length, reducedMotion, rotateOne]);
+    stepTimerRef.current = setTimeout(finishStepAndScheduleAutoplay, STEP_COOLDOWN_MS);
+  }, [
+    clearAutoplayTimer,
+    clearStepTimer,
+    finishStepAndScheduleAutoplay,
+    itemList.length,
+    reducedMotion,
+    rotateOne,
+    scheduleAutoplay,
+  ]);
+
+  advanceRef.current = advance;
 
   const handleExitComplete = useCallback(() => {
-    isAnimatingRef.current = false;
-  }, []);
+    finishStepAndScheduleAutoplay();
+  }, [finishStepAndScheduleAutoplay]);
+
+  useEffect(() => {
+    scheduleAutoplay();
+    return () => {
+      clearStepTimer();
+      clearAutoplayTimer();
+    };
+  }, [clearAutoplayTimer, clearStepTimer, scheduleAutoplay]);
+
+  useEffect(() => {
+    const onVisibilityChange = () => {
+      if (document.hidden) {
+        clearAutoplayTimer();
+        return;
+      }
+      if (!isAnimatingRef.current) {
+        scheduleAutoplay();
+      }
+    };
+
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => document.removeEventListener("visibilitychange", onVisibilityChange);
+  }, [clearAutoplayTimer, scheduleAutoplay]);
 
   const value = useMemo(
     () => ({
@@ -197,12 +378,25 @@ function CardStackRoot({
       visibleItems,
       activeItem,
       depth,
+      isAnimating,
+      throwImpulse,
       advance,
       handleExitComplete,
       reducedMotion,
       layers,
     }),
-    [itemList, visibleItems, activeItem, depth, advance, handleExitComplete, reducedMotion, layers],
+    [
+      itemList,
+      visibleItems,
+      activeItem,
+      depth,
+      isAnimating,
+      throwImpulse,
+      advance,
+      handleExitComplete,
+      reducedMotion,
+      layers,
+    ],
   );
 
   return <CardStackContext value={value}>{children}</CardStackContext>;
@@ -274,7 +468,10 @@ function CardStackTrigger({
 function CardStackViewport({ className, children, ...props }: ComponentProps<"div">) {
   return (
     <div
-      className={cn("relative mx-auto w-full min-h-[26rem] sm:min-h-[28rem]", className)}
+      className={cn(
+        "relative mx-auto w-full overflow-visible pt-20 sm:pt-24 min-h-[26rem] sm:min-h-[28rem]",
+        className,
+      )}
       {...props}
     >
       {children}
@@ -291,7 +488,20 @@ function CardStackList({ children }: CardStackListProps) {
 
   return (
     <AnimatePresence initial={false} mode="sync" onExitComplete={handleExitComplete}>
-      {visibleItems.map((item, index) => children(item, index, layers[index]!))}
+      {visibleItems.map((item, index) => {
+        const layer = layers[index]!;
+        const node = children(item, index, layer);
+
+        if (isValidElement(node) && node.type === CardStackCard) {
+          return cloneElement(node, {
+            key: item.id,
+            stackIndex: index,
+            layer,
+          });
+        }
+
+        return node;
+      })}
     </AnimatePresence>
   );
 }
@@ -302,9 +512,19 @@ interface CardStackCardProps extends HTMLMotionProps<"article"> {
   stackDepth?: number;
 }
 
-function CardStackCard({ layer, stackIndex, stackDepth, className, ...props }: CardStackCardProps) {
-  const { depth } = useCardStack();
+function CardStackCard({
+  layer,
+  stackIndex,
+  stackDepth,
+  className,
+  style,
+  ...props
+}: CardStackCardProps) {
+  const { depth, reducedMotion, throwImpulse } = useCardStack();
   const total = stackDepth ?? depth;
+
+  const initial = getCardStackInitial(stackIndex, depth, layer);
+  const exit = getCardStackExit(stackIndex, layer, reducedMotion, throwImpulse);
 
   return (
     <motion.article
@@ -317,9 +537,14 @@ function CardStackCard({ layer, stackIndex, stackDepth, className, ...props }: C
         className,
       )}
       aria-roledescription={`Card ${stackIndex + 1} of ${total}`}
-      initial={stackIndex === 0 || stackIndex === depth - 1 ? layer.initial : false}
+      style={{
+        transformOrigin: CARD_STACK_STACK_ORIGIN,
+        ...layer.style,
+        ...style,
+      }}
+      initial={initial}
       animate={layer.animate}
-      exit={layer.exit}
+      exit={exit}
       transition={layer.transition}
       {...props}
     />

--- a/animata/card/card-stack.tsx
+++ b/animata/card/card-stack.tsx
@@ -1,0 +1,523 @@
+"use client";
+
+import type { LucideIcon } from "lucide-react";
+import { AnimatePresence, type HTMLMotionProps, motion, type Transition } from "motion/react";
+import {
+  type ComponentProps,
+  createContext,
+  type ReactNode,
+  use,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
+
+import { CardStackMaskDefs } from "@/components/shapes/card-stack-mask-defs";
+import { cn } from "@/lib/utils";
+
+export const CARD_STACK_MASK_IDS = [
+  "cs_mask_1_ellipse-1",
+  "cs_mask_1_flower-14",
+  "cs_mask_1_flower-1",
+  "cs_mask_1_misc-5",
+] as const;
+
+export type CardStackMaskId = (typeof CARD_STACK_MASK_IDS)[number];
+
+export type CardStackMediaAspect = "fill" | "square" | "4/5" | "3/4" | "16/10";
+
+export interface CardStackItem {
+  id: string;
+  image: string;
+  title: string;
+  tagline: string;
+  counts: {
+    like: number;
+    comment: number;
+  };
+  maskId: CardStackMaskId;
+}
+
+export interface CardStackLayerMotion {
+  className: string;
+  initial: HTMLMotionProps<"article">["initial"];
+  animate: HTMLMotionProps<"article">["animate"];
+  exit?: HTMLMotionProps<"article">["exit"];
+  transition: Transition;
+  style?: HTMLMotionProps<"article">["style"];
+}
+
+const DEFAULT_STACK_DEPTH = 3;
+
+const easeOut: Transition["ease"] = [0, 0, 0.2, 1];
+
+const CARD_STACK_MASK_STYLE = {
+  maskSize: "cover",
+  maskPosition: "center",
+  maskRepeat: "no-repeat",
+} as const;
+
+const MEDIA_ASPECT_CLASS: Record<Exclude<CardStackMediaAspect, "fill">, string> = {
+  square: "aspect-square",
+  "4/5": "aspect-[4/5]",
+  "3/4": "aspect-[3/4]",
+  "16/10": "aspect-[16/10]",
+};
+
+function subscribeReducedMotion(callback: () => void) {
+  const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+  mq.addEventListener("change", callback);
+  return () => mq.removeEventListener("change", callback);
+}
+
+function getReducedMotionSnapshot() {
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+function usePrefersReducedMotion() {
+  return useSyncExternalStore(subscribeReducedMotion, getReducedMotionSnapshot, () => false);
+}
+
+export function getCardStackLayers(
+  reducedMotion: boolean,
+  depth = DEFAULT_STACK_DEPTH,
+): CardStackLayerMotion[] {
+  const stackTransition: Transition = reducedMotion
+    ? { duration: 0 }
+    : { duration: 0.28, ease: easeOut };
+
+  const layers: CardStackLayerMotion[] = [
+    {
+      className: "",
+      initial: { y: 90, rotate: 0, scale: 1, opacity: 1, zIndex: 20 },
+      animate: { y: 90, rotate: 0, scale: 1, opacity: 1, zIndex: 20 },
+      exit: reducedMotion
+        ? { y: 90, scale: 1, opacity: 1, zIndex: 20 }
+        : {
+            y: 420,
+            rotate: 0,
+            scale: 0.96,
+            opacity: 1,
+            zIndex: 30,
+            transition: stackTransition,
+          },
+      transition: stackTransition,
+    },
+    {
+      className: "",
+      initial: { y: 0, rotate: 0, scale: 0.75, opacity: 1, zIndex: 5 },
+      animate: { y: 40, rotate: -1, scale: 0.85, opacity: 1, zIndex: 5 },
+      transition: stackTransition,
+    },
+    {
+      className: "",
+      initial: { y: -40, rotate: 0, scale: 0.5, opacity: 1, zIndex: 0 },
+      animate: { y: 0, rotate: 1, scale: 0.7, opacity: 1, zIndex: 0 },
+      transition: stackTransition,
+    },
+  ];
+
+  return layers.slice(0, depth);
+}
+
+interface CardStackContextValue {
+  items: CardStackItem[];
+  visibleItems: CardStackItem[];
+  activeItem: CardStackItem | undefined;
+  depth: number;
+  advance: () => void;
+  handleExitComplete: () => void;
+  reducedMotion: boolean;
+  layers: CardStackLayerMotion[];
+}
+
+const CardStackContext = createContext<CardStackContextValue | null>(null);
+
+export function useCardStack() {
+  const context = use(CardStackContext);
+  if (!context) {
+    throw new Error("CardStack primitives must be used within <CardStack>.");
+  }
+  return context;
+}
+
+interface CardStackRootProps {
+  items: CardStackItem[];
+  depth?: number;
+  onItemsChange?: (items: CardStackItem[]) => void;
+  children: ReactNode;
+}
+
+function CardStackRoot({
+  items,
+  depth = DEFAULT_STACK_DEPTH,
+  onItemsChange,
+  children,
+}: CardStackRootProps) {
+  const reducedMotion = usePrefersReducedMotion();
+  const layers = useMemo(() => getCardStackLayers(reducedMotion, depth), [reducedMotion, depth]);
+  const [itemList, setItemList] = useState(items);
+  const isAnimatingRef = useRef(false);
+
+  const visibleItems = itemList.slice(0, depth);
+  const activeItem = visibleItems[0];
+
+  const rotateOne = useCallback(() => {
+    setItemList((current) => {
+      if (current.length <= 1) return current;
+      const next = [...current];
+      next.push(next.shift()!);
+      onItemsChange?.(next);
+      return next;
+    });
+  }, [onItemsChange]);
+
+  const advance = useCallback(() => {
+    if (itemList.length <= 1) return;
+    if (isAnimatingRef.current) return;
+
+    if (reducedMotion) {
+      rotateOne();
+      return;
+    }
+
+    isAnimatingRef.current = true;
+    rotateOne();
+  }, [itemList.length, reducedMotion, rotateOne]);
+
+  const handleExitComplete = useCallback(() => {
+    isAnimatingRef.current = false;
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      items: itemList,
+      visibleItems,
+      activeItem,
+      depth,
+      advance,
+      handleExitComplete,
+      reducedMotion,
+      layers,
+    }),
+    [itemList, visibleItems, activeItem, depth, advance, handleExitComplete, reducedMotion, layers],
+  );
+
+  return <CardStackContext value={value}>{children}</CardStackContext>;
+}
+
+function CardStackFrame({
+  "aria-label": ariaLabel = "Interactive card stack",
+  className,
+  children,
+  ...props
+}: ComponentProps<"section">) {
+  return (
+    <section aria-label={ariaLabel} className={cn("relative", className)} {...props}>
+      {children}
+    </section>
+  );
+}
+
+function CardStackPanel({ className, children, ...props }: ComponentProps<"div">) {
+  return (
+    <div className={cn("relative z-10", className)} {...props}>
+      {children}
+    </div>
+  );
+}
+
+function CardStackLiveRegion({ className }: { className?: string }) {
+  const { activeItem } = useCardStack();
+
+  return (
+    <p className={cn("sr-only", className)} aria-live="polite" aria-atomic="true">
+      {activeItem ? `Showing ${activeItem.title}, ${activeItem.tagline}` : "No cards available"}
+    </p>
+  );
+}
+
+function CardStackTrigger({
+  "aria-label": ariaLabel = "Show next card",
+  className,
+  children,
+  onClick,
+  ...props
+}: ComponentProps<"button">) {
+  const { advance } = useCardStack();
+
+  return (
+    <button
+      type="button"
+      aria-label={ariaLabel}
+      onClick={(event) => {
+        onClick?.(event);
+        if (!event.defaultPrevented) {
+          advance();
+        }
+      }}
+      className={cn(
+        "relative block w-full cursor-pointer outline-none",
+        "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        "active:scale-[0.995] motion-reduce:active:scale-100",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}
+
+function CardStackViewport({ className, children, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      className={cn("relative mx-auto w-full min-h-[26rem] sm:min-h-[28rem]", className)}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+interface CardStackListProps {
+  children: (item: CardStackItem, index: number, layer: CardStackLayerMotion) => ReactNode;
+}
+
+function CardStackList({ children }: CardStackListProps) {
+  const { visibleItems, layers, handleExitComplete } = useCardStack();
+
+  return (
+    <AnimatePresence initial={false} mode="sync" onExitComplete={handleExitComplete}>
+      {visibleItems.map((item, index) => children(item, index, layers[index]!))}
+    </AnimatePresence>
+  );
+}
+
+interface CardStackCardProps extends HTMLMotionProps<"article"> {
+  layer: CardStackLayerMotion;
+  stackIndex: number;
+  stackDepth?: number;
+}
+
+function CardStackCard({ layer, stackIndex, stackDepth, className, ...props }: CardStackCardProps) {
+  const { depth } = useCardStack();
+  const total = stackDepth ?? depth;
+
+  return (
+    <motion.article
+      className={cn(
+        "absolute inset-x-0 top-0 flex h-fit w-full flex-col gap-3 rounded-4xl p-0",
+        "bg-linear-to-br from-pink-100 via-white to-white shadow-xl ring-1 ring-border",
+        "will-change-transform motion-reduce:transition-none",
+        "dark:from-pink-950 dark:via-card dark:to-card",
+        layer.className,
+        className,
+      )}
+      aria-roledescription={`Card ${stackIndex + 1} of ${total}`}
+      initial={stackIndex === 0 || stackIndex === depth - 1 ? layer.initial : false}
+      animate={layer.animate}
+      exit={layer.exit}
+      transition={layer.transition}
+      {...props}
+    />
+  );
+}
+
+function CardStackHeader({ className, ...props }: ComponentProps<"header">) {
+  return <header className={cn("flex gap-2 p-4 items-center", className)} {...props} />;
+}
+
+interface CardStackAvatarProps extends ComponentProps<"div"> {
+  src: string;
+}
+
+function CardStackAvatar({ src, className, ...props }: CardStackAvatarProps) {
+  return (
+    <div
+      className={cn(
+        "relative size-7 shrink-0 overflow-hidden rounded-full ring-2 ring-border",
+        className,
+      )}
+      {...props}
+    >
+      <img
+        src={src}
+        alt=""
+        aria-hidden
+        width={28}
+        height={28}
+        decoding="async"
+        className="size-full object-cover"
+      />
+    </div>
+  );
+}
+
+interface CardStackMetaProps extends ComponentProps<"div"> {
+  title: string;
+  tagline: string;
+}
+
+function CardStackMeta({ title, tagline, className, ...props }: CardStackMetaProps) {
+  return (
+    <div className={cn("min-w-0 flex flex-col gap-0.5 items-start", className)} {...props}>
+      <h3 className="truncate text-xs font-medium leading-none tracking-wide text-foreground">
+        {title}
+      </h3>
+      <p className="truncate text-[10px] leading-none overflow-visible text-muted-foreground">
+        {tagline}
+      </p>
+    </div>
+  );
+}
+
+interface CardStackMediaProps extends Omit<ComponentProps<"img">, "src" | "alt"> {
+  src: string;
+  alt: string;
+  maskId: CardStackMaskId;
+  aspect?: CardStackMediaAspect;
+}
+
+function CardStackMedia({
+  src,
+  alt,
+  maskId,
+  aspect = "square",
+  className,
+  style,
+  ...props
+}: CardStackMediaProps) {
+  const maskStyle = {
+    ...CARD_STACK_MASK_STYLE,
+    maskImage: `url(#${maskId})`,
+    WebkitMaskImage: `url(#${maskId})`,
+    WebkitMaskSize: CARD_STACK_MASK_STYLE.maskSize,
+    WebkitMaskPosition: CARD_STACK_MASK_STYLE.maskPosition,
+    WebkitMaskRepeat: CARD_STACK_MASK_STYLE.maskRepeat,
+    ...style,
+  };
+
+  return (
+    <figure
+      className={cn(
+        "mx-auto shrink-0 overflow-hidden",
+        aspect === "square" && "aspect-square size-52",
+        aspect === "fill" && "min-h-0 w-full flex-1",
+        aspect !== "square" && aspect !== "fill" && MEDIA_ASPECT_CLASS[aspect],
+        className,
+      )}
+    >
+      <img
+        src={src}
+        alt={alt}
+        width={208}
+        height={208}
+        decoding="async"
+        draggable={false}
+        className="size-full object-cover"
+        style={maskStyle}
+        {...props}
+      />
+    </figure>
+  );
+}
+
+function CardStackBody({ className, ...props }: ComponentProps<"div">) {
+  return <div className={cn("flex flex-1 flex-col bg-card", className)} {...props} />;
+}
+
+function CardStackFooter({ className, ...props }: ComponentProps<"footer">) {
+  return (
+    <footer
+      className={cn("flex items-center gap-3 px-4 pb-4 pt-1 text-sm text-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+interface CardStackMetricProps extends ComponentProps<"span"> {
+  icon: LucideIcon;
+  label: string;
+  value: number | string;
+}
+
+function CardStackMetric({ icon: Icon, label, value, className, ...props }: CardStackMetricProps) {
+  return (
+    <span className={cn("inline-flex items-center gap-1", className)} {...props}>
+      <Icon aria-hidden className="size-6 shrink-0" />
+      <span className="sr-only">{label}: </span>
+      {value}
+    </span>
+  );
+}
+
+interface CardStackActionProps extends ComponentProps<"span"> {
+  icon?: LucideIcon;
+}
+
+function CardStackAction({ icon: Icon, className, children, ...props }: CardStackActionProps) {
+  return (
+    <span
+      className={cn(
+        "ml-auto inline-flex items-center gap-1.5 text-xs font-medium text-muted-foreground",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      {Icon ? <Icon aria-hidden className="size-4 shrink-0" /> : null}
+    </span>
+  );
+}
+
+interface CardStackMasksProps {
+  className?: string;
+}
+
+function CardStackMasks({ className }: CardStackMasksProps) {
+  return <CardStackMaskDefs className={cn("pointer-events-none absolute", className)} />;
+}
+
+const CardStack = Object.assign(CardStackRoot, {
+  Frame: CardStackFrame,
+  Panel: CardStackPanel,
+  LiveRegion: CardStackLiveRegion,
+  Trigger: CardStackTrigger,
+  Viewport: CardStackViewport,
+  List: CardStackList,
+  Card: CardStackCard,
+  Header: CardStackHeader,
+  Avatar: CardStackAvatar,
+  Meta: CardStackMeta,
+  Body: CardStackBody,
+  Media: CardStackMedia,
+  Footer: CardStackFooter,
+  Metric: CardStackMetric,
+  Action: CardStackAction,
+  Masks: CardStackMasks,
+});
+
+export default CardStack;
+export {
+  CardStack,
+  CardStackAction,
+  CardStackAvatar,
+  CardStackBody,
+  CardStackCard,
+  CardStackFooter,
+  CardStackFrame,
+  CardStackHeader,
+  CardStackList,
+  CardStackLiveRegion,
+  CardStackMasks,
+  CardStackMedia,
+  CardStackMeta,
+  CardStackMetric,
+  CardStackPanel,
+  CardStackRoot,
+  CardStackTrigger,
+  CardStackViewport,
+};

--- a/animata/card/card-stack.tsx
+++ b/animata/card/card-stack.tsx
@@ -553,8 +553,8 @@ function CardStackList({ children }: CardStackListProps) {
         const layer = layers[index]!;
         const node = children(item, index, layer);
 
-        if (isValidElement(node) && node.type === CardStackCard) {
-          return cloneElement(node, {
+        if (isValidElement<CardStackCardProps>(node) && node.type === CardStackCard) {
+          return cloneElement<CardStackCardProps>(node, {
             key: item.id,
             stackIndex: index,
             layer,
@@ -588,8 +588,12 @@ function CardStackCard({
   const exit = getCardStackExit(stackIndex, layer, reducedMotion, throwImpulse);
   const baseScale = getLayerScale(layer);
   const isPressed = stackIndex === 0 && pressActive && !reducedMotion && !isAnimating;
+  const animateTarget =
+    typeof layer.animate === "object" && layer.animate !== null && !Array.isArray(layer.animate)
+      ? layer.animate
+      : {};
   const animate = isPressed
-    ? { ...layer.animate, scale: baseScale * PRESS_SCALE_FACTOR }
+    ? { ...animateTarget, scale: baseScale * PRESS_SCALE_FACTOR }
     : layer.animate;
   const transition = isPressed ? PRESS_SPRING : layer.transition;
 

--- a/animata/card/card-stack.tsx
+++ b/animata/card/card-stack.tsx
@@ -70,6 +70,15 @@ const PROMOTE_SPRING: Transition = {
   bounce: 0,
 };
 
+/** Top-card press — same transform channel as stack promote / throw */
+const PRESS_SPRING: Transition = {
+  type: "spring",
+  visualDuration: 0.1,
+  bounce: 0,
+};
+
+const PRESS_SCALE_FACTOR = 0.985;
+
 const THROW_SPRING: Transition = {
   type: "spring",
   visualDuration: 0.24,
@@ -169,6 +178,19 @@ export function getCardStackLayers(
   return layers.slice(0, depth);
 }
 
+function getLayerScale(layer: CardStackLayerMotion): number {
+  const target = layer.animate;
+  if (
+    target &&
+    typeof target === "object" &&
+    "scale" in target &&
+    typeof target.scale === "number"
+  ) {
+    return target.scale;
+  }
+  return 1;
+}
+
 function getCardStackInitial(
   stackIndex: number,
   depth: number,
@@ -220,6 +242,8 @@ interface CardStackContextValue {
   activeItem: CardStackItem | undefined;
   depth: number;
   isAnimating: boolean;
+  pressActive: boolean;
+  setPressActive: (active: boolean) => void;
   throwImpulse: CardStackThrowImpulse | null;
   advance: () => void;
   handleExitComplete: () => void;
@@ -258,6 +282,7 @@ function CardStackRoot({
   const layers = useMemo(() => getCardStackLayers(reducedMotion, depth), [reducedMotion, depth]);
   const [itemList, setItemList] = useState(items);
   const [isAnimating, setIsAnimating] = useState(false);
+  const [pressActive, setPressActive] = useState(false);
   const [throwImpulse, setThrowImpulse] = useState<CardStackThrowImpulse | null>(null);
   const isAnimatingRef = useRef(false);
   const stepTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -379,6 +404,8 @@ function CardStackRoot({
       activeItem,
       depth,
       isAnimating,
+      pressActive,
+      setPressActive,
       throwImpulse,
       advance,
       handleExitComplete,
@@ -391,6 +418,7 @@ function CardStackRoot({
       activeItem,
       depth,
       isAnimating,
+      pressActive,
       throwImpulse,
       advance,
       handleExitComplete,
@@ -438,14 +466,36 @@ function CardStackTrigger({
   className,
   children,
   onClick,
+  onPointerDown,
+  onPointerUp,
+  onPointerLeave,
+  onPointerCancel,
   ...props
 }: ComponentProps<"button">) {
-  const { advance } = useCardStack();
+  const { advance, isAnimating, setPressActive } = useCardStack();
 
   return (
     <button
       type="button"
       aria-label={ariaLabel}
+      onPointerDown={(event) => {
+        onPointerDown?.(event);
+        if (!event.defaultPrevented && !isAnimating) {
+          setPressActive(true);
+        }
+      }}
+      onPointerUp={(event) => {
+        onPointerUp?.(event);
+        window.setTimeout(() => setPressActive(false), 0);
+      }}
+      onPointerLeave={(event) => {
+        onPointerLeave?.(event);
+        setPressActive(false);
+      }}
+      onPointerCancel={(event) => {
+        onPointerCancel?.(event);
+        setPressActive(false);
+      }}
       onClick={(event) => {
         onClick?.(event);
         if (!event.defaultPrevented) {
@@ -455,7 +505,6 @@ function CardStackTrigger({
       className={cn(
         "relative block w-full cursor-pointer outline-none",
         "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
-        "active:scale-[0.995] motion-reduce:active:scale-100",
         className,
       )}
       {...props}
@@ -520,11 +569,17 @@ function CardStackCard({
   style,
   ...props
 }: CardStackCardProps) {
-  const { depth, reducedMotion, throwImpulse } = useCardStack();
+  const { depth, isAnimating, pressActive, reducedMotion, throwImpulse } = useCardStack();
   const total = stackDepth ?? depth;
 
   const initial = getCardStackInitial(stackIndex, depth, layer);
   const exit = getCardStackExit(stackIndex, layer, reducedMotion, throwImpulse);
+  const baseScale = getLayerScale(layer);
+  const isPressed = stackIndex === 0 && pressActive && !reducedMotion && !isAnimating;
+  const animate = isPressed
+    ? { ...layer.animate, scale: baseScale * PRESS_SCALE_FACTOR }
+    : layer.animate;
+  const transition = isPressed ? PRESS_SPRING : layer.transition;
 
   return (
     <motion.article
@@ -543,9 +598,9 @@ function CardStackCard({
         ...style,
       }}
       initial={initial}
-      animate={layer.animate}
+      animate={animate}
       exit={exit}
-      transition={layer.transition}
+      transition={transition}
       {...props}
     />
   );

--- a/animata/image/trailing-image.stories.tsx
+++ b/animata/image/trailing-image.stories.tsx
@@ -16,7 +16,13 @@ type Story = StoryObj<typeof meta>;
 
 export const Primary: Story = {
   args: {
-    className: "h-96 w-full max-w-md rounded-xl border border-border",
-    children: <div aria-hidden className="h-full w-full" />,
+    className: "h-96 w-full full-content",
+    children: (
+      <div className="h-full w-full flex items-center justify-center">
+        <span className="text-sm text-muted-foreground">
+          Move your mouse to see the trailing effect
+        </span>
+      </div>
+    ),
   },
 };

--- a/animata/image/trailing-image.stories.tsx
+++ b/animata/image/trailing-image.stories.tsx
@@ -15,5 +15,8 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Primary: Story = {
-  args: {},
+  args: {
+    className: "h-96 w-full max-w-md rounded-xl border border-border",
+    children: <div aria-hidden className="h-full w-full" />,
+  },
 };

--- a/animata/image/trailing-image.tsx
+++ b/animata/image/trailing-image.tsx
@@ -201,8 +201,9 @@ export default function TrailingImage({
   excludeRefs = [],
   maxTrailZIndex,
 }: TrailingImageProps) {
+  const resolvedImages = images.length > 0 ? images : DEFAULT_IMAGES;
   const containerRef = useRef<HTMLDivElement>(null);
-  const trailCount = Math.max(20, images.length);
+  const trailCount = Math.max(20, resolvedImages.length);
   const trailsRef = useRef(
     Array.from(
       { length: trailCount },
@@ -297,7 +298,7 @@ export default function TrailingImage({
   const trailLayer = (
     <div className="pointer-events-none absolute inset-0 overflow-hidden" aria-hidden>
       {trailsRef.current.map((ref, index) => (
-        <AnimatedImage key={index} ref={ref} src={images[index % images.length]!} />
+        <AnimatedImage key={index} ref={ref} src={resolvedImages[index % resolvedImages.length]!} />
       ))}
     </div>
   );

--- a/animata/image/trailing-image.tsx
+++ b/animata/image/trailing-image.tsx
@@ -1,8 +1,19 @@
+"use client";
+
 import { motion, useAnimation } from "motion/react";
-import { createRef, forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import {
+  createRef,
+  forwardRef,
+  type ReactNode,
+  type RefObject,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+} from "react";
 
 import { useMousePosition } from "@/hooks/use-mouse-position";
-import { getDistance, lerp } from "@/lib/utils";
+import { cn, getDistance, lerp } from "@/lib/utils";
 
 interface AnimatedImageRef {
   show: ({
@@ -92,15 +103,17 @@ const AnimatedImage = forwardRef<AnimatedImageRef, { src: string }>(({ src }, re
       initial={{ opacity: 0, scale: 1 }}
       animate={controls}
       src={src}
-      alt="trail element"
-      className="absolute h-56 w-44 object-cover"
+      alt=""
+      aria-hidden
+      draggable={false}
+      className="pointer-events-none absolute h-56 w-44 select-none object-cover"
     />
   );
 });
 
 AnimatedImage.displayName = "AnimatedImage";
 
-const images = [
+const DEFAULT_IMAGES = [
   "https://assets.lummi.ai/assets/Qma1aBRXFsApFohRJrpJczE5QXGY6HhHKz24ybuw1khbou?auto=format&w=500",
   "https://assets.lummi.ai/assets/QmZBpAeh18DHxVNEEcJErt1UXGjZYCedSidJ6cybrDZdeS?auto=format&w=500",
   "https://assets.lummi.ai/assets/QmbMZFEfk2qwQkkmXYncpvHapkNQF5HuTrcascJC7edpfW?auto=format&w=500",
@@ -108,66 +121,228 @@ const images = [
   "https://assets.lummi.ai/assets/QmRy3tpFDCbgA3CQgRpySTGN6tNdomQE96rMpV31HeBUUd?auto=format&w=500",
 ];
 
-const TrailingImage = () => {
+export interface TrailingImageProps {
+  images?: string[];
+  className?: string;
+  children?: ReactNode;
+  /** Distance in px between trail spawns. Default 50. */
+  threshold?: number;
+  /** Full-viewport trail layer; tracks pointer on `window` so UI stays clickable. */
+  edgeToEdge?: boolean;
+  /** Render only the trail layer (no children wrapper). */
+  layerOnly?: boolean;
+  /** Pin to `absolute inset-0` inside a positioned parent instead of `fixed`. */
+  contained?: boolean;
+  /** Wrapper classes for interactive content when `edgeToEdge` is set. */
+  contentClassName?: string;
+  /** Pointer regions where trail spawns are suppressed (viewport/client coordinates). */
+  excludeRefs?: RefObject<HTMLElement | null>[];
+  /** Cap inline z-index so trails stay under foreground UI (e.g. z-20 content). */
+  maxTrailZIndex?: number;
+}
+
+function isInsideExcludeZones(
+  clientX: number,
+  clientY: number,
+  excludeRefs: RefObject<HTMLElement | null>[],
+) {
+  return excludeRefs.some((ref) => {
+    const rect = ref.current?.getBoundingClientRect();
+    if (!rect) {
+      return false;
+    }
+
+    return (
+      clientX >= rect.left && clientX <= rect.right && clientY >= rect.top && clientY <= rect.bottom
+    );
+  });
+}
+
+function isPointerOverExcludeZones(
+  clientX: number,
+  clientY: number,
+  target: EventTarget | null,
+  excludeRefs: RefObject<HTMLElement | null>[],
+) {
+  if (target instanceof Node) {
+    for (const ref of excludeRefs) {
+      if (ref.current?.contains(target)) {
+        return true;
+      }
+    }
+  }
+
+  if (isInsideExcludeZones(clientX, clientY, excludeRefs)) {
+    return true;
+  }
+
+  if (typeof document.elementsFromPoint !== "function") {
+    return false;
+  }
+
+  return document
+    .elementsFromPoint(clientX, clientY)
+    .some((element) =>
+      excludeRefs.some(
+        (ref) => ref.current && (ref.current === element || ref.current.contains(element)),
+      ),
+    );
+}
+
+export default function TrailingImage({
+  images = DEFAULT_IMAGES,
+  className,
+  children,
+  threshold = 50,
+  edgeToEdge = false,
+  layerOnly = false,
+  contained = false,
+  contentClassName,
+  excludeRefs = [],
+  maxTrailZIndex,
+}: TrailingImageProps) {
   const containerRef = useRef<HTMLDivElement>(null);
-  // Create a maximum of 20 trails for a smoother experience
+  const trailCount = Math.max(20, images.length);
   const trailsRef = useRef(
-    Array.from({ length: Math.max(20, images.length) }, createRef<AnimatedImageRef>),
+    Array.from(
+      { length: trailCount },
+      () => createRef<AnimatedImageRef>() as RefObject<AnimatedImageRef>,
+    ),
   );
 
   const lastPosition = useRef({ x: 0, y: 0 });
   const cachedPosition = useRef({ x: 0, y: 0 });
   const imageIndex = useRef(0);
   const zIndex = useRef(1);
+  const excludeRefsRef = useRef(excludeRefs);
+  excludeRefsRef.current = excludeRefs;
+  const maxTrailZIndexRef = useRef(maxTrailZIndex);
+  maxTrailZIndexRef.current = maxTrailZIndex;
 
-  const update = useCallback((cursor: { x: number; y: number }) => {
-    const activeRefCount = trailsRef.current.filter((ref) => ref.current?.isActive()).length;
-    if (activeRefCount === 0) {
-      // Reset zIndex since there are no active references
-      // This prevents zIndex from incrementing indefinitely
-      zIndex.current = 1;
+  const update = useCallback(
+    (cursor: { x: number; y: number }, eventTarget: EventTarget | null = null) => {
+      if (isPointerOverExcludeZones(cursor.x, cursor.y, eventTarget, excludeRefsRef.current)) {
+        lastPosition.current = cursor;
+        cachedPosition.current = cursor;
+        return;
+      }
+
+      const activeRefCount = trailsRef.current.filter((ref) => ref.current?.isActive()).length;
+      if (activeRefCount === 0) {
+        zIndex.current = 1;
+      }
+
+      const distance = getDistance(
+        cursor.x,
+        cursor.y,
+        lastPosition.current.x,
+        lastPosition.current.y,
+      );
+
+      const newCachePosition = {
+        x: lerp(cachedPosition.current.x || cursor.x, cursor.x, 0.1),
+        y: lerp(cachedPosition.current.y || cursor.y, cursor.y, 0.1),
+      };
+      cachedPosition.current = newCachePosition;
+
+      if (distance > threshold) {
+        imageIndex.current = (imageIndex.current + 1) % trailsRef.current.length;
+        const nextZ = zIndex.current + 1;
+        zIndex.current =
+          maxTrailZIndexRef.current !== undefined
+            ? Math.min(nextZ, maxTrailZIndexRef.current)
+            : nextZ;
+        lastPosition.current = cursor;
+        trailsRef.current[imageIndex.current].current?.show?.({
+          x: newCachePosition.x,
+          y: newCachePosition.y,
+          zIndex: zIndex.current,
+          newX: cursor.x,
+          newY: cursor.y,
+        });
+      }
+    },
+    [threshold],
+  );
+
+  useMousePosition(containerRef, edgeToEdge ? undefined : update);
+
+  useEffect(() => {
+    if (!edgeToEdge) {
+      return;
     }
 
-    const distance = getDistance(
-      cursor.x,
-      cursor.y,
-      lastPosition.current.x,
-      lastPosition.current.y,
-    );
-    const threshold = 50;
-
-    const newCachePosition = {
-      x: lerp(cachedPosition.current.x || cursor.x, cursor.x, 0.1),
-      y: lerp(cachedPosition.current.y || cursor.y, cursor.y, 0.1),
+    const handleMouseMove = (event: MouseEvent) => {
+      update({ x: event.clientX, y: event.clientY }, event.target);
     };
-    cachedPosition.current = newCachePosition;
 
-    if (distance > threshold) {
-      imageIndex.current = (imageIndex.current + 1) % trailsRef.current.length;
-      zIndex.current = zIndex.current + 1;
-      lastPosition.current = cursor;
-      trailsRef.current[imageIndex.current].current?.show?.({
-        x: newCachePosition.x,
-        y: newCachePosition.y,
-        zIndex: zIndex.current,
-        newX: cursor.x,
-        newY: cursor.y,
-      });
-    }
-  }, []);
+    const handleTouchMove = (event: TouchEvent) => {
+      const touch = event.touches[0];
+      if (!touch) {
+        return;
+      }
 
-  useMousePosition(containerRef, update);
+      update({ x: touch.clientX, y: touch.clientY }, event.target);
+    };
 
-  return (
-    <div ref={containerRef} className="storybook-fix relative flex min-h-96 w-full">
+    window.addEventListener("mousemove", handleMouseMove);
+    window.addEventListener("touchmove", handleTouchMove, { passive: true });
+
+    return () => {
+      window.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener("touchmove", handleTouchMove);
+    };
+  }, [edgeToEdge, update]);
+
+  const trailLayer = (
+    <div className="pointer-events-none absolute inset-0 overflow-hidden" aria-hidden>
       {trailsRef.current.map((ref, index) => (
-        <AnimatedImage key={index} ref={ref} src={images[index % images.length]} />
+        <AnimatedImage key={index} ref={ref} src={images[index % images.length]!} />
       ))}
-      <div className="flex w-full flex-1 items-center justify-center p-4 text-center text-sm text-foreground md:text-3xl">
-        <div className="max-w-sm">Move your mouse over this element to see the effect</div>
-      </div>
     </div>
   );
-};
 
-export default TrailingImage;
+  if (edgeToEdge && layerOnly) {
+    return (
+      <div
+        ref={containerRef}
+        className={cn(
+          "pointer-events-none overflow-hidden",
+          contained ? "absolute inset-0" : "fixed inset-0",
+          className,
+        )}
+        aria-hidden
+      >
+        {trailLayer}
+      </div>
+    );
+  }
+
+  if (edgeToEdge) {
+    return (
+      <>
+        <div
+          ref={containerRef}
+          className={cn(
+            "pointer-events-none overflow-hidden",
+            contained ? "absolute inset-0" : "fixed inset-0",
+            className,
+          )}
+          aria-hidden
+        >
+          {trailLayer}
+        </div>
+        {children ? <div className={cn("relative z-10", contentClassName)}>{children}</div> : null}
+      </>
+    );
+  }
+
+  return (
+    <div ref={containerRef} className={cn("relative w-full", className)}>
+      {trailLayer}
+      {children ? <div className="relative z-10 h-full w-full">{children}</div> : null}
+    </div>
+  );
+}
+
+export { DEFAULT_IMAGES as TRAILING_IMAGE_DEFAULTS };

--- a/animata/image/trailing-image.tsx
+++ b/animata/image/trailing-image.tsx
@@ -9,6 +9,7 @@ import {
   useCallback,
   useEffect,
   useImperativeHandle,
+  useLayoutEffect,
   useRef,
 } from "react";
 
@@ -32,84 +33,88 @@ interface AnimatedImageRef {
   isActive: () => boolean;
 }
 
-const AnimatedImage = forwardRef<AnimatedImageRef, { src: string }>(({ src }, ref) => {
-  const controls = useAnimation();
-  const isRunning = useRef(false);
-  const imgRef = useRef<HTMLImageElement>(null);
+interface AnimatedImageProps {
+  src: string;
+  onActivityChange?: (delta: number) => void;
+}
 
-  useImperativeHandle(ref, () => ({
-    isActive: () => isRunning.current,
-    show: async ({
-      x,
-      y,
-      newX,
-      newY,
-      zIndex,
-    }: {
-      x: number;
-      y: number;
-      zIndex: number;
-      newX: number;
-      newY: number;
-    }) => {
-      const rect = imgRef.current?.getBoundingClientRect();
-      if (!rect) {
-        return;
-      }
+const AnimatedImage = forwardRef<AnimatedImageRef, AnimatedImageProps>(
+  ({ src, onActivityChange }, ref) => {
+    const controls = useAnimation();
+    const isRunning = useRef(false);
+    const onActivityChangeRef = useRef(onActivityChange);
+    onActivityChangeRef.current = onActivityChange;
 
-      const center = (posX: number, posY: number) => {
-        const coords = {
-          x: posX - rect.width / 2,
-          y: posY - rect.height / 2,
-        };
-        return `translate(${coords.x}px, ${coords.y}px)`;
-      };
-
-      controls.stop();
-
-      controls.set({
-        opacity: isRunning.current ? 1 : 0.75,
+    useImperativeHandle(ref, () => ({
+      isActive: () => isRunning.current,
+      show: async ({
+        x,
+        y,
+        newX,
+        newY,
         zIndex,
-        transform: `${center(x, y)} scale(1)`,
-        transition: { ease: "circOut" },
-      });
+      }: {
+        x: number;
+        y: number;
+        zIndex: number;
+        newX: number;
+        newY: number;
+      }) => {
+        controls.stop();
 
-      isRunning.current = true;
+        controls.set({
+          opacity: isRunning.current ? 1 : 0.75,
+          zIndex,
+          x,
+          y,
+          scale: 1,
+          transition: { ease: "circOut" },
+        });
 
-      await controls.start({
-        opacity: 1,
-        transform: `${center(newX, newY)} scale(1)`,
-        transition: { duration: 0.9, ease: "circOut" },
-      });
+        isRunning.current = true;
+        onActivityChangeRef.current?.(1);
 
-      await Promise.all([
-        controls.start({
-          transition: { duration: 1, ease: "easeInOut" },
-          transform: `${center(newX, newY)} scale(0.1)`,
-        }),
-        controls.start({
-          opacity: 0,
-          transition: { duration: 1.1, ease: "easeOut" },
-        }),
-      ]);
+        try {
+          await controls.start({
+            opacity: 1,
+            x: newX,
+            y: newY,
+            scale: 1,
+            transition: { duration: 0.9, ease: "circOut" },
+          });
 
-      isRunning.current = false;
-    },
-  }));
+          await Promise.all([
+            controls.start({
+              x: newX,
+              y: newY,
+              scale: 0.1,
+              transition: { duration: 1, ease: "easeInOut" },
+            }),
+            controls.start({
+              opacity: 0,
+              transition: { duration: 1.1, ease: "easeOut" },
+            }),
+          ]);
+        } finally {
+          isRunning.current = false;
+          onActivityChangeRef.current?.(-1);
+        }
+      },
+    }));
 
-  return (
-    <motion.img
-      ref={imgRef}
-      initial={{ opacity: 0, scale: 1 }}
-      animate={controls}
-      src={src}
-      alt=""
-      aria-hidden
-      draggable={false}
-      className="pointer-events-none absolute h-56 w-44 select-none object-cover"
-    />
-  );
-});
+    return (
+      <motion.img
+        initial={{ opacity: 0, scale: 1 }}
+        animate={controls}
+        src={src}
+        alt=""
+        aria-hidden
+        draggable={false}
+        className="pointer-events-none absolute h-56 w-44 -translate-x-1/2 -translate-y-1/2 select-none object-cover"
+      />
+    );
+  },
+);
 
 AnimatedImage.displayName = "AnimatedImage";
 
@@ -141,28 +146,19 @@ export interface TrailingImageProps {
   maxTrailZIndex?: number;
 }
 
-function isInsideExcludeZones(
-  clientX: number,
-  clientY: number,
-  excludeRefs: RefObject<HTMLElement | null>[],
-) {
-  return excludeRefs.some((ref) => {
-    const rect = ref.current?.getBoundingClientRect();
-    if (!rect) {
-      return false;
-    }
-
-    return (
-      clientX >= rect.left && clientX <= rect.right && clientY >= rect.top && clientY <= rect.bottom
-    );
-  });
+function isPointInRect(clientX: number, clientY: number, rect: DOMRect) {
+  return (
+    clientX >= rect.left && clientX <= rect.right && clientY >= rect.top && clientY <= rect.bottom
+  );
 }
 
+/** Fast exclusion: DOM contains first, then cached viewport rects (no layout reads per move). */
 function isPointerOverExcludeZones(
   clientX: number,
   clientY: number,
   target: EventTarget | null,
   excludeRefs: RefObject<HTMLElement | null>[],
+  excludeRects: DOMRect[],
 ) {
   if (target instanceof Node) {
     for (const ref of excludeRefs) {
@@ -172,21 +168,56 @@ function isPointerOverExcludeZones(
     }
   }
 
-  if (isInsideExcludeZones(clientX, clientY, excludeRefs)) {
-    return true;
+  for (const rect of excludeRects) {
+    if (isPointInRect(clientX, clientY, rect)) {
+      return true;
+    }
   }
 
-  if (typeof document.elementsFromPoint !== "function") {
-    return false;
-  }
+  return false;
+}
 
-  return document
-    .elementsFromPoint(clientX, clientY)
-    .some((element) =>
-      excludeRefs.some(
-        (ref) => ref.current && (ref.current === element || ref.current.contains(element)),
-      ),
-    );
+function useExcludeZoneRects(excludeRefs: RefObject<HTMLElement | null>[], enabled: boolean) {
+  const excludeRectsRef = useRef<DOMRect[]>([]);
+  const excludeRefsRef = useRef(excludeRefs);
+  excludeRefsRef.current = excludeRefs;
+
+  const measureExcludeRects = useCallback(() => {
+    excludeRectsRef.current = excludeRefsRef.current.flatMap((ref) => {
+      const rect = ref.current?.getBoundingClientRect();
+      return rect ? [rect] : [];
+    });
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!enabled || excludeRefsRef.current.length === 0) {
+      excludeRectsRef.current = [];
+      return;
+    }
+
+    measureExcludeRects();
+
+    const observers: ResizeObserver[] = [];
+    for (const ref of excludeRefsRef.current) {
+      if (!ref.current) continue;
+      const observer = new ResizeObserver(measureExcludeRects);
+      observer.observe(ref.current);
+      observers.push(observer);
+    }
+
+    window.addEventListener("scroll", measureExcludeRects, { passive: true, capture: true });
+    window.addEventListener("resize", measureExcludeRects, { passive: true });
+
+    return () => {
+      for (const observer of observers) {
+        observer.disconnect();
+      }
+      window.removeEventListener("scroll", measureExcludeRects, { capture: true });
+      window.removeEventListener("resize", measureExcludeRects);
+    };
+  }, [enabled, measureExcludeRects]);
+
+  return { excludeRectsRef, measureExcludeRects };
 }
 
 export default function TrailingImage({
@@ -215,21 +246,43 @@ export default function TrailingImage({
   const cachedPosition = useRef({ x: 0, y: 0 });
   const imageIndex = useRef(0);
   const zIndex = useRef(1);
+  const activeTrailCountRef = useRef(0);
   const excludeRefsRef = useRef(excludeRefs);
   excludeRefsRef.current = excludeRefs;
   const maxTrailZIndexRef = useRef(maxTrailZIndex);
   maxTrailZIndexRef.current = maxTrailZIndex;
+  const hasExcludeZones = excludeRefs.length > 0;
+  const { excludeRectsRef } = useExcludeZoneRects(excludeRefs, hasExcludeZones);
 
-  const update = useCallback(
+  const pendingPointerRef = useRef<{
+    x: number;
+    y: number;
+    target: EventTarget | null;
+  } | null>(null);
+  const frameRef = useRef<number | null>(null);
+
+  const handleTrailActivity = useCallback((delta: number) => {
+    activeTrailCountRef.current += delta;
+  }, []);
+
+  const runUpdate = useCallback(
     (cursor: { x: number; y: number }, eventTarget: EventTarget | null = null) => {
-      if (isPointerOverExcludeZones(cursor.x, cursor.y, eventTarget, excludeRefsRef.current)) {
+      if (
+        hasExcludeZones &&
+        isPointerOverExcludeZones(
+          cursor.x,
+          cursor.y,
+          eventTarget,
+          excludeRefsRef.current,
+          excludeRectsRef.current,
+        )
+      ) {
         lastPosition.current = cursor;
         cachedPosition.current = cursor;
         return;
       }
 
-      const activeRefCount = trailsRef.current.filter((ref) => ref.current?.isActive()).length;
-      if (activeRefCount === 0) {
+      if (activeTrailCountRef.current === 0) {
         zIndex.current = 1;
       }
 
@@ -263,10 +316,37 @@ export default function TrailingImage({
         });
       }
     },
-    [threshold],
+    [hasExcludeZones, excludeRectsRef, threshold],
   );
 
-  useMousePosition(containerRef, edgeToEdge ? undefined : update);
+  const scheduleUpdate = useCallback(
+    (cursor: { x: number; y: number }, eventTarget: EventTarget | null = null) => {
+      pendingPointerRef.current = { x: cursor.x, y: cursor.y, target: eventTarget };
+      if (frameRef.current !== null) {
+        return;
+      }
+
+      frameRef.current = requestAnimationFrame(() => {
+        frameRef.current = null;
+        const pending = pendingPointerRef.current;
+        if (!pending) {
+          return;
+        }
+        runUpdate({ x: pending.x, y: pending.y }, pending.target);
+      });
+    },
+    [runUpdate],
+  );
+
+  useEffect(() => {
+    return () => {
+      if (frameRef.current !== null) {
+        cancelAnimationFrame(frameRef.current);
+      }
+    };
+  }, []);
+
+  useMousePosition(containerRef, edgeToEdge ? undefined : runUpdate);
 
   useEffect(() => {
     if (!edgeToEdge) {
@@ -274,7 +354,7 @@ export default function TrailingImage({
     }
 
     const handleMouseMove = (event: MouseEvent) => {
-      update({ x: event.clientX, y: event.clientY }, event.target);
+      scheduleUpdate({ x: event.clientX, y: event.clientY }, event.target);
     };
 
     const handleTouchMove = (event: TouchEvent) => {
@@ -283,22 +363,27 @@ export default function TrailingImage({
         return;
       }
 
-      update({ x: touch.clientX, y: touch.clientY }, event.target);
+      scheduleUpdate({ x: touch.clientX, y: touch.clientY }, event.target);
     };
 
-    window.addEventListener("mousemove", handleMouseMove);
+    window.addEventListener("mousemove", handleMouseMove, { passive: true });
     window.addEventListener("touchmove", handleTouchMove, { passive: true });
 
     return () => {
       window.removeEventListener("mousemove", handleMouseMove);
       window.removeEventListener("touchmove", handleTouchMove);
     };
-  }, [edgeToEdge, update]);
+  }, [edgeToEdge, scheduleUpdate]);
 
   const trailLayer = (
     <div className="pointer-events-none absolute inset-0 overflow-hidden" aria-hidden>
       {trailsRef.current.map((ref, index) => (
-        <AnimatedImage key={index} ref={ref} src={resolvedImages[index % resolvedImages.length]!} />
+        <AnimatedImage
+          key={index}
+          ref={ref}
+          src={resolvedImages[index % resolvedImages.length]!}
+          onActivityChange={handleTrailActivity}
+        />
       ))}
     </div>
   );

--- a/animata/preloader/split-reveal.stories.tsx
+++ b/animata/preloader/split-reveal.stories.tsx
@@ -32,67 +32,10 @@ type Story = StoryObj<typeof meta>;
 export const Primary: Story = {
   render: (args) => (
     <>
-      <div className="flex min-h-svh items-center justify-center bg-zinc-100 px-6">
-        <p className="max-w-md text-center text-2xl font-semibold tracking-tight text-zinc-900">
-          Page content mounts normally. SplitReveal covers it until images load.
-        </p>
-      </div>
+      <p className="flex full-content items-center justify-center bg-zinc-100 max-w-md text-center text-balance leading-loose text-xl tracking-tight text-zinc-900 px-6 py-12">
+        Page content mounts normally. SplitReveal covers it until images load.
+      </p>
       <SplitReveal {...args} />
-    </>
-  ),
-  args: {
-    images: SAMPLE_IMAGES,
-    backgroundColor: "#fff",
-    foregroundColor: "#000",
-    revealDuration: 0.85,
-    holdMs: 240,
-    lockScroll: true,
-  },
-};
-
-export const CustomProgress: Story = {
-  render: (args) => (
-    <>
-      <div className="flex min-h-svh items-center justify-center bg-neutral-950 px-6 text-white">
-        <p className="text-xl font-medium">Underneath the overlay</p>
-      </div>
-      <SplitReveal
-        {...args}
-        renderProgress={({ progress, loaded, total }) => (
-          <p className="text-center text-sm tabular-nums text-white/70">
-            {loaded}/{total} · {progress}%
-          </p>
-        )}
-      />
-    </>
-  ),
-  args: {
-    images: SAMPLE_IMAGES,
-    backgroundColor: "#0a0a0a",
-    foregroundColor: "#fff",
-    revealDuration: 0.85,
-    holdMs: 240,
-    lockScroll: true,
-  },
-};
-
-export const ComposedOverlay: Story = {
-  render: (args) => (
-    <>
-      <div className="flex min-h-svh items-center justify-center bg-zinc-200 px-6">
-        <p className="text-lg font-medium text-zinc-800">Full overlay override via children</p>
-      </div>
-      <SplitReveal {...args}>
-        <SplitReveal.Shutter side="top" />
-        <SplitReveal.Shutter side="bottom" />
-        <SplitReveal.Progress>
-          {({ loaded, total }) => (
-            <p className="text-center text-xs uppercase tracking-[0.14em] text-black/50">
-              {loaded} of {total}
-            </p>
-          )}
-        </SplitReveal.Progress>
-      </SplitReveal>
     </>
   ),
   args: {

--- a/animata/preloader/split-reveal.stories.tsx
+++ b/animata/preloader/split-reveal.stories.tsx
@@ -18,6 +18,7 @@ const meta = {
   tags: ["autodocs"],
   argTypes: {
     revealDuration: { control: { type: "number", min: 0.2, max: 2, step: 0.05 } },
+    progressFadeMs: { control: { type: "number", min: 0, max: 800, step: 20 } },
     holdMs: { control: { type: "number", min: 0, max: 1200, step: 20 } },
     backgroundColor: { control: "color" },
     foregroundColor: { control: "color" },

--- a/animata/preloader/split-reveal.stories.tsx
+++ b/animata/preloader/split-reveal.stories.tsx
@@ -1,0 +1,105 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import SplitReveal from "@/animata/preloader/split-reveal";
+
+const SAMPLE_IMAGES = [
+  "https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?auto=format&fit=crop&w=900&h=1125&q=85",
+  "https://images.unsplash.com/photo-1544005313-94ddf0286df2?auto=format&fit=crop&w=900&h=1125&q=85",
+  "https://images.unsplash.com/photo-1511795409834-ef04bbd61622?auto=format&fit=crop&w=900&h=1125&q=85",
+  "https://images.unsplash.com/photo-1534528741775-53994a69daeb?auto=format&fit=crop&w=900&h=1125&q=85",
+];
+
+const meta = {
+  title: "Preloader/Split Reveal",
+  component: SplitReveal,
+  parameters: {
+    layout: "fullscreen",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    revealDuration: { control: { type: "number", min: 0.2, max: 2, step: 0.05 } },
+    holdMs: { control: { type: "number", min: 0, max: 1200, step: 20 } },
+    backgroundColor: { control: "color" },
+    foregroundColor: { control: "color" },
+    lockScroll: { control: "boolean" },
+  },
+} satisfies Meta<typeof SplitReveal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  render: (args) => (
+    <>
+      <div className="flex min-h-svh items-center justify-center bg-zinc-100 px-6">
+        <p className="max-w-md text-center text-2xl font-semibold tracking-tight text-zinc-900">
+          Page content mounts normally. SplitReveal covers it until images load.
+        </p>
+      </div>
+      <SplitReveal {...args} />
+    </>
+  ),
+  args: {
+    images: SAMPLE_IMAGES,
+    backgroundColor: "#fff",
+    foregroundColor: "#000",
+    revealDuration: 0.85,
+    holdMs: 240,
+    lockScroll: true,
+  },
+};
+
+export const CustomProgress: Story = {
+  render: (args) => (
+    <>
+      <div className="flex min-h-svh items-center justify-center bg-neutral-950 px-6 text-white">
+        <p className="text-xl font-medium">Underneath the overlay</p>
+      </div>
+      <SplitReveal
+        {...args}
+        renderProgress={({ progress, loaded, total }) => (
+          <p className="text-center text-sm tabular-nums text-white/70">
+            {loaded}/{total} · {progress}%
+          </p>
+        )}
+      />
+    </>
+  ),
+  args: {
+    images: SAMPLE_IMAGES,
+    backgroundColor: "#0a0a0a",
+    foregroundColor: "#fff",
+    revealDuration: 0.85,
+    holdMs: 240,
+    lockScroll: true,
+  },
+};
+
+export const ComposedOverlay: Story = {
+  render: (args) => (
+    <>
+      <div className="flex min-h-svh items-center justify-center bg-zinc-200 px-6">
+        <p className="text-lg font-medium text-zinc-800">Full overlay override via children</p>
+      </div>
+      <SplitReveal {...args}>
+        <SplitReveal.Shutter side="top" />
+        <SplitReveal.Shutter side="bottom" />
+        <SplitReveal.Progress>
+          {({ loaded, total }) => (
+            <p className="text-center text-xs uppercase tracking-[0.14em] text-black/50">
+              {loaded} of {total}
+            </p>
+          )}
+        </SplitReveal.Progress>
+      </SplitReveal>
+    </>
+  ),
+  args: {
+    images: SAMPLE_IMAGES,
+    backgroundColor: "#fff",
+    foregroundColor: "#000",
+    revealDuration: 0.85,
+    holdMs: 240,
+    lockScroll: true,
+  },
+};

--- a/animata/preloader/split-reveal.tsx
+++ b/animata/preloader/split-reveal.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { motion, useReducedMotion } from "motion/react";
 import {
   type ComponentProps,
+  type CSSProperties,
   createContext,
   type ReactNode,
   use,
@@ -10,6 +10,7 @@ import {
   useMemo,
   useRef,
   useState,
+  useSyncExternalStore,
 } from "react";
 
 import { cn } from "@/lib/utils";
@@ -33,6 +34,8 @@ interface SplitRevealContextValue extends SplitRevealProgressState {
 }
 
 const SplitRevealContext = createContext<SplitRevealContextValue | null>(null);
+
+const REVEAL_EASE = "cubic-bezier(0.76, 0, 0.24, 1)";
 
 export function useSplitReveal() {
   const context = use(SplitRevealContext);
@@ -60,6 +63,20 @@ export interface SplitRevealProps {
   onComplete?: () => void;
 }
 
+function subscribeReducedMotion(callback: () => void) {
+  const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+  mq.addEventListener("change", callback);
+  return () => mq.removeEventListener("change", callback);
+}
+
+function getReducedMotionSnapshot() {
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+function usePrefersReducedMotion() {
+  return useSyncExternalStore(subscribeReducedMotion, getReducedMotionSnapshot, () => false);
+}
+
 function preloadImages(urls: string[], onProgress: (loaded: number, total: number) => void) {
   const total = urls.length;
 
@@ -68,25 +85,42 @@ function preloadImages(urls: string[], onProgress: (loaded: number, total: numbe
     return Promise.resolve();
   }
 
-  return new Promise<void>((resolve) => {
-    let loaded = 0;
+  let loaded = 0;
 
-    const markDone = () => {
-      loaded += 1;
-      onProgress(loaded, total);
-      if (loaded >= total) {
-        resolve();
-      }
-    };
-
-    for (const url of urls) {
+  const preloadOne = (url: string) =>
+    new Promise<void>((resolve) => {
       const img = new Image();
+      let settled = false;
+
+      const settle = () => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        loaded += 1;
+        onProgress(loaded, total);
+        resolve();
+      };
+
+      const ready = () => {
+        if (typeof img.decode === "function") {
+          img.decode().then(settle).catch(settle);
+          return;
+        }
+        settle();
+      };
+
+      img.onload = ready;
+      img.onerror = settle;
       img.decoding = "async";
-      img.onload = markDone;
-      img.onerror = markDone;
       img.src = url;
-    }
-  });
+
+      if (img.complete && img.naturalWidth > 0) {
+        ready();
+      }
+    });
+
+  return Promise.all(urls.map((url) => preloadOne(url))).then(() => undefined);
 }
 
 function useScrollLock(active: boolean) {
@@ -133,8 +167,61 @@ function useScrollLock(active: boolean) {
   }, [active]);
 }
 
+function SplitRevealStyles() {
+  return (
+    <style>{`
+      @keyframes split-reveal-shutter-top {
+        from {
+          transform: translate3d(0, 0, 0);
+        }
+        to {
+          transform: translate3d(0, -100%, 0);
+        }
+      }
+
+      @keyframes split-reveal-shutter-bottom {
+        from {
+          transform: translate3d(0, 0, 0);
+        }
+        to {
+          transform: translate3d(0, 100%, 0);
+        }
+      }
+
+      [data-split-reveal-overlay] [data-split-reveal-progress] {
+        opacity: 1;
+        transition: opacity var(--split-reveal-progress-fade) ease-out;
+      }
+
+      [data-split-reveal-overlay][data-phase="fade-ui"] [data-split-reveal-progress],
+      [data-split-reveal-overlay][data-phase="reveal"] [data-split-reveal-progress] {
+        opacity: 0;
+      }
+
+      [data-split-reveal-overlay][data-phase="reveal"] [data-split-reveal-shutter="top"] {
+        animation: split-reveal-shutter-top var(--split-reveal-duration) ${REVEAL_EASE} forwards;
+      }
+
+      [data-split-reveal-overlay][data-phase="reveal"] [data-split-reveal-shutter="bottom"] {
+        animation: split-reveal-shutter-bottom var(--split-reveal-duration) ${REVEAL_EASE} forwards;
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        [data-split-reveal-overlay][data-phase="reveal"] [data-split-reveal-shutter] {
+          animation: none;
+          opacity: 0;
+        }
+
+        [data-split-reveal-overlay] [data-split-reveal-progress] {
+          transition: none;
+        }
+      }
+    `}</style>
+  );
+}
+
 function SplitRevealOverlayFrame({ className, children, ...props }: ComponentProps<"div">) {
-  const { phase, zIndex, isActive } = useSplitReveal();
+  const { phase, zIndex, revealDuration, progressFadeMs, isActive } = useSplitReveal();
 
   if (!isActive) {
     return null;
@@ -147,13 +234,21 @@ function SplitRevealOverlayFrame({ className, children, ...props }: ComponentPro
         phase === "loading" ? "pointer-events-auto" : "pointer-events-none",
         className,
       )}
-      style={{ zIndex }}
+      style={
+        {
+          zIndex,
+          "--split-reveal-duration": `${revealDuration}s`,
+          "--split-reveal-progress-fade": `${progressFadeMs}ms`,
+        } as CSSProperties
+      }
+      data-phase={phase}
       aria-busy={phase === "loading"}
       aria-live="polite"
       role="status"
       data-split-reveal-overlay=""
       {...props}
     >
+      <SplitRevealStyles />
       {children}
     </div>
   );
@@ -162,24 +257,19 @@ function SplitRevealOverlayFrame({ className, children, ...props }: ComponentPro
 function SplitRevealShutter({
   side,
   className,
+  style,
   ...props
-}: ComponentProps<typeof motion.div> & { side: "top" | "bottom" }) {
-  const { phase, backgroundColor, revealDuration } = useSplitReveal();
+}: ComponentProps<"div"> & { side: "top" | "bottom" }) {
+  const { backgroundColor } = useSplitReveal();
 
   return (
-    <motion.div
+    <div
       className={cn(
         "absolute inset-x-0 h-1/2 will-change-transform",
         side === "top" ? "top-0" : "bottom-0",
         className,
       )}
-      style={{ backgroundColor }}
-      initial={{ y: "0%" }}
-      animate={phase === "reveal" ? { y: side === "top" ? "-100%" : "100%" } : { y: "0%" }}
-      transition={{
-        duration: revealDuration,
-        ease: [0.76, 0, 0.24, 1] as const,
-      }}
+      style={{ backgroundColor, ...style }}
       data-split-reveal-shutter={side}
       {...props}
     />
@@ -234,28 +324,18 @@ function SplitRevealProgressCount({
   );
 }
 
-function SplitRevealProgressSlot({
-  className,
-  children,
-  ...props
-}: ComponentProps<typeof motion.div>) {
-  const { phase, progressFadeMs } = useSplitReveal();
-  const showProgress = phase === "loading";
-
+function SplitRevealProgressSlot({ className, children, ...props }: ComponentProps<"div">) {
   return (
-    <motion.div
+    <div
       className={cn(
         "pointer-events-none absolute inset-0 z-10 flex items-center justify-center",
         className,
       )}
-      initial={{ opacity: 1 }}
-      animate={{ opacity: showProgress ? 1 : 0 }}
-      transition={{ duration: progressFadeMs / 1000, ease: "easeOut" }}
       data-split-reveal-progress=""
       {...props}
     >
       <div className="w-[min(18rem,70vw)]">{children}</div>
-    </motion.div>
+    </div>
   );
 }
 
@@ -263,7 +343,7 @@ function SplitRevealProgress({
   className,
   children,
   ...props
-}: ComponentProps<typeof motion.div> & {
+}: ComponentProps<"div"> & {
   children?: ReactNode | ((state: SplitRevealProgressState) => ReactNode);
 }) {
   const { phase, progress, loaded, total, foregroundColor } = useSplitReveal();
@@ -330,11 +410,15 @@ function SplitRevealRoot({
   lockScroll = true,
   onComplete,
 }: SplitRevealProps) {
-  const reduceMotion = useReducedMotion();
+  const reduceMotion = usePrefersReducedMotion();
   const onCompleteRef = useRef(onComplete);
+  const phaseRef = useRef<PreloaderPhase>("loading");
+  const [bootId, setBootId] = useState(0);
   const [phase, setPhase] = useState<PreloaderPhase>("loading");
   const [loaded, setLoaded] = useState(0);
   const [total, setTotal] = useState(0);
+
+  phaseRef.current = phase;
 
   const uniqueImages = useMemo(() => [...new Set(images.filter(Boolean))], [images]);
 
@@ -345,60 +429,115 @@ function SplitRevealRoot({
     onCompleteRef.current = onComplete;
   }, [onComplete]);
 
+  // bootId intentionally restarts preload after bfcache / tab restore
+  // biome-ignore lint/correctness/useExhaustiveDependencies: bootId is the restart signal
   useEffect(() => {
-    let cancelled = false;
+    let runId = 0;
     let fadeTimer: number | undefined;
     let revealTimer: number | undefined;
     let doneTimer: number | undefined;
 
-    setPhase("loading");
-    setLoaded(0);
-    setTotal(uniqueImages.length);
+    const clearTimers = () => {
+      if (fadeTimer !== undefined) {
+        window.clearTimeout(fadeTimer);
+        fadeTimer = undefined;
+      }
+      if (revealTimer !== undefined) {
+        window.clearTimeout(revealTimer);
+        revealTimer = undefined;
+      }
+      if (doneTimer !== undefined) {
+        window.clearTimeout(doneTimer);
+        doneTimer = undefined;
+      }
+    };
 
-    const finish = () => {
+    const finish = (currentRun: number) => {
+      if (currentRun !== runId) {
+        return;
+      }
       onCompleteRef.current?.();
       setPhase("done");
     };
 
-    preloadImages(uniqueImages, (nextLoaded, nextTotal) => {
-      if (cancelled) {
-        return;
-      }
-      setLoaded(nextLoaded);
-      setTotal(nextTotal);
-    }).then(() => {
-      if (cancelled) {
-        return;
-      }
-
+    const startReveal = (currentRun: number) => {
       if (reduceMotion) {
-        finish();
+        finish(currentRun);
         return;
       }
 
-      fadeTimer = window.setTimeout(() => {
-        setPhase("fade-ui");
+      setPhase("fade-ui");
 
-        revealTimer = window.setTimeout(() => {
-          setPhase("reveal");
-          doneTimer = window.setTimeout(finish, revealDuration * 1000);
-        }, progressFadeMs);
-      }, holdMs);
-    });
+      revealTimer = window.setTimeout(() => {
+        if (currentRun !== runId) {
+          return;
+        }
+
+        setPhase("reveal");
+        doneTimer = window.setTimeout(() => finish(currentRun), revealDuration * 1000);
+      }, progressFadeMs);
+    };
+
+    const start = () => {
+      runId += 1;
+      const currentRun = runId;
+      clearTimers();
+
+      const imageCount = uniqueImages.length;
+
+      setPhase("loading");
+      setLoaded(0);
+      setTotal(imageCount);
+
+      if (imageCount === 0) {
+        fadeTimer = window.setTimeout(() => startReveal(currentRun), holdMs);
+        return;
+      }
+
+      preloadImages(uniqueImages, (nextLoaded, nextTotal) => {
+        if (currentRun !== runId) {
+          return;
+        }
+        setLoaded(nextLoaded);
+        setTotal(nextTotal);
+      }).then(() => {
+        if (currentRun !== runId) {
+          return;
+        }
+
+        fadeTimer = window.setTimeout(() => startReveal(currentRun), holdMs);
+      });
+    };
+
+    start();
 
     return () => {
-      cancelled = true;
-      if (fadeTimer !== undefined) {
-        window.clearTimeout(fadeTimer);
-      }
-      if (revealTimer !== undefined) {
-        window.clearTimeout(revealTimer);
-      }
-      if (doneTimer !== undefined) {
-        window.clearTimeout(doneTimer);
+      runId += 1;
+      clearTimers();
+    };
+  }, [bootId, holdMs, progressFadeMs, reduceMotion, revealDuration, uniqueImages]);
+
+  useEffect(() => {
+    const onPageShow = (event: PageTransitionEvent) => {
+      if (event.persisted && phaseRef.current !== "done") {
+        setBootId((id) => id + 1);
       }
     };
-  }, [holdMs, progressFadeMs, reduceMotion, revealDuration, uniqueImages]);
+
+    const onResume = () => {
+      if (phaseRef.current !== "done") {
+        setBootId((id) => id + 1);
+      }
+    };
+
+    window.addEventListener("pageshow", onPageShow);
+    document.addEventListener("resume", onResume);
+
+    return () => {
+      window.removeEventListener("pageshow", onPageShow);
+      document.removeEventListener("resume", onResume);
+    };
+  }, []);
 
   useScrollLock(lockScroll && isActive);
 

--- a/animata/preloader/split-reveal.tsx
+++ b/animata/preloader/split-reveal.tsx
@@ -1,0 +1,450 @@
+"use client";
+
+import { motion, useReducedMotion } from "motion/react";
+import {
+  type ComponentProps,
+  createContext,
+  type ReactNode,
+  use,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import { cn } from "@/lib/utils";
+
+type PreloaderPhase = "loading" | "reveal" | "done";
+
+export interface SplitRevealProgressState {
+  phase: PreloaderPhase;
+  progress: number;
+  loaded: number;
+  total: number;
+}
+
+interface SplitRevealContextValue extends SplitRevealProgressState {
+  backgroundColor: string;
+  foregroundColor: string;
+  revealDuration: number;
+  zIndex: number;
+  isActive: boolean;
+}
+
+const SplitRevealContext = createContext<SplitRevealContextValue | null>(null);
+
+export function useSplitReveal() {
+  const context = use(SplitRevealContext);
+  if (!context) {
+    throw new Error("SplitReveal primitives must be used within <SplitReveal>.");
+  }
+  return context;
+}
+
+export interface SplitRevealProps {
+  images: string[];
+  /** Full overlay override — shutters, progress, all of it */
+  children?: ReactNode;
+  /** Swap the center progress UI while keeping default shutters */
+  renderProgress?: (state: SplitRevealProgressState) => ReactNode;
+  overlayClassName?: string;
+  backgroundColor?: string;
+  foregroundColor?: string;
+  revealDuration?: number;
+  holdMs?: number;
+  zIndex?: number;
+  lockScroll?: boolean;
+  onComplete?: () => void;
+}
+
+function preloadImages(urls: string[], onProgress: (loaded: number, total: number) => void) {
+  const total = urls.length;
+
+  if (total === 0) {
+    onProgress(0, 0);
+    return Promise.resolve();
+  }
+
+  return new Promise<void>((resolve) => {
+    let loaded = 0;
+
+    const markDone = () => {
+      loaded += 1;
+      onProgress(loaded, total);
+      if (loaded >= total) {
+        resolve();
+      }
+    };
+
+    for (const url of urls) {
+      const img = new Image();
+      img.decoding = "async";
+      img.onload = markDone;
+      img.onerror = markDone;
+      img.src = url;
+    }
+  });
+}
+
+function useScrollLock(active: boolean) {
+  useEffect(() => {
+    if (!active) {
+      return;
+    }
+
+    const html = document.documentElement;
+    const body = document.body;
+    const scrollY = window.scrollY;
+
+    const previous = {
+      htmlOverflow: html.style.overflow,
+      bodyOverflow: body.style.overflow,
+      bodyPosition: body.style.position,
+      bodyTop: body.style.top,
+      bodyLeft: body.style.left,
+      bodyRight: body.style.right,
+      bodyWidth: body.style.width,
+      bodyTouchAction: body.style.touchAction,
+    };
+
+    html.style.overflow = "hidden";
+    body.style.overflow = "hidden";
+    body.style.position = "fixed";
+    body.style.top = `-${scrollY}px`;
+    body.style.left = "0";
+    body.style.right = "0";
+    body.style.width = "100%";
+    body.style.touchAction = "none";
+
+    return () => {
+      html.style.overflow = previous.htmlOverflow;
+      body.style.overflow = previous.bodyOverflow;
+      body.style.position = previous.bodyPosition;
+      body.style.top = previous.bodyTop;
+      body.style.left = previous.bodyLeft;
+      body.style.right = previous.bodyRight;
+      body.style.width = previous.bodyWidth;
+      body.style.touchAction = previous.bodyTouchAction;
+      window.scrollTo(0, scrollY);
+    };
+  }, [active]);
+}
+
+function SplitRevealOverlayFrame({ className, children, ...props }: ComponentProps<"div">) {
+  const { phase, zIndex, isActive } = useSplitReveal();
+
+  if (!isActive) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn(
+        "fixed inset-0 overscroll-none touch-none",
+        phase === "loading" ? "pointer-events-auto" : "pointer-events-none",
+        className,
+      )}
+      style={{ zIndex }}
+      aria-busy={phase === "loading"}
+      aria-live="polite"
+      role="status"
+      data-split-reveal-overlay=""
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+function SplitRevealShutter({
+  side,
+  className,
+  ...props
+}: ComponentProps<typeof motion.div> & { side: "top" | "bottom" }) {
+  const { phase, backgroundColor, revealDuration } = useSplitReveal();
+
+  return (
+    <motion.div
+      className={cn(
+        "absolute inset-x-0 h-1/2 will-change-transform",
+        side === "top" ? "top-0" : "bottom-0",
+        className,
+      )}
+      style={{ backgroundColor }}
+      initial={{ y: "0%" }}
+      animate={phase === "reveal" ? { y: side === "top" ? "-100%" : "100%" } : { y: "0%" }}
+      transition={{
+        duration: revealDuration,
+        ease: [0.76, 0, 0.24, 1] as const,
+      }}
+      data-split-reveal-shutter={side}
+      {...props}
+    />
+  );
+}
+
+function SplitRevealProgressTrack({
+  progress,
+  foregroundColor,
+  className,
+}: {
+  progress: number;
+  foregroundColor: string;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn("h-px w-full", className)}
+      style={{ backgroundColor: `${foregroundColor}14` }}
+    >
+      <div
+        className="h-px transition-[width] duration-300 ease-out"
+        style={{ width: `${progress}%`, backgroundColor: foregroundColor }}
+      />
+    </div>
+  );
+}
+
+function SplitRevealProgressCount({
+  loaded,
+  total,
+  foregroundColor,
+  className,
+}: {
+  loaded: number;
+  total: number;
+  foregroundColor: string;
+  className?: string;
+}) {
+  return (
+    <p
+      className={cn(
+        "mt-3 text-center text-[11px] font-medium tabular-nums tracking-[0.12em]",
+        className,
+      )}
+      style={{ color: `${foregroundColor}73` }}
+    >
+      {String(loaded).padStart(2, "0")}
+      <span style={{ color: `${foregroundColor}33` }}> / </span>
+      {String(total).padStart(2, "0")}
+    </p>
+  );
+}
+
+function SplitRevealProgressSlot({
+  className,
+  children,
+  ...props
+}: ComponentProps<typeof motion.div>) {
+  const { phase } = useSplitReveal();
+
+  return (
+    <motion.div
+      className={cn(
+        "pointer-events-none absolute inset-0 z-10 flex items-center justify-center",
+        className,
+      )}
+      initial={{ opacity: 1 }}
+      animate={phase === "reveal" ? { opacity: 0 } : { opacity: 1 }}
+      transition={{ duration: 0.28, ease: "easeOut" }}
+      data-split-reveal-progress=""
+      {...props}
+    >
+      <div className="w-[min(18rem,70vw)]">{children}</div>
+    </motion.div>
+  );
+}
+
+function SplitRevealProgress({
+  className,
+  children,
+  ...props
+}: ComponentProps<typeof motion.div> & {
+  children?: ReactNode | ((state: SplitRevealProgressState) => ReactNode);
+}) {
+  const { phase, progress, loaded, total, foregroundColor } = useSplitReveal();
+
+  const content =
+    typeof children === "function"
+      ? children({ progress, loaded, total, phase })
+      : (children ?? (
+          <>
+            <SplitRevealProgressTrack progress={progress} foregroundColor={foregroundColor} />
+            <SplitRevealProgressCount
+              loaded={loaded}
+              total={total}
+              foregroundColor={foregroundColor}
+            />
+          </>
+        ));
+
+  return (
+    <SplitRevealProgressSlot className={className} {...props}>
+      {content}
+    </SplitRevealProgressSlot>
+  );
+}
+
+function SplitRevealDefaultOverlay({
+  renderProgress,
+}: {
+  renderProgress?: (state: SplitRevealProgressState) => ReactNode;
+}) {
+  const state = useSplitReveal();
+
+  return (
+    <>
+      <SplitRevealShutter side="top" />
+      <SplitRevealShutter side="bottom" />
+      {renderProgress ? (
+        <SplitRevealProgressSlot>
+          {renderProgress({
+            phase: state.phase,
+            progress: state.progress,
+            loaded: state.loaded,
+            total: state.total,
+          })}
+        </SplitRevealProgressSlot>
+      ) : (
+        <SplitRevealProgress />
+      )}
+    </>
+  );
+}
+
+function SplitRevealRoot({
+  images,
+  children,
+  renderProgress,
+  overlayClassName,
+  backgroundColor = "#fff",
+  foregroundColor = "#000",
+  revealDuration = 0.85,
+  holdMs = 240,
+  zIndex = 100,
+  lockScroll = true,
+  onComplete,
+}: SplitRevealProps) {
+  const reduceMotion = useReducedMotion();
+  const onCompleteRef = useRef(onComplete);
+  const [phase, setPhase] = useState<PreloaderPhase>("loading");
+  const [loaded, setLoaded] = useState(0);
+  const [total, setTotal] = useState(0);
+
+  const uniqueImages = useMemo(() => [...new Set(images.filter(Boolean))], [images]);
+
+  const progress = total === 0 ? 100 : Math.round((loaded / total) * 100);
+  const isActive = phase !== "done";
+
+  useEffect(() => {
+    onCompleteRef.current = onComplete;
+  }, [onComplete]);
+
+  useEffect(() => {
+    let cancelled = false;
+    let revealTimer: number | undefined;
+    let doneTimer: number | undefined;
+
+    setPhase("loading");
+    setLoaded(0);
+    setTotal(uniqueImages.length);
+
+    const finish = () => {
+      onCompleteRef.current?.();
+      setPhase("done");
+    };
+
+    preloadImages(uniqueImages, (nextLoaded, nextTotal) => {
+      if (cancelled) {
+        return;
+      }
+      setLoaded(nextLoaded);
+      setTotal(nextTotal);
+    }).then(() => {
+      if (cancelled) {
+        return;
+      }
+
+      if (reduceMotion) {
+        finish();
+        return;
+      }
+
+      revealTimer = window.setTimeout(() => {
+        setPhase("reveal");
+        doneTimer = window.setTimeout(finish, revealDuration * 1000);
+      }, holdMs);
+    });
+
+    return () => {
+      cancelled = true;
+      if (revealTimer !== undefined) {
+        window.clearTimeout(revealTimer);
+      }
+      if (doneTimer !== undefined) {
+        window.clearTimeout(doneTimer);
+      }
+    };
+  }, [holdMs, reduceMotion, revealDuration, uniqueImages]);
+
+  useScrollLock(lockScroll && isActive);
+
+  const contextValue = useMemo<SplitRevealContextValue>(
+    () => ({
+      phase,
+      progress,
+      loaded,
+      total,
+      backgroundColor,
+      foregroundColor,
+      revealDuration,
+      zIndex,
+      isActive,
+    }),
+    [
+      backgroundColor,
+      foregroundColor,
+      isActive,
+      loaded,
+      phase,
+      progress,
+      revealDuration,
+      total,
+      zIndex,
+    ],
+  );
+
+  if (!isActive) {
+    return null;
+  }
+
+  return (
+    <SplitRevealContext value={contextValue}>
+      <SplitRevealOverlayFrame className={overlayClassName}>
+        {children ?? <SplitRevealDefaultOverlay renderProgress={renderProgress} />}
+      </SplitRevealOverlayFrame>
+    </SplitRevealContext>
+  );
+}
+
+const SplitReveal = Object.assign(SplitRevealRoot, {
+  Shutter: SplitRevealShutter,
+  Progress: SplitRevealProgress,
+  ProgressTrack: SplitRevealProgressTrack,
+  ProgressCount: SplitRevealProgressCount,
+});
+
+export default SplitReveal;
+export {
+  type PreloaderPhase,
+  preloadImages,
+  SplitReveal,
+  SplitRevealOverlayFrame,
+  SplitRevealProgress,
+  SplitRevealProgressCount,
+  SplitRevealProgressSlot,
+  SplitRevealProgressTrack,
+  SplitRevealRoot,
+  SplitRevealShutter,
+  useScrollLock,
+};

--- a/animata/preloader/split-reveal.tsx
+++ b/animata/preloader/split-reveal.tsx
@@ -288,7 +288,7 @@ function SplitRevealProgressTrack({
   return (
     <div
       className={cn("h-px w-full", className)}
-      style={{ backgroundColor: `${foregroundColor}14` }}
+      style={{ backgroundColor: `color-mix(in srgb, ${foregroundColor} 8%, transparent)` }}
     >
       <div
         className="h-px transition-[width] duration-300 ease-out"

--- a/animata/preloader/split-reveal.tsx
+++ b/animata/preloader/split-reveal.tsx
@@ -14,7 +14,7 @@ import {
 
 import { cn } from "@/lib/utils";
 
-type PreloaderPhase = "loading" | "reveal" | "done";
+type PreloaderPhase = "loading" | "fade-ui" | "reveal" | "done";
 
 export interface SplitRevealProgressState {
   phase: PreloaderPhase;
@@ -27,6 +27,7 @@ interface SplitRevealContextValue extends SplitRevealProgressState {
   backgroundColor: string;
   foregroundColor: string;
   revealDuration: number;
+  progressFadeMs: number;
   zIndex: number;
   isActive: boolean;
 }
@@ -51,6 +52,8 @@ export interface SplitRevealProps {
   backgroundColor?: string;
   foregroundColor?: string;
   revealDuration?: number;
+  /** Progress UI fade duration before shutters move */
+  progressFadeMs?: number;
   holdMs?: number;
   zIndex?: number;
   lockScroll?: boolean;
@@ -236,7 +239,8 @@ function SplitRevealProgressSlot({
   children,
   ...props
 }: ComponentProps<typeof motion.div>) {
-  const { phase } = useSplitReveal();
+  const { phase, progressFadeMs } = useSplitReveal();
+  const showProgress = phase === "loading";
 
   return (
     <motion.div
@@ -245,8 +249,8 @@ function SplitRevealProgressSlot({
         className,
       )}
       initial={{ opacity: 1 }}
-      animate={phase === "reveal" ? { opacity: 0 } : { opacity: 1 }}
-      transition={{ duration: 0.28, ease: "easeOut" }}
+      animate={{ opacity: showProgress ? 1 : 0 }}
+      transition={{ duration: progressFadeMs / 1000, ease: "easeOut" }}
       data-split-reveal-progress=""
       {...props}
     >
@@ -320,6 +324,7 @@ function SplitRevealRoot({
   backgroundColor = "#fff",
   foregroundColor = "#000",
   revealDuration = 0.85,
+  progressFadeMs = 280,
   holdMs = 240,
   zIndex = 100,
   lockScroll = true,
@@ -342,6 +347,7 @@ function SplitRevealRoot({
 
   useEffect(() => {
     let cancelled = false;
+    let fadeTimer: number | undefined;
     let revealTimer: number | undefined;
     let doneTimer: number | undefined;
 
@@ -370,14 +376,21 @@ function SplitRevealRoot({
         return;
       }
 
-      revealTimer = window.setTimeout(() => {
-        setPhase("reveal");
-        doneTimer = window.setTimeout(finish, revealDuration * 1000);
+      fadeTimer = window.setTimeout(() => {
+        setPhase("fade-ui");
+
+        revealTimer = window.setTimeout(() => {
+          setPhase("reveal");
+          doneTimer = window.setTimeout(finish, revealDuration * 1000);
+        }, progressFadeMs);
       }, holdMs);
     });
 
     return () => {
       cancelled = true;
+      if (fadeTimer !== undefined) {
+        window.clearTimeout(fadeTimer);
+      }
       if (revealTimer !== undefined) {
         window.clearTimeout(revealTimer);
       }
@@ -385,7 +398,7 @@ function SplitRevealRoot({
         window.clearTimeout(doneTimer);
       }
     };
-  }, [holdMs, reduceMotion, revealDuration, uniqueImages]);
+  }, [holdMs, progressFadeMs, reduceMotion, revealDuration, uniqueImages]);
 
   useScrollLock(lockScroll && isActive);
 
@@ -398,6 +411,7 @@ function SplitRevealRoot({
       backgroundColor,
       foregroundColor,
       revealDuration,
+      progressFadeMs,
       zIndex,
       isActive,
     }),
@@ -408,6 +422,7 @@ function SplitRevealRoot({
       loaded,
       phase,
       progress,
+      progressFadeMs,
       revealDuration,
       total,
       zIndex,

--- a/app/(main)/_landing/card-stack-bento.tsx
+++ b/app/(main)/_landing/card-stack-bento.tsx
@@ -6,7 +6,6 @@ import { useState } from "react";
 import CardStack, { useCardStack } from "@/animata/card/card-stack";
 import { DEMO_PEOPLE } from "@/app/demo/library/shared/card-stack-people";
 import { ProfileStackCard } from "@/app/demo/library/shared/profile-stack-card";
-import ComponentLinkWrapper from "@/components/component-link-wrapper";
 import { cn } from "@/lib/utils";
 
 const BENTO_PEOPLE = DEMO_PEOPLE.slice(0, 4);
@@ -47,24 +46,22 @@ function BentoStackInner() {
 
 export function CardStackBento() {
   return (
-    <ComponentLinkWrapper link="/demo/hero/photographer-portfolio" className="block h-full">
-      <div className={cn("flex h-full flex-col")}>
-        <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground sm:text-xs">
-          Card stack
-        </span>
-        <p className="mt-2 text-sm text-foreground">Click through the deck</p>
-        <div className="mt-auto flex justify-center pt-4">
-          <CardStack items={BENTO_PEOPLE} depth={3}>
-            <BentoStackInner />
-          </CardStack>
-        </div>
-        <Link
-          href="/demo/hero/photographer-portfolio"
-          className="mt-3 text-[11px] font-medium text-[hsl(var(--accent))] hover:underline"
-        >
-          Open full demo →
-        </Link>
+    <div className={cn("flex h-full flex-col")}>
+      <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground sm:text-xs">
+        Card stack
+      </span>
+      <p className="mt-2 text-sm text-foreground">Click through the deck</p>
+      <div className="mt-auto flex justify-center pt-4">
+        <CardStack items={BENTO_PEOPLE} depth={3}>
+          <BentoStackInner />
+        </CardStack>
       </div>
-    </ComponentLinkWrapper>
+      <Link
+        href="/demo/hero/photographer-portfolio"
+        className="mt-3 text-[11px] font-medium text-[hsl(var(--accent))] hover:underline"
+      >
+        Open full demo →
+      </Link>
+    </div>
   );
 }

--- a/app/(main)/_landing/card-stack-bento.tsx
+++ b/app/(main)/_landing/card-stack-bento.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+
+import CardStack, { useCardStack } from "@/animata/card/card-stack";
+import { DEMO_PEOPLE } from "@/app/demo/library/shared/card-stack-people";
+import { ProfileStackCard } from "@/app/demo/library/shared/profile-stack-card";
+import ComponentLinkWrapper from "@/components/component-link-wrapper";
+import { cn } from "@/lib/utils";
+
+const BENTO_PEOPLE = DEMO_PEOPLE.slice(0, 4);
+
+function BentoStackInner() {
+  const [viewed, setViewed] = useState(0);
+  const { activeItem } = useCardStack();
+
+  return (
+    <CardStack.Frame className="mx-auto w-full max-w-[16rem]">
+      <CardStack.Masks />
+      <CardStack.LiveRegion />
+      <CardStack.Trigger
+        className="w-full"
+        onClick={() => setViewed((count) => Math.min(BENTO_PEOPLE.length, count + 1))}
+      >
+        <CardStack.Viewport className="min-h-[14rem] sm:min-h-[15rem]">
+          <CardStack.List>
+            {(item, index, layer) => (
+              <ProfileStackCard
+                key={item.id}
+                item={item}
+                index={index}
+                layer={layer}
+                cardClassName="shadow-lg ring-border/60"
+              />
+            )}
+          </CardStack.List>
+        </CardStack.Viewport>
+      </CardStack.Trigger>
+      <p className="mt-3 text-center text-[11px] text-muted-foreground">
+        {viewed}/{BENTO_PEOPLE.length} viewed
+        {activeItem ? ` · ${activeItem.title.split(" ")[0]}` : ""}
+      </p>
+    </CardStack.Frame>
+  );
+}
+
+export function CardStackBento() {
+  return (
+    <ComponentLinkWrapper link="/demo/hero/photographer-portfolio" className="block h-full">
+      <div className={cn("flex h-full flex-col")}>
+        <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground sm:text-xs">
+          Card stack
+        </span>
+        <p className="mt-2 text-sm text-foreground">Click through the deck</p>
+        <div className="mt-auto flex justify-center pt-4">
+          <CardStack items={BENTO_PEOPLE} depth={3}>
+            <BentoStackInner />
+          </CardStack>
+        </div>
+        <Link
+          href="/demo/hero/photographer-portfolio"
+          className="mt-3 text-[11px] font-medium text-[hsl(var(--accent))] hover:underline"
+        >
+          Open full demo →
+        </Link>
+      </div>
+    </ComponentLinkWrapper>
+  );
+}

--- a/app/(main)/_landing/stats-bento.tsx
+++ b/app/(main)/_landing/stats-bento.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { type CSSProperties, useEffect, useState } from "react";
+import type { CSSProperties } from "react";
 
 import AnimatedBorderTrail from "@/animata/container/animated-border-trail";
 import Marquee from "@/animata/container/marquee";
@@ -15,6 +15,8 @@ import RemountOnMouseIn from "@/components/remount-on-mouse-in";
 import { docsConfig } from "@/config/docs";
 import { siteStats } from "@/config/site-stats";
 import { cn } from "@/lib/utils";
+
+import { CardStackBento } from "./card-stack-bento";
 
 // Get component categories from the sidebar nav (skip Getting Started + Contributing)
 const categories = docsConfig.sidebarNav
@@ -297,6 +299,12 @@ export default function StatsBento() {
             <div className="mt-3 inline-block self-start rounded-full bg-foreground px-3 py-1 text-[11px] font-bold text-background sm:px-4 sm:py-1.5 sm:text-[12px]">
               MIT Licensed — free forever
             </div>
+          </BentoCard>
+        </div>
+
+        <div className="mt-3 sm:mt-4">
+          <BentoCard className="min-h-[22rem] sm:min-h-[24rem]">
+            <CardStackBento />
           </BentoCard>
         </div>
 

--- a/app/demo/demo-experience.tsx
+++ b/app/demo/demo-experience.tsx
@@ -48,6 +48,15 @@ const CHROME_IDLE_MS = 2200;
 const EDGE_SWIPE_PX = 28;
 const EDGE_SWIPE_MIN = 72;
 
+const DEMO_PRESS_SPRING = {
+  type: "spring" as const,
+  stiffness: 250,
+  damping: 25,
+};
+
+const PILL_CONTROL_CLASS =
+  "grid size-9 shrink-0 touch-manipulation place-items-center rounded-full text-white/62 outline-none transition-[color,background-color] duration-150 hover:bg-white/10 hover:text-white focus-visible:bg-white/10 focus-visible:text-white";
+
 function isTypingTarget(target: EventTarget | null) {
   if (!(target instanceof HTMLElement)) return false;
   const tag = target.tagName;
@@ -751,60 +760,34 @@ function PillHomeButton({
   onShowTip: (label: string, anchor: HTMLElement) => void;
 }) {
   const reducedMotion = useReducedMotion();
-  const logoRef = useRef<HTMLSpanElement>(null);
-  const swingRef = useRef<ReturnType<typeof animate> | null>(null);
   const tipLabel = formatDemoTooltipLabel("Home", "H");
 
   const revealTip = (anchor: HTMLElement) => {
     onShowTip(tipLabel, anchor);
   };
 
-  const swingLogo = useCallback(() => {
-    if (reducedMotion || !logoRef.current) return;
-
-    swingRef.current?.stop();
-    swingRef.current = animate(
-      logoRef.current,
-      { rotate: [18, -12, 7, -3, 1, 0] },
-      {
-        duration: 1.15,
-        ease: [0.22, 1.12, 0.36, 1],
-        times: [0, 0.24, 0.46, 0.68, 0.86, 1],
-      },
-    );
-  }, [reducedMotion]);
-
-  useEffect(() => {
-    return () => {
-      swingRef.current?.stop();
-    };
-  }, []);
-
   return (
-    <button
+    <motion.button
       type="button"
       aria-label="Back to animata home"
       aria-keyshortcuts="H"
       onClick={onClick}
-      onMouseEnter={(event) => {
-        revealTip(event.currentTarget);
-        swingLogo();
-      }}
-      onFocus={(event) => {
-        revealTip(event.currentTarget);
-        swingLogo();
-      }}
-      className="grid size-9 shrink-0 touch-manipulation place-items-center rounded-full text-white/62 outline-none transition-[color,background-color] duration-150 hover:bg-white/10 hover:text-white focus-visible:bg-white/10 focus-visible:text-white"
+      onMouseEnter={(event) => revealTip(event.currentTarget)}
+      onFocus={(event) => revealTip(event.currentTarget)}
+      whileTap={reducedMotion ? undefined : { scale: 0.94 }}
+      transition={DEMO_PRESS_SPRING}
+      className={cn(PILL_CONTROL_CLASS, "group")}
     >
       <span
-        ref={logoRef}
         aria-hidden="true"
-        className="inline-block origin-top will-change-transform"
-        style={{ transformOrigin: "top center" }}
+        className={cn(
+          "demo-home-logo inline-flex size-3.5 items-center justify-center",
+          !reducedMotion && "demo-home-logo-swing",
+        )}
       >
         <Icons.logo className="size-3.5" />
       </span>
-    </button>
+    </motion.button>
   );
 }
 
@@ -838,14 +821,16 @@ function PillRefreshButton({
   }, [refreshKey, reducedMotion]);
 
   return (
-    <button
+    <motion.button
       type="button"
       aria-label="Refresh demo"
       aria-keyshortcuts="R"
       onClick={onClick}
       onMouseEnter={(event) => revealTip(event.currentTarget)}
       onFocus={(event) => revealTip(event.currentTarget)}
-      className="grid size-9 shrink-0 touch-manipulation place-items-center rounded-full text-white/62 outline-none transition-[color,background-color] duration-150 hover:bg-white/10 hover:text-white focus-visible:bg-white/10 focus-visible:text-white active:scale-95"
+      whileTap={reducedMotion ? undefined : { scale: 0.94 }}
+      transition={DEMO_PRESS_SPRING}
+      className={PILL_CONTROL_CLASS}
     >
       <span
         ref={iconRef}
@@ -854,7 +839,7 @@ function PillRefreshButton({
       >
         <RefreshCwIcon className="size-3.5" />
       </span>
-    </button>
+    </motion.button>
   );
 }
 
@@ -866,6 +851,7 @@ function PillIconButton({
   onClick,
   onShowTip,
 }: PillIconButtonProps) {
+  const reducedMotion = useReducedMotion();
   const tipLabel = formatDemoTooltipLabel(label, keyShortcut);
 
   const revealTip = (anchor: HTMLElement) => {
@@ -873,20 +859,19 @@ function PillIconButton({
   };
 
   return (
-    <button
+    <motion.button
       type="button"
       aria-label={label}
       aria-keyshortcuts={keyShortcut}
       onClick={onClick}
       onMouseEnter={(event) => revealTip(event.currentTarget)}
       onFocus={(event) => revealTip(event.currentTarget)}
-      className={cn(
-        "grid size-9 shrink-0 touch-manipulation place-items-center rounded-full text-white/62 outline-none transition-[color,background-color,transform] duration-150 hover:bg-white/10 hover:text-white focus-visible:bg-white/10 focus-visible:text-white active:scale-95",
-        className,
-      )}
+      whileTap={reducedMotion ? undefined : { scale: 0.94 }}
+      transition={DEMO_PRESS_SPRING}
+      className={cn(PILL_CONTROL_CLASS, className)}
     >
       <Icon aria-hidden="true" className="size-3.5" />
-    </button>
+    </motion.button>
   );
 }
 
@@ -911,6 +896,7 @@ function PillIconLink({
   className,
   onShowTip,
 }: PillIconLinkProps) {
+  const reducedMotion = useReducedMotion();
   const tipLabel = formatDemoTooltipLabel(label, keyShortcut);
 
   const revealTip = (anchor: HTMLElement) => {
@@ -918,7 +904,7 @@ function PillIconLink({
   };
 
   return (
-    <a
+    <motion.a
       aria-label={label}
       aria-keyshortcuts={keyShortcut}
       href={href}
@@ -926,13 +912,12 @@ function PillIconLink({
       rel={rel}
       onMouseEnter={(event) => revealTip(event.currentTarget)}
       onFocus={(event) => revealTip(event.currentTarget)}
-      className={cn(
-        "grid size-9 shrink-0 touch-manipulation place-items-center rounded-full text-white/62 outline-none transition-[color,background-color,transform] duration-150 hover:bg-white/10 hover:text-white focus-visible:bg-white/10 focus-visible:text-white active:scale-95",
-        className,
-      )}
+      whileTap={reducedMotion ? undefined : { scale: 0.94 }}
+      transition={DEMO_PRESS_SPRING}
+      className={cn(PILL_CONTROL_CLASS, className)}
     >
       <Icon aria-hidden="true" className="size-3.5" />
-    </a>
+    </motion.a>
   );
 }
 
@@ -971,6 +956,24 @@ function DemoShellStyles() {
       @keyframes demo-fade-in {
         from { opacity: 0; }
         to { opacity: 1; }
+      }
+
+      @keyframes demo-logo-swing {
+        from {
+          transform: rotate(-14deg);
+        }
+        to {
+          transform: rotate(14deg);
+        }
+      }
+
+      .demo-home-logo {
+        transform-origin: 60% 0;
+      }
+
+      .group:hover .demo-home-logo-swing,
+      .group:focus-visible .demo-home-logo-swing {
+        animation: demo-logo-swing 0.95s ease-in-out infinite alternate;
       }
 
       .demo-picker-shell {

--- a/app/demo/demo-registry.config.js
+++ b/app/demo/demo-registry.config.js
@@ -66,4 +66,32 @@ export const DEMO_REGISTRY = [
       },
     ],
   },
+  {
+    key: "hero/photographer-portfolio",
+    groupSlug: "hero",
+    itemSlug: "photographer-portfolio",
+    label: "Photographer portfolio",
+    components: [
+      {
+        docSlug: "card/card-stack",
+        category: "Card",
+        name: "Card Stack",
+        description:
+          "Portfolio deck — full-bleed 4:5 prints, forward-only carousel, autoplay after preload.",
+      },
+      {
+        docSlug: "image/trailing-image",
+        category: "Image",
+        name: "Trailing Image",
+        description: "Mouse trail of portfolio frames across the white field.",
+      },
+      {
+        docSlug: "preloader/split-reveal",
+        category: "Preloader",
+        name: "Split Reveal",
+        description:
+          "Fixed overlay — preloads images, locks scroll, splits from the center seam when done.",
+      },
+    ],
+  },
 ];

--- a/app/demo/demo-sources.config.js
+++ b/app/demo/demo-sources.config.js
@@ -3,4 +3,5 @@ export const DEMO_SOURCE_FILES = {
   "footer/footer-wordmark": ["app/demo/library/footer/footer-wordmark.tsx"],
   "hero/launch-shift": ["app/demo/library/hero/launch-shift.tsx"],
   "browse/cinema-row": ["app/demo/library/browse/cinema-row.tsx"],
+  "hero/photographer-portfolio": ["app/demo/library/hero/photographer-portfolio.tsx"],
 };

--- a/app/demo/demos.ts
+++ b/app/demo/demos.ts
@@ -50,6 +50,12 @@ export const DEMO_GROUPS: DemoGroup[] = [
         themeColor: "#0E0E10",
         ...lazyDemo(() => import("./library/hero/launch-shift")),
       },
+      {
+        slug: "photographer-portfolio",
+        label: "Photographer portfolio",
+        themeColor: "#ffffff",
+        ...lazyDemo(() => import("./library/hero/photographer-portfolio")),
+      },
     ],
   },
   {

--- a/app/demo/generated/demo-sources.ts
+++ b/app/demo/generated/demo-sources.ts
@@ -2778,10 +2778,7 @@ function PrintCaption() {
   }
 
   return (
-    <figcaption
-      className="relative z-10 shrink-0 border-b border-black/80 pb-3"
-      style={{ backgroundColor: CANVAS }}
-    >
+    <figcaption className="relative z-10 shrink-0 border-b border-black/80 pb-3">
       <div className="flex items-baseline justify-between gap-4">
         <p className="text-[11px] font-medium uppercase tracking-[0.1em] text-black">
           {activeItem.title}
@@ -2859,11 +2856,7 @@ function PrintProof({
           "md:w-[min(100cqw,calc((100cqh-4.5rem)*8/11))]",
         )}
       >
-        <div
-          ref={captionRef}
-          className="relative z-30 w-full shrink-0"
-          style={{ backgroundColor: CANVAS }}
-        >
+        <div ref={captionRef} className="relative z-30 w-full shrink-0">
           <PrintCaption />
         </div>
 
@@ -3179,10 +3172,7 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#24292E">  }</span></span>
 <span class="line"></span>
 <span class="line"><span style="color:#D73A49">  return</span><span style="color:#24292E"> (</span></span>
-<span class="line"><span style="color:#24292E">    &#x3C;</span><span style="color:#22863A">figcaption</span></span>
-<span class="line"><span style="color:#6F42C1">      className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"relative z-10 shrink-0 border-b border-black/80 pb-3"</span></span>
-<span class="line"><span style="color:#6F42C1">      style</span><span style="color:#D73A49">=</span><span style="color:#24292E">{{ backgroundColor: </span><span style="color:#005CC5">CANVAS</span><span style="color:#24292E"> }}</span></span>
-<span class="line"><span style="color:#24292E">    ></span></span>
+<span class="line"><span style="color:#24292E">    &#x3C;</span><span style="color:#22863A">figcaption</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"relative z-10 shrink-0 border-b border-black/80 pb-3"</span><span style="color:#24292E">></span></span>
 <span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#22863A">div</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"flex items-baseline justify-between gap-4"</span><span style="color:#24292E">></span></span>
 <span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">p</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"text-[11px] font-medium uppercase tracking-[0.1em] text-black"</span><span style="color:#24292E">></span></span>
 <span class="line"><span style="color:#24292E">          {activeItem.title}</span></span>
@@ -3260,11 +3250,7 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#032F62">          "md:w-[min(100cqw,calc((100cqh-4.5rem)*8/11))]"</span><span style="color:#24292E">,</span></span>
 <span class="line"><span style="color:#24292E">        )}</span></span>
 <span class="line"><span style="color:#24292E">      ></span></span>
-<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">div</span></span>
-<span class="line"><span style="color:#6F42C1">          ref</span><span style="color:#D73A49">=</span><span style="color:#24292E">{captionRef}</span></span>
-<span class="line"><span style="color:#6F42C1">          className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"relative z-30 w-full shrink-0"</span></span>
-<span class="line"><span style="color:#6F42C1">          style</span><span style="color:#D73A49">=</span><span style="color:#24292E">{{ backgroundColor: </span><span style="color:#005CC5">CANVAS</span><span style="color:#24292E"> }}</span></span>
-<span class="line"><span style="color:#24292E">        ></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">div</span><span style="color:#6F42C1"> ref</span><span style="color:#D73A49">=</span><span style="color:#24292E">{captionRef} </span><span style="color:#6F42C1">className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"relative z-30 w-full shrink-0"</span><span style="color:#24292E">></span></span>
 <span class="line"><span style="color:#24292E">          &#x3C;</span><span style="color:#005CC5">PrintCaption</span><span style="color:#24292E"> /></span></span>
 <span class="line"><span style="color:#24292E">        &#x3C;/</span><span style="color:#22863A">div</span><span style="color:#24292E">></span></span>
 <span class="line"></span>
@@ -3580,10 +3566,7 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#E1E4E8">  }</span></span>
 <span class="line"></span>
 <span class="line"><span style="color:#F97583">  return</span><span style="color:#E1E4E8"> (</span></span>
-<span class="line"><span style="color:#E1E4E8">    &#x3C;</span><span style="color:#85E89D">figcaption</span></span>
-<span class="line"><span style="color:#B392F0">      className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"relative z-10 shrink-0 border-b border-black/80 pb-3"</span></span>
-<span class="line"><span style="color:#B392F0">      style</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{{ backgroundColor: </span><span style="color:#79B8FF">CANVAS</span><span style="color:#E1E4E8"> }}</span></span>
-<span class="line"><span style="color:#E1E4E8">    ></span></span>
+<span class="line"><span style="color:#E1E4E8">    &#x3C;</span><span style="color:#85E89D">figcaption</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"relative z-10 shrink-0 border-b border-black/80 pb-3"</span><span style="color:#E1E4E8">></span></span>
 <span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#85E89D">div</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"flex items-baseline justify-between gap-4"</span><span style="color:#E1E4E8">></span></span>
 <span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">p</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"text-[11px] font-medium uppercase tracking-[0.1em] text-black"</span><span style="color:#E1E4E8">></span></span>
 <span class="line"><span style="color:#E1E4E8">          {activeItem.title}</span></span>
@@ -3661,11 +3644,7 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#9ECBFF">          "md:w-[min(100cqw,calc((100cqh-4.5rem)*8/11))]"</span><span style="color:#E1E4E8">,</span></span>
 <span class="line"><span style="color:#E1E4E8">        )}</span></span>
 <span class="line"><span style="color:#E1E4E8">      ></span></span>
-<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">div</span></span>
-<span class="line"><span style="color:#B392F0">          ref</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{captionRef}</span></span>
-<span class="line"><span style="color:#B392F0">          className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"relative z-30 w-full shrink-0"</span></span>
-<span class="line"><span style="color:#B392F0">          style</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{{ backgroundColor: </span><span style="color:#79B8FF">CANVAS</span><span style="color:#E1E4E8"> }}</span></span>
-<span class="line"><span style="color:#E1E4E8">        ></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">div</span><span style="color:#B392F0"> ref</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{captionRef} </span><span style="color:#B392F0">className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"relative z-30 w-full shrink-0"</span><span style="color:#E1E4E8">></span></span>
 <span class="line"><span style="color:#E1E4E8">          &#x3C;</span><span style="color:#79B8FF">PrintCaption</span><span style="color:#E1E4E8"> /></span></span>
 <span class="line"><span style="color:#E1E4E8">        &#x3C;/</span><span style="color:#85E89D">div</span><span style="color:#E1E4E8">></span></span>
 <span class="line"></span>

--- a/app/demo/generated/demo-sources.ts
+++ b/app/demo/generated/demo-sources.ts
@@ -2621,7 +2621,7 @@ const PHOTOGRAPHER = {
   studio: "Maya Chen",
   name: "Maya",
   location: "Brooklyn",
-  email: "mailto:hello@mayachen.studio",
+  email: "mailto:hello@codse.com",
   avatar: lummi(LUMMI_ASSETS.avatar),
 };
 
@@ -2852,21 +2852,21 @@ function PrintProof({
   captionRef: RefObject<HTMLDivElement | null>;
 }) {
   return (
-    <figure ref={stackRef} className="flex w-full min-w-0 flex-col">
-      <div
-        ref={captionRef}
-        className="relative z-30 w-full shrink-0"
-        style={{ backgroundColor: CANVAS }}
-      >
-        <PrintCaption />
-      </div>
-
+    <figure ref={stackRef} className="flex w-full min-w-0 flex-col md:items-end">
       <div
         className={cn(
-          "flex w-full flex-col",
-          "md:ml-auto md:w-[min(100cqw,calc((100cqh-4.5rem)*8/11))]",
+          "flex w-full min-w-0 flex-col",
+          "md:w-[min(100cqw,calc((100cqh-4.5rem)*8/11))]",
         )}
       >
+        <div
+          ref={captionRef}
+          className="relative z-30 w-full shrink-0"
+          style={{ backgroundColor: CANVAS }}
+        >
+          <PrintCaption />
+        </div>
+
         <div aria-hidden="true" className={cn("w-full shrink-0", STACK_PEEK)} />
         <div className="relative aspect-[4/5] w-full shrink-0 overflow-visible">
           <PrintStack />
@@ -2890,10 +2890,13 @@ function PortfolioLayout({
       className={cn("flex flex-col gap-8", "md:h-full md:min-h-0 md:flex-1 md:flex-row md:gap-6")}
     >
       <div
-        ref={heroRef}
         className="relative z-20 min-w-0 md:flex md:flex-[2] md:basis-0 md:flex-col md:justify-end"
       >
-        <HeroStory />
+        <div
+          ref={heroRef}
+        >
+          <HeroStory />
+        </div>
       </div>
 
       <div className="w-full min-w-0 md:flex md:min-h-0 md:flex-[3] md:basis-0 md:flex-col md:justify-end md:@container/print md:[container-type:size]">
@@ -3023,7 +3026,7 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#24292E">  studio: </span><span style="color:#032F62">"Maya Chen"</span><span style="color:#24292E">,</span></span>
 <span class="line"><span style="color:#24292E">  name: </span><span style="color:#032F62">"Maya"</span><span style="color:#24292E">,</span></span>
 <span class="line"><span style="color:#24292E">  location: </span><span style="color:#032F62">"Brooklyn"</span><span style="color:#24292E">,</span></span>
-<span class="line"><span style="color:#24292E">  email: </span><span style="color:#032F62">"mailto:hello@mayachen.studio"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#24292E">  email: </span><span style="color:#032F62">"mailto:hello@codse.com"</span><span style="color:#24292E">,</span></span>
 <span class="line"><span style="color:#24292E">  avatar: </span><span style="color:#6F42C1">lummi</span><span style="color:#24292E">(</span><span style="color:#005CC5">LUMMI_ASSETS</span><span style="color:#24292E">.avatar),</span></span>
 <span class="line"><span style="color:#24292E">};</span></span>
 <span class="line"></span>
@@ -3254,21 +3257,21 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#E36209">  captionRef</span><span style="color:#D73A49">:</span><span style="color:#6F42C1"> RefObject</span><span style="color:#24292E">&#x3C;</span><span style="color:#6F42C1">HTMLDivElement</span><span style="color:#D73A49"> |</span><span style="color:#005CC5"> null</span><span style="color:#24292E">>;</span></span>
 <span class="line"><span style="color:#24292E">}) {</span></span>
 <span class="line"><span style="color:#D73A49">  return</span><span style="color:#24292E"> (</span></span>
-<span class="line"><span style="color:#24292E">    &#x3C;</span><span style="color:#22863A">figure</span><span style="color:#6F42C1"> ref</span><span style="color:#D73A49">=</span><span style="color:#24292E">{stackRef} </span><span style="color:#6F42C1">className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"flex w-full min-w-0 flex-col"</span><span style="color:#24292E">></span></span>
-<span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#22863A">div</span></span>
-<span class="line"><span style="color:#6F42C1">        ref</span><span style="color:#D73A49">=</span><span style="color:#24292E">{captionRef}</span></span>
-<span class="line"><span style="color:#6F42C1">        className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"relative z-30 w-full shrink-0"</span></span>
-<span class="line"><span style="color:#6F42C1">        style</span><span style="color:#D73A49">=</span><span style="color:#24292E">{{ backgroundColor: </span><span style="color:#005CC5">CANVAS</span><span style="color:#24292E"> }}</span></span>
-<span class="line"><span style="color:#24292E">      ></span></span>
-<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#005CC5">PrintCaption</span><span style="color:#24292E"> /></span></span>
-<span class="line"><span style="color:#24292E">      &#x3C;/</span><span style="color:#22863A">div</span><span style="color:#24292E">></span></span>
-<span class="line"></span>
+<span class="line"><span style="color:#24292E">    &#x3C;</span><span style="color:#22863A">figure</span><span style="color:#6F42C1"> ref</span><span style="color:#D73A49">=</span><span style="color:#24292E">{stackRef} </span><span style="color:#6F42C1">className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"flex w-full min-w-0 flex-col md:items-end"</span><span style="color:#24292E">></span></span>
 <span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#22863A">div</span></span>
 <span class="line"><span style="color:#6F42C1">        className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#6F42C1">cn</span><span style="color:#24292E">(</span></span>
-<span class="line"><span style="color:#032F62">          "flex w-full flex-col"</span><span style="color:#24292E">,</span></span>
-<span class="line"><span style="color:#032F62">          "md:ml-auto md:w-[min(100cqw,calc((100cqh-4.5rem)*8/11))]"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#032F62">          "flex w-full min-w-0 flex-col"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#032F62">          "md:w-[min(100cqw,calc((100cqh-4.5rem)*8/11))]"</span><span style="color:#24292E">,</span></span>
 <span class="line"><span style="color:#24292E">        )}</span></span>
 <span class="line"><span style="color:#24292E">      ></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">div</span></span>
+<span class="line"><span style="color:#6F42C1">          ref</span><span style="color:#D73A49">=</span><span style="color:#24292E">{captionRef}</span></span>
+<span class="line"><span style="color:#6F42C1">          className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"relative z-30 w-full shrink-0"</span></span>
+<span class="line"><span style="color:#6F42C1">          style</span><span style="color:#D73A49">=</span><span style="color:#24292E">{{ backgroundColor: </span><span style="color:#005CC5">CANVAS</span><span style="color:#24292E"> }}</span></span>
+<span class="line"><span style="color:#24292E">        ></span></span>
+<span class="line"><span style="color:#24292E">          &#x3C;</span><span style="color:#005CC5">PrintCaption</span><span style="color:#24292E"> /></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;/</span><span style="color:#22863A">div</span><span style="color:#24292E">></span></span>
+<span class="line"></span>
 <span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">div</span><span style="color:#6F42C1"> aria-hidden</span><span style="color:#D73A49">=</span><span style="color:#032F62">"true"</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#6F42C1">cn</span><span style="color:#24292E">(</span><span style="color:#032F62">"w-full shrink-0"</span><span style="color:#24292E">, </span><span style="color:#005CC5">STACK_PEEK</span><span style="color:#24292E">)} /></span></span>
 <span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">div</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"relative aspect-[4/5] w-full shrink-0 overflow-visible"</span><span style="color:#24292E">></span></span>
 <span class="line"><span style="color:#24292E">          &#x3C;</span><span style="color:#005CC5">PrintStack</span><span style="color:#24292E"> /></span></span>
@@ -3292,10 +3295,13 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#6F42C1">      className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#6F42C1">cn</span><span style="color:#24292E">(</span><span style="color:#032F62">"flex flex-col gap-8"</span><span style="color:#24292E">, </span><span style="color:#032F62">"md:h-full md:min-h-0 md:flex-1 md:flex-row md:gap-6"</span><span style="color:#24292E">)}</span></span>
 <span class="line"><span style="color:#24292E">    ></span></span>
 <span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#22863A">div</span></span>
-<span class="line"><span style="color:#6F42C1">        ref</span><span style="color:#D73A49">=</span><span style="color:#24292E">{heroRef}</span></span>
 <span class="line"><span style="color:#6F42C1">        className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"relative z-20 min-w-0 md:flex md:flex-[2] md:basis-0 md:flex-col md:justify-end"</span></span>
 <span class="line"><span style="color:#24292E">      ></span></span>
-<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#005CC5">HeroStory</span><span style="color:#24292E"> /></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">div</span></span>
+<span class="line"><span style="color:#6F42C1">          ref</span><span style="color:#D73A49">=</span><span style="color:#24292E">{heroRef}</span></span>
+<span class="line"><span style="color:#24292E">        ></span></span>
+<span class="line"><span style="color:#24292E">          &#x3C;</span><span style="color:#005CC5">HeroStory</span><span style="color:#24292E"> /></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;/</span><span style="color:#22863A">div</span><span style="color:#24292E">></span></span>
 <span class="line"><span style="color:#24292E">      &#x3C;/</span><span style="color:#22863A">div</span><span style="color:#24292E">></span></span>
 <span class="line"></span>
 <span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#22863A">div</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"w-full min-w-0 md:flex md:min-h-0 md:flex-[3] md:basis-0 md:flex-col md:justify-end md:@container/print md:[container-type:size]"</span><span style="color:#24292E">></span></span>
@@ -3425,7 +3431,7 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#E1E4E8">  studio: </span><span style="color:#9ECBFF">"Maya Chen"</span><span style="color:#E1E4E8">,</span></span>
 <span class="line"><span style="color:#E1E4E8">  name: </span><span style="color:#9ECBFF">"Maya"</span><span style="color:#E1E4E8">,</span></span>
 <span class="line"><span style="color:#E1E4E8">  location: </span><span style="color:#9ECBFF">"Brooklyn"</span><span style="color:#E1E4E8">,</span></span>
-<span class="line"><span style="color:#E1E4E8">  email: </span><span style="color:#9ECBFF">"mailto:hello@mayachen.studio"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">  email: </span><span style="color:#9ECBFF">"mailto:hello@codse.com"</span><span style="color:#E1E4E8">,</span></span>
 <span class="line"><span style="color:#E1E4E8">  avatar: </span><span style="color:#B392F0">lummi</span><span style="color:#E1E4E8">(</span><span style="color:#79B8FF">LUMMI_ASSETS</span><span style="color:#E1E4E8">.avatar),</span></span>
 <span class="line"><span style="color:#E1E4E8">};</span></span>
 <span class="line"></span>
@@ -3656,21 +3662,21 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#FFAB70">  captionRef</span><span style="color:#F97583">:</span><span style="color:#B392F0"> RefObject</span><span style="color:#E1E4E8">&#x3C;</span><span style="color:#B392F0">HTMLDivElement</span><span style="color:#F97583"> |</span><span style="color:#79B8FF"> null</span><span style="color:#E1E4E8">>;</span></span>
 <span class="line"><span style="color:#E1E4E8">}) {</span></span>
 <span class="line"><span style="color:#F97583">  return</span><span style="color:#E1E4E8"> (</span></span>
-<span class="line"><span style="color:#E1E4E8">    &#x3C;</span><span style="color:#85E89D">figure</span><span style="color:#B392F0"> ref</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{stackRef} </span><span style="color:#B392F0">className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"flex w-full min-w-0 flex-col"</span><span style="color:#E1E4E8">></span></span>
-<span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#85E89D">div</span></span>
-<span class="line"><span style="color:#B392F0">        ref</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{captionRef}</span></span>
-<span class="line"><span style="color:#B392F0">        className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"relative z-30 w-full shrink-0"</span></span>
-<span class="line"><span style="color:#B392F0">        style</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{{ backgroundColor: </span><span style="color:#79B8FF">CANVAS</span><span style="color:#E1E4E8"> }}</span></span>
-<span class="line"><span style="color:#E1E4E8">      ></span></span>
-<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#79B8FF">PrintCaption</span><span style="color:#E1E4E8"> /></span></span>
-<span class="line"><span style="color:#E1E4E8">      &#x3C;/</span><span style="color:#85E89D">div</span><span style="color:#E1E4E8">></span></span>
-<span class="line"></span>
+<span class="line"><span style="color:#E1E4E8">    &#x3C;</span><span style="color:#85E89D">figure</span><span style="color:#B392F0"> ref</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{stackRef} </span><span style="color:#B392F0">className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"flex w-full min-w-0 flex-col md:items-end"</span><span style="color:#E1E4E8">></span></span>
 <span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#85E89D">div</span></span>
 <span class="line"><span style="color:#B392F0">        className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#B392F0">cn</span><span style="color:#E1E4E8">(</span></span>
-<span class="line"><span style="color:#9ECBFF">          "flex w-full flex-col"</span><span style="color:#E1E4E8">,</span></span>
-<span class="line"><span style="color:#9ECBFF">          "md:ml-auto md:w-[min(100cqw,calc((100cqh-4.5rem)*8/11))]"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#9ECBFF">          "flex w-full min-w-0 flex-col"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#9ECBFF">          "md:w-[min(100cqw,calc((100cqh-4.5rem)*8/11))]"</span><span style="color:#E1E4E8">,</span></span>
 <span class="line"><span style="color:#E1E4E8">        )}</span></span>
 <span class="line"><span style="color:#E1E4E8">      ></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">div</span></span>
+<span class="line"><span style="color:#B392F0">          ref</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{captionRef}</span></span>
+<span class="line"><span style="color:#B392F0">          className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"relative z-30 w-full shrink-0"</span></span>
+<span class="line"><span style="color:#B392F0">          style</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{{ backgroundColor: </span><span style="color:#79B8FF">CANVAS</span><span style="color:#E1E4E8"> }}</span></span>
+<span class="line"><span style="color:#E1E4E8">        ></span></span>
+<span class="line"><span style="color:#E1E4E8">          &#x3C;</span><span style="color:#79B8FF">PrintCaption</span><span style="color:#E1E4E8"> /></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;/</span><span style="color:#85E89D">div</span><span style="color:#E1E4E8">></span></span>
+<span class="line"></span>
 <span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">div</span><span style="color:#B392F0"> aria-hidden</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"true"</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#B392F0">cn</span><span style="color:#E1E4E8">(</span><span style="color:#9ECBFF">"w-full shrink-0"</span><span style="color:#E1E4E8">, </span><span style="color:#79B8FF">STACK_PEEK</span><span style="color:#E1E4E8">)} /></span></span>
 <span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">div</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"relative aspect-[4/5] w-full shrink-0 overflow-visible"</span><span style="color:#E1E4E8">></span></span>
 <span class="line"><span style="color:#E1E4E8">          &#x3C;</span><span style="color:#79B8FF">PrintStack</span><span style="color:#E1E4E8"> /></span></span>
@@ -3694,10 +3700,13 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#B392F0">      className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#B392F0">cn</span><span style="color:#E1E4E8">(</span><span style="color:#9ECBFF">"flex flex-col gap-8"</span><span style="color:#E1E4E8">, </span><span style="color:#9ECBFF">"md:h-full md:min-h-0 md:flex-1 md:flex-row md:gap-6"</span><span style="color:#E1E4E8">)}</span></span>
 <span class="line"><span style="color:#E1E4E8">    ></span></span>
 <span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#85E89D">div</span></span>
-<span class="line"><span style="color:#B392F0">        ref</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{heroRef}</span></span>
 <span class="line"><span style="color:#B392F0">        className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"relative z-20 min-w-0 md:flex md:flex-[2] md:basis-0 md:flex-col md:justify-end"</span></span>
 <span class="line"><span style="color:#E1E4E8">      ></span></span>
-<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#79B8FF">HeroStory</span><span style="color:#E1E4E8"> /></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">div</span></span>
+<span class="line"><span style="color:#B392F0">          ref</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{heroRef}</span></span>
+<span class="line"><span style="color:#E1E4E8">        ></span></span>
+<span class="line"><span style="color:#E1E4E8">          &#x3C;</span><span style="color:#79B8FF">HeroStory</span><span style="color:#E1E4E8"> /></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;/</span><span style="color:#85E89D">div</span><span style="color:#E1E4E8">></span></span>
 <span class="line"><span style="color:#E1E4E8">      &#x3C;/</span><span style="color:#85E89D">div</span><span style="color:#E1E4E8">></span></span>
 <span class="line"></span>
 <span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#85E89D">div</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"w-full min-w-0 md:flex md:min-h-0 md:flex-[3] md:basis-0 md:flex-col md:justify-end md:@container/print md:[container-type:size]"</span><span style="color:#E1E4E8">></span></span>

--- a/app/demo/generated/demo-sources.ts
+++ b/app/demo/generated/demo-sources.ts
@@ -2565,7 +2565,7 @@ export default function CinemaRow() {
       code: `"use client";
 
 import "@fontsource-variable/instrument-sans";
-import { useRef, useState, type CSSProperties, type ReactNode, type RefObject } from "react";
+import { type CSSProperties, type ReactNode, type RefObject, useRef, useState } from "react";
 
 import CardStack, {
   CARD_STACK_MASK_IDS,
@@ -2580,8 +2580,7 @@ import { cn } from "@/lib/utils";
 
 import { PhotographerPortfolioNotes } from "./photographer-portfolio-notes";
 
-const FONT =
-  '"Instrument Sans Variable", ui-sans-serif, system-ui, sans-serif';
+const FONT = '"Instrument Sans Variable", ui-sans-serif, system-ui, sans-serif';
 
 const CANVAS = "#fff";
 const INK = "#000";
@@ -2640,7 +2639,6 @@ const SHOT_SETTINGS: Record<string, { aperture: string; shutter: string; stock: 
 const HERO_TONE = {
   mute: "text-black/40",
   ink: "text-black",
-  accent: "text-[#c2410c]",
 } as const;
 
 const PORTFOLIO: CardStackItem[] = [
@@ -2695,11 +2693,7 @@ const PORTFOLIO: CardStackItem[] = [
 ];
 
 const PRELOAD_IMAGES = [
-  ...new Set([
-    PHOTOGRAPHER.avatar,
-    ...PORTFOLIO.map((item) => item.image),
-    ...TRAIL_IMAGES,
-  ]),
+  ...new Set([PHOTOGRAPHER.avatar, ...PORTFOLIO.map((item) => item.image), ...TRAIL_IMAGES]),
 ];
 
 const HERO_MARK =
@@ -2707,9 +2701,9 @@ const HERO_MARK =
 
 function HeroMark({ children, className }: { children: ReactNode; className?: string }) {
   return (
-    <span className={cn(HERO_MARK, className)} aria-hidden>
+    <div className={cn(HERO_MARK, className)} aria-hidden>
       {children}
-    </span>
+    </div>
   );
 }
 
@@ -2722,12 +2716,11 @@ function ProfileGlyph({ src, alt }: { src: string; alt: string }) {
 }
 
 function HeroStory() {
-  const type =
-    "text-[clamp(1.25rem,2vw,1.75rem)] font-medium leading-[1.55] tracking-[-0.02em]";
+  const type = "text-[clamp(1.25rem,2vw,1.75rem)] font-medium leading-[1.55] tracking-[-0.02em]";
 
   return (
-    <div className="max-w-[min(100%,36rem)] space-y-6">
-      <p className={type}>
+    <div className="flex flex-col gap-[1.15em]">
+      <div className={type}>
         <span className={HERO_TONE.mute}>Hi, I'm </span>
         <span className={HERO_TONE.ink}>{PHOTOGRAPHER.name}</span>
         <ProfileGlyph src={PHOTOGRAPHER.avatar} alt={PHOTOGRAPHER.studio} />
@@ -2743,15 +2736,11 @@ function HeroStory() {
         </HeroMark>
         <span className={HERO_TONE.mute}> </span>
         <span className={HERO_TONE.ink}>{PHOTOGRAPHER.location}</span>
-        <span className={HERO_TONE.mute}>
-          {" "}
-          — good light, real moments, and photos that don't feel forced.
-        </span>
-      </p>
+        <span className={HERO_TONE.mute}> and capture photos you hang on the wall.</span>
+      </div>
 
-      <p className={type}>
-        <span className={HERO_TONE.accent}>Booking Q3.</span>
-        <span className={HERO_TONE.mute}> </span>
+      <p className={type} style={{ textBoxTrim: "trim-both" } as CSSProperties}>
+        <span className={HERO_TONE.mute}>Booking Q3. </span>
         <a
           href={PHOTOGRAPHER.email}
           className={cn(HERO_TONE.ink, "underline-offset-[4px] hover:underline")}
@@ -2789,9 +2778,14 @@ function PrintCaption() {
   }
 
   return (
-    <figcaption className="relative z-10 shrink-0 border-b border-black/80 bg-transparent pb-3">
+    <figcaption
+      className="relative z-10 shrink-0 border-b border-black/80 pb-3"
+      style={{ backgroundColor: CANVAS }}
+    >
       <div className="flex items-baseline justify-between gap-4">
-        <p className="text-[11px] font-medium uppercase tracking-[0.1em] text-black">{activeItem.title}</p>
+        <p className="text-[11px] font-medium uppercase tracking-[0.1em] text-black">
+          {activeItem.title}
+        </p>
         <p className="shrink-0 text-[11px] font-medium tabular-nums tracking-[0.1em] text-black/45">
           {String(index).padStart(2, "0")}
           <span className="text-black/20">/</span>
@@ -2809,14 +2803,48 @@ function PrintCaption() {
   );
 }
 
-const BASELINE = 8;
-const LAYOUT = {
-  shell: "px-6 sm:px-10 lg:px-14",
-  blockY: "py-8 lg:py-10",
-  grid: "gap-x-8 gap-y-8 lg:gap-x-10 lg:gap-y-10",
-} as const;
+const SHELL =
+  "px-6 pt-6 pb-[calc(var(--demo-chrome-reserve,5rem)+1.5rem)] sm:px-10 sm:pt-10 sm:pb-[calc(var(--demo-chrome-reserve,5rem)+2.5rem)] lg:px-14 lg:pt-14 lg:pb-[calc(var(--demo-chrome-reserve,5rem)+3.5rem)]";
 
-function ProofStack({
+/** Stack peek is 10% of print height — at 4:5 that is an 8:1 strip */
+const STACK_PEEK = "aspect-[8/1]";
+
+function PrintStack() {
+  return (
+    <CardStack.Frame className="absolute inset-0 overflow-visible">
+      <CardStack.LiveRegion />
+      <CardStack.Trigger aria-label="Show next photo" className="absolute inset-0 block text-left">
+        <CardStack.Viewport className="size-full overflow-visible !min-h-0 !pt-0">
+          <CardStack.List>
+            {(item, index, layer) => (
+              <CardStack.Card
+                key={item.id}
+                layer={layer}
+                stackIndex={index}
+                className="!inset-x-0 !top-0 !h-fit !w-full gap-0 overflow-visible rounded-none !bg-transparent p-0 shadow-none ring-0"
+              >
+                <figure className="relative aspect-[4/5] size-full overflow-hidden bg-black/5">
+                  <img
+                    src={item.image}
+                    alt={\`\${PHOTOGRAPHER.studio} — \${item.title}\`}
+                    width={PRINT_WIDTH}
+                    height={PRINT_HEIGHT}
+                    decoding="async"
+                    draggable={false}
+                    className="size-full object-cover object-center"
+                  />
+                  {index === 0 ? <ViewfinderFrame /> : null}
+                </figure>
+              </CardStack.Card>
+            )}
+          </CardStack.List>
+        </CardStack.Viewport>
+      </CardStack.Trigger>
+    </CardStack.Frame>
+  );
+}
+
+function PrintProof({
   stackRef,
   captionRef,
 }: {
@@ -2824,46 +2852,25 @@ function ProofStack({
   captionRef: RefObject<HTMLDivElement | null>;
 }) {
   return (
-    <figure
-      ref={stackRef}
-      className="ml-auto grid h-full min-h-0 w-full min-w-0 max-w-full grid-rows-[auto_minmax(0,1fr)] gap-y-3 sm:gap-y-4"
-    >
-      <div ref={captionRef} className="relative z-30 w-full shrink-0 bg-transparent">
+    <figure ref={stackRef} className="flex w-full min-w-0 flex-col">
+      <div
+        ref={captionRef}
+        className="relative z-30 w-full shrink-0"
+        style={{ backgroundColor: CANVAS }}
+      >
         <PrintCaption />
       </div>
-      <div className="@container/stack relative flex min-h-0 flex-1 items-end justify-end pt-[max(2.5rem,11%)]">
-        <CardStack.Frame className="relative aspect-[4/5] h-auto w-[min(100cqw,calc(100cqh*4/5))] max-h-full min-h-0 shrink-0 overflow-visible">
-          <CardStack.LiveRegion />
-          <CardStack.Trigger aria-label="Show next photo" className="block size-full text-left">
-            <CardStack.Viewport className="relative size-full overflow-visible !min-h-0 !pt-0">
-            <CardStack.List>
-              {(item, index, layer) => (
-                <CardStack.Card
-                  key={item.id}
-                  layer={layer}
-                  stackIndex={index}
-                  className="size-full gap-0 overflow-visible rounded-none bg-transparent p-0 shadow-none ring-0 [background-image:none]"
-                >
-                  <figure className="flex size-full flex-col border-0 bg-transparent p-0">
-                    <div className="relative min-h-0 w-full flex-1 overflow-hidden bg-black/5">
-                      <img
-                        src={item.image}
-                        alt={\`\${PHOTOGRAPHER.studio} — \${item.title}\`}
-                        width={PRINT_WIDTH}
-                        height={PRINT_HEIGHT}
-                        decoding="async"
-                        draggable={false}
-                        className="absolute inset-0 size-full object-cover object-center"
-                      />
-                      {index === 0 ? <ViewfinderFrame /> : null}
-                    </div>
-                  </figure>
-                </CardStack.Card>
-              )}
-            </CardStack.List>
-          </CardStack.Viewport>
-        </CardStack.Trigger>
-      </CardStack.Frame>
+
+      <div
+        className={cn(
+          "flex w-full flex-col",
+          "md:ml-auto md:w-[min(100cqw,calc((100cqh-4.5rem)*8/11))]",
+        )}
+      >
+        <div aria-hidden="true" className={cn("w-full shrink-0", STACK_PEEK)} />
+        <div className="relative aspect-[4/5] w-full shrink-0 overflow-visible">
+          <PrintStack />
+        </div>
       </div>
     </figure>
   );
@@ -2880,22 +2887,17 @@ function PortfolioLayout({
 }) {
   return (
     <div
-      className={cn(
-        "grid h-[calc(100svh-var(--demo-chrome-reserve,5rem))] min-h-0 grid-cols-1 grid-rows-[auto_minmax(18rem,1fr)]",
-        "md:grid-cols-[minmax(0,2fr)_minmax(0,3fr)] md:grid-rows-1",
-        LAYOUT.grid,
-        LAYOUT.blockY,
-      )}
-      style={{ "--layout-baseline": \`\${BASELINE}px\` } as CSSProperties}
+      className={cn("flex flex-col gap-8", "md:h-full md:min-h-0 md:flex-1 md:flex-row md:gap-6")}
     >
-      <div className="flex min-h-0 flex-col justify-end md:col-start-1 md:row-start-1 md:pt-[clamp(3rem,11vh,8rem)]">
-        <div ref={heroRef} className="relative z-20 w-fit max-w-full bg-transparent">
-          <HeroStory />
-        </div>
+      <div
+        ref={heroRef}
+        className="relative z-20 min-w-0 md:flex md:flex-[2] md:basis-0 md:flex-col md:justify-end"
+      >
+        <HeroStory />
       </div>
 
-      <div className="relative z-20 flex min-h-0 min-w-0 flex-col overflow-visible md:col-start-2 md:row-start-1 md:h-full md:pl-6 md:pt-[clamp(3rem,11vh,8rem)] lg:pl-10">
-        <ProofStack stackRef={stackRef} captionRef={captionRef} />
+      <div className="w-full min-w-0 md:flex md:min-h-0 md:flex-[3] md:basis-0 md:flex-col md:justify-end md:@container/print md:[container-type:size]">
+        <PrintProof stackRef={stackRef} captionRef={captionRef} />
       </div>
     </div>
   );
@@ -2910,7 +2912,7 @@ export default function PhotographerPortfolio() {
   return (
     <>
       <section
-        className="relative isolate min-h-[calc(100svh-var(--demo-chrome-reserve,5rem))] overflow-hidden"
+        className="relative isolate min-h-svh overflow-x-hidden overflow-y-auto md:h-svh md:overflow-hidden"
         style={{ backgroundColor: CANVAS, color: INK, fontFamily: FONT }}
       >
         <TrailingImage
@@ -2924,16 +2926,11 @@ export default function PhotographerPortfolio() {
           excludeRefs={[heroRef, captionRef]}
         />
 
-        <CardStack
-          items={PORTFOLIO}
-          depth={3}
-          autoplay={preloaderDone}
-          autoplayInterval={4500}
-        >
+        <CardStack items={PORTFOLIO} depth={3} autoplay={preloaderDone} autoplayInterval={4500}>
           <div
             className={cn(
-              "relative z-20 isolate mx-auto min-h-[calc(100svh-var(--demo-chrome-reserve,5rem))] w-full max-w-[92rem] pb-[var(--demo-chrome-reserve,5rem)]",
-              LAYOUT.shell,
+              "relative z-20 isolate mx-auto flex w-full max-w-[92rem] flex-col md:h-full md:min-h-0 md:flex-1",
+              SHELL,
             )}
           >
             <PortfolioLayout stackRef={stackRef} heroRef={heroRef} captionRef={captionRef} />
@@ -2970,7 +2967,7 @@ export default function PhotographerPortfolio() {
       htmlLight: `<pre class="shiki github-light" tabindex="0"><code><span class="line"><span style="color:#032F62">"use client"</span><span style="color:#24292E">;</span></span>
 <span class="line"></span>
 <span class="line"><span style="color:#D73A49">import</span><span style="color:#032F62"> "@fontsource-variable/instrument-sans"</span><span style="color:#24292E">;</span></span>
-<span class="line"><span style="color:#D73A49">import</span><span style="color:#24292E"> { useRef, useState, </span><span style="color:#D73A49">type</span><span style="color:#24292E"> CSSProperties, </span><span style="color:#D73A49">type</span><span style="color:#24292E"> ReactNode, </span><span style="color:#D73A49">type</span><span style="color:#24292E"> RefObject } </span><span style="color:#D73A49">from</span><span style="color:#032F62"> "react"</span><span style="color:#24292E">;</span></span>
+<span class="line"><span style="color:#D73A49">import</span><span style="color:#24292E"> { </span><span style="color:#D73A49">type</span><span style="color:#24292E"> CSSProperties, </span><span style="color:#D73A49">type</span><span style="color:#24292E"> ReactNode, </span><span style="color:#D73A49">type</span><span style="color:#24292E"> RefObject, useRef, useState } </span><span style="color:#D73A49">from</span><span style="color:#032F62"> "react"</span><span style="color:#24292E">;</span></span>
 <span class="line"></span>
 <span class="line"><span style="color:#D73A49">import</span><span style="color:#24292E"> CardStack, {</span></span>
 <span class="line"><span style="color:#24292E">  CARD_STACK_MASK_IDS,</span></span>
@@ -2985,8 +2982,7 @@ export default function PhotographerPortfolio() {
 <span class="line"></span>
 <span class="line"><span style="color:#D73A49">import</span><span style="color:#24292E"> { PhotographerPortfolioNotes } </span><span style="color:#D73A49">from</span><span style="color:#032F62"> "./photographer-portfolio-notes"</span><span style="color:#24292E">;</span></span>
 <span class="line"></span>
-<span class="line"><span style="color:#D73A49">const</span><span style="color:#005CC5"> FONT</span><span style="color:#D73A49"> =</span></span>
-<span class="line"><span style="color:#032F62">  '"Instrument Sans Variable", ui-sans-serif, system-ui, sans-serif'</span><span style="color:#24292E">;</span></span>
+<span class="line"><span style="color:#D73A49">const</span><span style="color:#005CC5"> FONT</span><span style="color:#D73A49"> =</span><span style="color:#032F62"> '"Instrument Sans Variable", ui-sans-serif, system-ui, sans-serif'</span><span style="color:#24292E">;</span></span>
 <span class="line"></span>
 <span class="line"><span style="color:#D73A49">const</span><span style="color:#005CC5"> CANVAS</span><span style="color:#D73A49"> =</span><span style="color:#032F62"> "#fff"</span><span style="color:#24292E">;</span></span>
 <span class="line"><span style="color:#D73A49">const</span><span style="color:#005CC5"> INK</span><span style="color:#D73A49"> =</span><span style="color:#032F62"> "#000"</span><span style="color:#24292E">;</span></span>
@@ -3045,7 +3041,6 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#D73A49">const</span><span style="color:#005CC5"> HERO_TONE</span><span style="color:#D73A49"> =</span><span style="color:#24292E"> {</span></span>
 <span class="line"><span style="color:#24292E">  mute: </span><span style="color:#032F62">"text-black/40"</span><span style="color:#24292E">,</span></span>
 <span class="line"><span style="color:#24292E">  ink: </span><span style="color:#032F62">"text-black"</span><span style="color:#24292E">,</span></span>
-<span class="line"><span style="color:#24292E">  accent: </span><span style="color:#032F62">"text-[#c2410c]"</span><span style="color:#24292E">,</span></span>
 <span class="line"><span style="color:#24292E">} </span><span style="color:#D73A49">as</span><span style="color:#D73A49"> const</span><span style="color:#24292E">;</span></span>
 <span class="line"></span>
 <span class="line"><span style="color:#D73A49">const</span><span style="color:#005CC5"> PORTFOLIO</span><span style="color:#D73A49">:</span><span style="color:#6F42C1"> CardStackItem</span><span style="color:#24292E">[] </span><span style="color:#D73A49">=</span><span style="color:#24292E"> [</span></span>
@@ -3100,11 +3095,7 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#24292E">];</span></span>
 <span class="line"></span>
 <span class="line"><span style="color:#D73A49">const</span><span style="color:#005CC5"> PRELOAD_IMAGES</span><span style="color:#D73A49"> =</span><span style="color:#24292E"> [</span></span>
-<span class="line"><span style="color:#D73A49">  ...new</span><span style="color:#6F42C1"> Set</span><span style="color:#24292E">([</span></span>
-<span class="line"><span style="color:#005CC5">    PHOTOGRAPHER</span><span style="color:#24292E">.avatar,</span></span>
-<span class="line"><span style="color:#D73A49">    ...</span><span style="color:#005CC5">PORTFOLIO</span><span style="color:#24292E">.</span><span style="color:#6F42C1">map</span><span style="color:#24292E">((</span><span style="color:#E36209">item</span><span style="color:#24292E">) </span><span style="color:#D73A49">=></span><span style="color:#24292E"> item.image),</span></span>
-<span class="line"><span style="color:#D73A49">    ...</span><span style="color:#005CC5">TRAIL_IMAGES</span><span style="color:#24292E">,</span></span>
-<span class="line"><span style="color:#24292E">  ]),</span></span>
+<span class="line"><span style="color:#D73A49">  ...new</span><span style="color:#6F42C1"> Set</span><span style="color:#24292E">([</span><span style="color:#005CC5">PHOTOGRAPHER</span><span style="color:#24292E">.avatar, </span><span style="color:#D73A49">...</span><span style="color:#005CC5">PORTFOLIO</span><span style="color:#24292E">.</span><span style="color:#6F42C1">map</span><span style="color:#24292E">((</span><span style="color:#E36209">item</span><span style="color:#24292E">) </span><span style="color:#D73A49">=></span><span style="color:#24292E"> item.image), </span><span style="color:#D73A49">...</span><span style="color:#005CC5">TRAIL_IMAGES</span><span style="color:#24292E">]),</span></span>
 <span class="line"><span style="color:#24292E">];</span></span>
 <span class="line"></span>
 <span class="line"><span style="color:#D73A49">const</span><span style="color:#005CC5"> HERO_MARK</span><span style="color:#D73A49"> =</span></span>
@@ -3112,9 +3103,9 @@ export default function PhotographerPortfolio() {
 <span class="line"></span>
 <span class="line"><span style="color:#D73A49">function</span><span style="color:#6F42C1"> HeroMark</span><span style="color:#24292E">({ </span><span style="color:#E36209">children</span><span style="color:#24292E">, </span><span style="color:#E36209">className</span><span style="color:#24292E"> }</span><span style="color:#D73A49">:</span><span style="color:#24292E"> { </span><span style="color:#E36209">children</span><span style="color:#D73A49">:</span><span style="color:#6F42C1"> ReactNode</span><span style="color:#24292E">; </span><span style="color:#E36209">className</span><span style="color:#D73A49">?:</span><span style="color:#005CC5"> string</span><span style="color:#24292E"> }) {</span></span>
 <span class="line"><span style="color:#D73A49">  return</span><span style="color:#24292E"> (</span></span>
-<span class="line"><span style="color:#24292E">    &#x3C;</span><span style="color:#22863A">span</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#6F42C1">cn</span><span style="color:#24292E">(</span><span style="color:#005CC5">HERO_MARK</span><span style="color:#24292E">, className)} </span><span style="color:#6F42C1">aria-hidden</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">    &#x3C;</span><span style="color:#22863A">div</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#6F42C1">cn</span><span style="color:#24292E">(</span><span style="color:#005CC5">HERO_MARK</span><span style="color:#24292E">, className)} </span><span style="color:#6F42C1">aria-hidden</span><span style="color:#24292E">></span></span>
 <span class="line"><span style="color:#24292E">      {children}</span></span>
-<span class="line"><span style="color:#24292E">    &#x3C;/</span><span style="color:#22863A">span</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">    &#x3C;/</span><span style="color:#22863A">div</span><span style="color:#24292E">></span></span>
 <span class="line"><span style="color:#24292E">  );</span></span>
 <span class="line"><span style="color:#24292E">}</span></span>
 <span class="line"></span>
@@ -3127,12 +3118,11 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#24292E">}</span></span>
 <span class="line"></span>
 <span class="line"><span style="color:#D73A49">function</span><span style="color:#6F42C1"> HeroStory</span><span style="color:#24292E">() {</span></span>
-<span class="line"><span style="color:#D73A49">  const</span><span style="color:#005CC5"> type</span><span style="color:#D73A49"> =</span></span>
-<span class="line"><span style="color:#032F62">    "text-[clamp(1.25rem,2vw,1.75rem)] font-medium leading-[1.55] tracking-[-0.02em]"</span><span style="color:#24292E">;</span></span>
+<span class="line"><span style="color:#D73A49">  const</span><span style="color:#005CC5"> type</span><span style="color:#D73A49"> =</span><span style="color:#032F62"> "text-[clamp(1.25rem,2vw,1.75rem)] font-medium leading-[1.55] tracking-[-0.02em]"</span><span style="color:#24292E">;</span></span>
 <span class="line"></span>
 <span class="line"><span style="color:#D73A49">  return</span><span style="color:#24292E"> (</span></span>
-<span class="line"><span style="color:#24292E">    &#x3C;</span><span style="color:#22863A">div</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"max-w-[min(100%,36rem)] space-y-6"</span><span style="color:#24292E">></span></span>
-<span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#22863A">p</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{type}></span></span>
+<span class="line"><span style="color:#24292E">    &#x3C;</span><span style="color:#22863A">div</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"flex flex-col gap-[1.15em]"</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#22863A">div</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{type}></span></span>
 <span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">span</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">HERO_TONE</span><span style="color:#24292E">.mute}>Hi, I'm &#x3C;/</span><span style="color:#22863A">span</span><span style="color:#24292E">></span></span>
 <span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">span</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">HERO_TONE</span><span style="color:#24292E">.ink}>{</span><span style="color:#005CC5">PHOTOGRAPHER</span><span style="color:#24292E">.name}&#x3C;/</span><span style="color:#22863A">span</span><span style="color:#24292E">></span></span>
 <span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#005CC5">ProfileGlyph</span><span style="color:#6F42C1"> src</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">PHOTOGRAPHER</span><span style="color:#24292E">.avatar} </span><span style="color:#6F42C1">alt</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">PHOTOGRAPHER</span><span style="color:#24292E">.studio} /></span></span>
@@ -3148,15 +3138,11 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#24292E">        &#x3C;/</span><span style="color:#005CC5">HeroMark</span><span style="color:#24292E">></span></span>
 <span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">span</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">HERO_TONE</span><span style="color:#24292E">.mute}> &#x3C;/</span><span style="color:#22863A">span</span><span style="color:#24292E">></span></span>
 <span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">span</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">HERO_TONE</span><span style="color:#24292E">.ink}>{</span><span style="color:#005CC5">PHOTOGRAPHER</span><span style="color:#24292E">.location}&#x3C;/</span><span style="color:#22863A">span</span><span style="color:#24292E">></span></span>
-<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">span</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">HERO_TONE</span><span style="color:#24292E">.mute}></span></span>
-<span class="line"><span style="color:#24292E">          {</span><span style="color:#032F62">" "</span><span style="color:#24292E">}</span></span>
-<span class="line"><span style="color:#24292E">          — good light, real moments, and photos that don't feel forced.</span></span>
-<span class="line"><span style="color:#24292E">        &#x3C;/</span><span style="color:#22863A">span</span><span style="color:#24292E">></span></span>
-<span class="line"><span style="color:#24292E">      &#x3C;/</span><span style="color:#22863A">p</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">span</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">HERO_TONE</span><span style="color:#24292E">.mute}> and capture photos you hang on the wall.&#x3C;/</span><span style="color:#22863A">span</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">      &#x3C;/</span><span style="color:#22863A">div</span><span style="color:#24292E">></span></span>
 <span class="line"></span>
-<span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#22863A">p</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{type}></span></span>
-<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">span</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">HERO_TONE</span><span style="color:#24292E">.accent}>Booking Q3.&#x3C;/</span><span style="color:#22863A">span</span><span style="color:#24292E">></span></span>
-<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">span</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">HERO_TONE</span><span style="color:#24292E">.mute}> &#x3C;/</span><span style="color:#22863A">span</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#22863A">p</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{type} </span><span style="color:#6F42C1">style</span><span style="color:#D73A49">=</span><span style="color:#24292E">{{ textBoxTrim: </span><span style="color:#032F62">"trim-both"</span><span style="color:#24292E"> } </span><span style="color:#D73A49">as</span><span style="color:#6F42C1"> CSSProperties</span><span style="color:#24292E">}></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">span</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">HERO_TONE</span><span style="color:#24292E">.mute}>Booking Q3. &#x3C;/</span><span style="color:#22863A">span</span><span style="color:#24292E">></span></span>
 <span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">a</span></span>
 <span class="line"><span style="color:#6F42C1">          href</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">PHOTOGRAPHER</span><span style="color:#24292E">.email}</span></span>
 <span class="line"><span style="color:#6F42C1">          className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#6F42C1">cn</span><span style="color:#24292E">(</span><span style="color:#005CC5">HERO_TONE</span><span style="color:#24292E">.ink, </span><span style="color:#032F62">"underline-offset-[4px] hover:underline"</span><span style="color:#24292E">)}</span></span>
@@ -3194,9 +3180,14 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#24292E">  }</span></span>
 <span class="line"></span>
 <span class="line"><span style="color:#D73A49">  return</span><span style="color:#24292E"> (</span></span>
-<span class="line"><span style="color:#24292E">    &#x3C;</span><span style="color:#22863A">figcaption</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"relative z-10 shrink-0 border-b border-black/80 bg-transparent pb-3"</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">    &#x3C;</span><span style="color:#22863A">figcaption</span></span>
+<span class="line"><span style="color:#6F42C1">      className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"relative z-10 shrink-0 border-b border-black/80 pb-3"</span></span>
+<span class="line"><span style="color:#6F42C1">      style</span><span style="color:#D73A49">=</span><span style="color:#24292E">{{ backgroundColor: </span><span style="color:#005CC5">CANVAS</span><span style="color:#24292E"> }}</span></span>
+<span class="line"><span style="color:#24292E">    ></span></span>
 <span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#22863A">div</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"flex items-baseline justify-between gap-4"</span><span style="color:#24292E">></span></span>
-<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">p</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"text-[11px] font-medium uppercase tracking-[0.1em] text-black"</span><span style="color:#24292E">>{activeItem.title}&#x3C;/</span><span style="color:#22863A">p</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">p</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"text-[11px] font-medium uppercase tracking-[0.1em] text-black"</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">          {activeItem.title}</span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;/</span><span style="color:#22863A">p</span><span style="color:#24292E">></span></span>
 <span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">p</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"shrink-0 text-[11px] font-medium tabular-nums tracking-[0.1em] text-black/45"</span><span style="color:#24292E">></span></span>
 <span class="line"><span style="color:#24292E">          {</span><span style="color:#6F42C1">String</span><span style="color:#24292E">(index).</span><span style="color:#6F42C1">padStart</span><span style="color:#24292E">(</span><span style="color:#005CC5">2</span><span style="color:#24292E">, </span><span style="color:#032F62">"0"</span><span style="color:#24292E">)}</span></span>
 <span class="line"><span style="color:#24292E">          &#x3C;</span><span style="color:#22863A">span</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"text-black/20"</span><span style="color:#24292E">>/&#x3C;/</span><span style="color:#22863A">span</span><span style="color:#24292E">></span></span>
@@ -3214,14 +3205,48 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#24292E">  );</span></span>
 <span class="line"><span style="color:#24292E">}</span></span>
 <span class="line"></span>
-<span class="line"><span style="color:#D73A49">const</span><span style="color:#005CC5"> BASELINE</span><span style="color:#D73A49"> =</span><span style="color:#005CC5"> 8</span><span style="color:#24292E">;</span></span>
-<span class="line"><span style="color:#D73A49">const</span><span style="color:#005CC5"> LAYOUT</span><span style="color:#D73A49"> =</span><span style="color:#24292E"> {</span></span>
-<span class="line"><span style="color:#24292E">  shell: </span><span style="color:#032F62">"px-6 sm:px-10 lg:px-14"</span><span style="color:#24292E">,</span></span>
-<span class="line"><span style="color:#24292E">  blockY: </span><span style="color:#032F62">"py-8 lg:py-10"</span><span style="color:#24292E">,</span></span>
-<span class="line"><span style="color:#24292E">  grid: </span><span style="color:#032F62">"gap-x-8 gap-y-8 lg:gap-x-10 lg:gap-y-10"</span><span style="color:#24292E">,</span></span>
-<span class="line"><span style="color:#24292E">} </span><span style="color:#D73A49">as</span><span style="color:#D73A49"> const</span><span style="color:#24292E">;</span></span>
+<span class="line"><span style="color:#D73A49">const</span><span style="color:#005CC5"> SHELL</span><span style="color:#D73A49"> =</span></span>
+<span class="line"><span style="color:#032F62">  "px-6 pt-6 pb-[calc(var(--demo-chrome-reserve,5rem)+1.5rem)] sm:px-10 sm:pt-10 sm:pb-[calc(var(--demo-chrome-reserve,5rem)+2.5rem)] lg:px-14 lg:pt-14 lg:pb-[calc(var(--demo-chrome-reserve,5rem)+3.5rem)]"</span><span style="color:#24292E">;</span></span>
 <span class="line"></span>
-<span class="line"><span style="color:#D73A49">function</span><span style="color:#6F42C1"> ProofStack</span><span style="color:#24292E">({</span></span>
+<span class="line"><span style="color:#6A737D">/** Stack peek is 10% of print height — at 4:5 that is an 8:1 strip */</span></span>
+<span class="line"><span style="color:#D73A49">const</span><span style="color:#005CC5"> STACK_PEEK</span><span style="color:#D73A49"> =</span><span style="color:#032F62"> "aspect-[8/1]"</span><span style="color:#24292E">;</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#D73A49">function</span><span style="color:#6F42C1"> PrintStack</span><span style="color:#24292E">() {</span></span>
+<span class="line"><span style="color:#D73A49">  return</span><span style="color:#24292E"> (</span></span>
+<span class="line"><span style="color:#24292E">    &#x3C;</span><span style="color:#005CC5">CardStack.Frame</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"absolute inset-0 overflow-visible"</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#005CC5">CardStack.LiveRegion</span><span style="color:#24292E"> /></span></span>
+<span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#005CC5">CardStack.Trigger</span><span style="color:#6F42C1"> aria-label</span><span style="color:#D73A49">=</span><span style="color:#032F62">"Show next photo"</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"absolute inset-0 block text-left"</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#005CC5">CardStack.Viewport</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"size-full overflow-visible !min-h-0 !pt-0"</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">          &#x3C;</span><span style="color:#005CC5">CardStack.List</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">            {(</span><span style="color:#E36209">item</span><span style="color:#24292E">, </span><span style="color:#E36209">index</span><span style="color:#24292E">, </span><span style="color:#E36209">layer</span><span style="color:#24292E">) </span><span style="color:#D73A49">=></span><span style="color:#24292E"> (</span></span>
+<span class="line"><span style="color:#24292E">              &#x3C;</span><span style="color:#005CC5">CardStack.Card</span></span>
+<span class="line"><span style="color:#6F42C1">                key</span><span style="color:#D73A49">=</span><span style="color:#24292E">{item.id}</span></span>
+<span class="line"><span style="color:#6F42C1">                layer</span><span style="color:#D73A49">=</span><span style="color:#24292E">{layer}</span></span>
+<span class="line"><span style="color:#6F42C1">                stackIndex</span><span style="color:#D73A49">=</span><span style="color:#24292E">{index}</span></span>
+<span class="line"><span style="color:#6F42C1">                className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"!inset-x-0 !top-0 !h-fit !w-full gap-0 overflow-visible rounded-none !bg-transparent p-0 shadow-none ring-0"</span></span>
+<span class="line"><span style="color:#24292E">              ></span></span>
+<span class="line"><span style="color:#24292E">                &#x3C;</span><span style="color:#22863A">figure</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"relative aspect-[4/5] size-full overflow-hidden bg-black/5"</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">                  &#x3C;</span><span style="color:#22863A">img</span></span>
+<span class="line"><span style="color:#6F42C1">                    src</span><span style="color:#D73A49">=</span><span style="color:#24292E">{item.image}</span></span>
+<span class="line"><span style="color:#6F42C1">                    alt</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#032F62">\`\${</span><span style="color:#005CC5">PHOTOGRAPHER</span><span style="color:#032F62">.</span><span style="color:#24292E">studio</span><span style="color:#032F62">} — \${</span><span style="color:#24292E">item</span><span style="color:#032F62">.</span><span style="color:#24292E">title</span><span style="color:#032F62">}\`</span><span style="color:#24292E">}</span></span>
+<span class="line"><span style="color:#6F42C1">                    width</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">PRINT_WIDTH</span><span style="color:#24292E">}</span></span>
+<span class="line"><span style="color:#6F42C1">                    height</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">PRINT_HEIGHT</span><span style="color:#24292E">}</span></span>
+<span class="line"><span style="color:#6F42C1">                    decoding</span><span style="color:#D73A49">=</span><span style="color:#032F62">"async"</span></span>
+<span class="line"><span style="color:#6F42C1">                    draggable</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">false</span><span style="color:#24292E">}</span></span>
+<span class="line"><span style="color:#6F42C1">                    className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"size-full object-cover object-center"</span></span>
+<span class="line"><span style="color:#24292E">                  /></span></span>
+<span class="line"><span style="color:#24292E">                  {index </span><span style="color:#D73A49">===</span><span style="color:#005CC5"> 0</span><span style="color:#D73A49"> ?</span><span style="color:#24292E"> &#x3C;</span><span style="color:#005CC5">ViewfinderFrame</span><span style="color:#24292E"> /> </span><span style="color:#D73A49">:</span><span style="color:#005CC5"> null</span><span style="color:#24292E">}</span></span>
+<span class="line"><span style="color:#24292E">                &#x3C;/</span><span style="color:#22863A">figure</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">              &#x3C;/</span><span style="color:#005CC5">CardStack.Card</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">            )}</span></span>
+<span class="line"><span style="color:#24292E">          &#x3C;/</span><span style="color:#005CC5">CardStack.List</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;/</span><span style="color:#005CC5">CardStack.Viewport</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">      &#x3C;/</span><span style="color:#005CC5">CardStack.Trigger</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">    &#x3C;/</span><span style="color:#005CC5">CardStack.Frame</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">  );</span></span>
+<span class="line"><span style="color:#24292E">}</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#D73A49">function</span><span style="color:#6F42C1"> PrintProof</span><span style="color:#24292E">({</span></span>
 <span class="line"><span style="color:#E36209">  stackRef</span><span style="color:#24292E">,</span></span>
 <span class="line"><span style="color:#E36209">  captionRef</span><span style="color:#24292E">,</span></span>
 <span class="line"><span style="color:#24292E">}</span><span style="color:#D73A49">:</span><span style="color:#24292E"> {</span></span>
@@ -3229,46 +3254,25 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#E36209">  captionRef</span><span style="color:#D73A49">:</span><span style="color:#6F42C1"> RefObject</span><span style="color:#24292E">&#x3C;</span><span style="color:#6F42C1">HTMLDivElement</span><span style="color:#D73A49"> |</span><span style="color:#005CC5"> null</span><span style="color:#24292E">>;</span></span>
 <span class="line"><span style="color:#24292E">}) {</span></span>
 <span class="line"><span style="color:#D73A49">  return</span><span style="color:#24292E"> (</span></span>
-<span class="line"><span style="color:#24292E">    &#x3C;</span><span style="color:#22863A">figure</span></span>
-<span class="line"><span style="color:#6F42C1">      ref</span><span style="color:#D73A49">=</span><span style="color:#24292E">{stackRef}</span></span>
-<span class="line"><span style="color:#6F42C1">      className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"ml-auto grid h-full min-h-0 w-full min-w-0 max-w-full grid-rows-[auto_minmax(0,1fr)] gap-y-3 sm:gap-y-4"</span></span>
-<span class="line"><span style="color:#24292E">    ></span></span>
-<span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#22863A">div</span><span style="color:#6F42C1"> ref</span><span style="color:#D73A49">=</span><span style="color:#24292E">{captionRef} </span><span style="color:#6F42C1">className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"relative z-30 w-full shrink-0 bg-transparent"</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">    &#x3C;</span><span style="color:#22863A">figure</span><span style="color:#6F42C1"> ref</span><span style="color:#D73A49">=</span><span style="color:#24292E">{stackRef} </span><span style="color:#6F42C1">className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"flex w-full min-w-0 flex-col"</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#22863A">div</span></span>
+<span class="line"><span style="color:#6F42C1">        ref</span><span style="color:#D73A49">=</span><span style="color:#24292E">{captionRef}</span></span>
+<span class="line"><span style="color:#6F42C1">        className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"relative z-30 w-full shrink-0"</span></span>
+<span class="line"><span style="color:#6F42C1">        style</span><span style="color:#D73A49">=</span><span style="color:#24292E">{{ backgroundColor: </span><span style="color:#005CC5">CANVAS</span><span style="color:#24292E"> }}</span></span>
+<span class="line"><span style="color:#24292E">      ></span></span>
 <span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#005CC5">PrintCaption</span><span style="color:#24292E"> /></span></span>
 <span class="line"><span style="color:#24292E">      &#x3C;/</span><span style="color:#22863A">div</span><span style="color:#24292E">></span></span>
-<span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#22863A">div</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"@container/stack relative flex min-h-0 flex-1 items-end justify-end pt-[max(2.5rem,11%)]"</span><span style="color:#24292E">></span></span>
-<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#005CC5">CardStack.Frame</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"relative aspect-[4/5] h-auto w-[min(100cqw,calc(100cqh*4/5))] max-h-full min-h-0 shrink-0 overflow-visible"</span><span style="color:#24292E">></span></span>
-<span class="line"><span style="color:#24292E">          &#x3C;</span><span style="color:#005CC5">CardStack.LiveRegion</span><span style="color:#24292E"> /></span></span>
-<span class="line"><span style="color:#24292E">          &#x3C;</span><span style="color:#005CC5">CardStack.Trigger</span><span style="color:#6F42C1"> aria-label</span><span style="color:#D73A49">=</span><span style="color:#032F62">"Show next photo"</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"block size-full text-left"</span><span style="color:#24292E">></span></span>
-<span class="line"><span style="color:#24292E">            &#x3C;</span><span style="color:#005CC5">CardStack.Viewport</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"relative size-full overflow-visible !min-h-0 !pt-0"</span><span style="color:#24292E">></span></span>
-<span class="line"><span style="color:#24292E">            &#x3C;</span><span style="color:#005CC5">CardStack.List</span><span style="color:#24292E">></span></span>
-<span class="line"><span style="color:#24292E">              {(</span><span style="color:#E36209">item</span><span style="color:#24292E">, </span><span style="color:#E36209">index</span><span style="color:#24292E">, </span><span style="color:#E36209">layer</span><span style="color:#24292E">) </span><span style="color:#D73A49">=></span><span style="color:#24292E"> (</span></span>
-<span class="line"><span style="color:#24292E">                &#x3C;</span><span style="color:#005CC5">CardStack.Card</span></span>
-<span class="line"><span style="color:#6F42C1">                  key</span><span style="color:#D73A49">=</span><span style="color:#24292E">{item.id}</span></span>
-<span class="line"><span style="color:#6F42C1">                  layer</span><span style="color:#D73A49">=</span><span style="color:#24292E">{layer}</span></span>
-<span class="line"><span style="color:#6F42C1">                  stackIndex</span><span style="color:#D73A49">=</span><span style="color:#24292E">{index}</span></span>
-<span class="line"><span style="color:#6F42C1">                  className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"size-full gap-0 overflow-visible rounded-none bg-transparent p-0 shadow-none ring-0 [background-image:none]"</span></span>
-<span class="line"><span style="color:#24292E">                ></span></span>
-<span class="line"><span style="color:#24292E">                  &#x3C;</span><span style="color:#22863A">figure</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"flex size-full flex-col border-0 bg-transparent p-0"</span><span style="color:#24292E">></span></span>
-<span class="line"><span style="color:#24292E">                    &#x3C;</span><span style="color:#22863A">div</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"relative min-h-0 w-full flex-1 overflow-hidden bg-black/5"</span><span style="color:#24292E">></span></span>
-<span class="line"><span style="color:#24292E">                      &#x3C;</span><span style="color:#22863A">img</span></span>
-<span class="line"><span style="color:#6F42C1">                        src</span><span style="color:#D73A49">=</span><span style="color:#24292E">{item.image}</span></span>
-<span class="line"><span style="color:#6F42C1">                        alt</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#032F62">\`\${</span><span style="color:#005CC5">PHOTOGRAPHER</span><span style="color:#032F62">.</span><span style="color:#24292E">studio</span><span style="color:#032F62">} — \${</span><span style="color:#24292E">item</span><span style="color:#032F62">.</span><span style="color:#24292E">title</span><span style="color:#032F62">}\`</span><span style="color:#24292E">}</span></span>
-<span class="line"><span style="color:#6F42C1">                        width</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">PRINT_WIDTH</span><span style="color:#24292E">}</span></span>
-<span class="line"><span style="color:#6F42C1">                        height</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">PRINT_HEIGHT</span><span style="color:#24292E">}</span></span>
-<span class="line"><span style="color:#6F42C1">                        decoding</span><span style="color:#D73A49">=</span><span style="color:#032F62">"async"</span></span>
-<span class="line"><span style="color:#6F42C1">                        draggable</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">false</span><span style="color:#24292E">}</span></span>
-<span class="line"><span style="color:#6F42C1">                        className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"absolute inset-0 size-full object-cover object-center"</span></span>
-<span class="line"><span style="color:#24292E">                      /></span></span>
-<span class="line"><span style="color:#24292E">                      {index </span><span style="color:#D73A49">===</span><span style="color:#005CC5"> 0</span><span style="color:#D73A49"> ?</span><span style="color:#24292E"> &#x3C;</span><span style="color:#005CC5">ViewfinderFrame</span><span style="color:#24292E"> /> </span><span style="color:#D73A49">:</span><span style="color:#005CC5"> null</span><span style="color:#24292E">}</span></span>
-<span class="line"><span style="color:#24292E">                    &#x3C;/</span><span style="color:#22863A">div</span><span style="color:#24292E">></span></span>
-<span class="line"><span style="color:#24292E">                  &#x3C;/</span><span style="color:#22863A">figure</span><span style="color:#24292E">></span></span>
-<span class="line"><span style="color:#24292E">                &#x3C;/</span><span style="color:#005CC5">CardStack.Card</span><span style="color:#24292E">></span></span>
-<span class="line"><span style="color:#24292E">              )}</span></span>
-<span class="line"><span style="color:#24292E">            &#x3C;/</span><span style="color:#005CC5">CardStack.List</span><span style="color:#24292E">></span></span>
-<span class="line"><span style="color:#24292E">          &#x3C;/</span><span style="color:#005CC5">CardStack.Viewport</span><span style="color:#24292E">></span></span>
-<span class="line"><span style="color:#24292E">        &#x3C;/</span><span style="color:#005CC5">CardStack.Trigger</span><span style="color:#24292E">></span></span>
-<span class="line"><span style="color:#24292E">      &#x3C;/</span><span style="color:#005CC5">CardStack.Frame</span><span style="color:#24292E">></span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#22863A">div</span></span>
+<span class="line"><span style="color:#6F42C1">        className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#6F42C1">cn</span><span style="color:#24292E">(</span></span>
+<span class="line"><span style="color:#032F62">          "flex w-full flex-col"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#032F62">          "md:ml-auto md:w-[min(100cqw,calc((100cqh-4.5rem)*8/11))]"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#24292E">        )}</span></span>
+<span class="line"><span style="color:#24292E">      ></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">div</span><span style="color:#6F42C1"> aria-hidden</span><span style="color:#D73A49">=</span><span style="color:#032F62">"true"</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#6F42C1">cn</span><span style="color:#24292E">(</span><span style="color:#032F62">"w-full shrink-0"</span><span style="color:#24292E">, </span><span style="color:#005CC5">STACK_PEEK</span><span style="color:#24292E">)} /></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">div</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"relative aspect-[4/5] w-full shrink-0 overflow-visible"</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">          &#x3C;</span><span style="color:#005CC5">PrintStack</span><span style="color:#24292E"> /></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;/</span><span style="color:#22863A">div</span><span style="color:#24292E">></span></span>
 <span class="line"><span style="color:#24292E">      &#x3C;/</span><span style="color:#22863A">div</span><span style="color:#24292E">></span></span>
 <span class="line"><span style="color:#24292E">    &#x3C;/</span><span style="color:#22863A">figure</span><span style="color:#24292E">></span></span>
 <span class="line"><span style="color:#24292E">  );</span></span>
@@ -3285,22 +3289,17 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#24292E">}) {</span></span>
 <span class="line"><span style="color:#D73A49">  return</span><span style="color:#24292E"> (</span></span>
 <span class="line"><span style="color:#24292E">    &#x3C;</span><span style="color:#22863A">div</span></span>
-<span class="line"><span style="color:#6F42C1">      className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#6F42C1">cn</span><span style="color:#24292E">(</span></span>
-<span class="line"><span style="color:#032F62">        "grid h-[calc(100svh-var(--demo-chrome-reserve,5rem))] min-h-0 grid-cols-1 grid-rows-[auto_minmax(18rem,1fr)]"</span><span style="color:#24292E">,</span></span>
-<span class="line"><span style="color:#032F62">        "md:grid-cols-[minmax(0,2fr)_minmax(0,3fr)] md:grid-rows-1"</span><span style="color:#24292E">,</span></span>
-<span class="line"><span style="color:#005CC5">        LAYOUT</span><span style="color:#24292E">.grid,</span></span>
-<span class="line"><span style="color:#005CC5">        LAYOUT</span><span style="color:#24292E">.blockY,</span></span>
-<span class="line"><span style="color:#24292E">      )}</span></span>
-<span class="line"><span style="color:#6F42C1">      style</span><span style="color:#D73A49">=</span><span style="color:#24292E">{{ </span><span style="color:#032F62">"--layout-baseline"</span><span style="color:#24292E">: </span><span style="color:#032F62">\`\${</span><span style="color:#005CC5">BASELINE</span><span style="color:#032F62">}px\`</span><span style="color:#24292E"> } </span><span style="color:#D73A49">as</span><span style="color:#6F42C1"> CSSProperties</span><span style="color:#24292E">}</span></span>
+<span class="line"><span style="color:#6F42C1">      className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#6F42C1">cn</span><span style="color:#24292E">(</span><span style="color:#032F62">"flex flex-col gap-8"</span><span style="color:#24292E">, </span><span style="color:#032F62">"md:h-full md:min-h-0 md:flex-1 md:flex-row md:gap-6"</span><span style="color:#24292E">)}</span></span>
 <span class="line"><span style="color:#24292E">    ></span></span>
-<span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#22863A">div</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"flex min-h-0 flex-col justify-end md:col-start-1 md:row-start-1 md:pt-[clamp(3rem,11vh,8rem)]"</span><span style="color:#24292E">></span></span>
-<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">div</span><span style="color:#6F42C1"> ref</span><span style="color:#D73A49">=</span><span style="color:#24292E">{heroRef} </span><span style="color:#6F42C1">className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"relative z-20 w-fit max-w-full bg-transparent"</span><span style="color:#24292E">></span></span>
-<span class="line"><span style="color:#24292E">          &#x3C;</span><span style="color:#005CC5">HeroStory</span><span style="color:#24292E"> /></span></span>
-<span class="line"><span style="color:#24292E">        &#x3C;/</span><span style="color:#22863A">div</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#22863A">div</span></span>
+<span class="line"><span style="color:#6F42C1">        ref</span><span style="color:#D73A49">=</span><span style="color:#24292E">{heroRef}</span></span>
+<span class="line"><span style="color:#6F42C1">        className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"relative z-20 min-w-0 md:flex md:flex-[2] md:basis-0 md:flex-col md:justify-end"</span></span>
+<span class="line"><span style="color:#24292E">      ></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#005CC5">HeroStory</span><span style="color:#24292E"> /></span></span>
 <span class="line"><span style="color:#24292E">      &#x3C;/</span><span style="color:#22863A">div</span><span style="color:#24292E">></span></span>
 <span class="line"></span>
-<span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#22863A">div</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"relative z-20 flex min-h-0 min-w-0 flex-col overflow-visible md:col-start-2 md:row-start-1 md:h-full md:pl-6 md:pt-[clamp(3rem,11vh,8rem)] lg:pl-10"</span><span style="color:#24292E">></span></span>
-<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#005CC5">ProofStack</span><span style="color:#6F42C1"> stackRef</span><span style="color:#D73A49">=</span><span style="color:#24292E">{stackRef} </span><span style="color:#6F42C1">captionRef</span><span style="color:#D73A49">=</span><span style="color:#24292E">{captionRef} /></span></span>
+<span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#22863A">div</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"w-full min-w-0 md:flex md:min-h-0 md:flex-[3] md:basis-0 md:flex-col md:justify-end md:@container/print md:[container-type:size]"</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#005CC5">PrintProof</span><span style="color:#6F42C1"> stackRef</span><span style="color:#D73A49">=</span><span style="color:#24292E">{stackRef} </span><span style="color:#6F42C1">captionRef</span><span style="color:#D73A49">=</span><span style="color:#24292E">{captionRef} /></span></span>
 <span class="line"><span style="color:#24292E">      &#x3C;/</span><span style="color:#22863A">div</span><span style="color:#24292E">></span></span>
 <span class="line"><span style="color:#24292E">    &#x3C;/</span><span style="color:#22863A">div</span><span style="color:#24292E">></span></span>
 <span class="line"><span style="color:#24292E">  );</span></span>
@@ -3315,7 +3314,7 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#D73A49">  return</span><span style="color:#24292E"> (</span></span>
 <span class="line"><span style="color:#24292E">    &#x3C;></span></span>
 <span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#22863A">section</span></span>
-<span class="line"><span style="color:#6F42C1">        className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"relative isolate min-h-[calc(100svh-var(--demo-chrome-reserve,5rem))] overflow-hidden"</span></span>
+<span class="line"><span style="color:#6F42C1">        className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"relative isolate min-h-svh overflow-x-hidden overflow-y-auto md:h-svh md:overflow-hidden"</span></span>
 <span class="line"><span style="color:#6F42C1">        style</span><span style="color:#D73A49">=</span><span style="color:#24292E">{{ backgroundColor: </span><span style="color:#005CC5">CANVAS</span><span style="color:#24292E">, color: </span><span style="color:#005CC5">INK</span><span style="color:#24292E">, fontFamily: </span><span style="color:#005CC5">FONT</span><span style="color:#24292E"> }}</span></span>
 <span class="line"><span style="color:#24292E">      ></span></span>
 <span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#005CC5">TrailingImage</span></span>
@@ -3329,16 +3328,11 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#6F42C1">          excludeRefs</span><span style="color:#D73A49">=</span><span style="color:#24292E">{[heroRef, captionRef]}</span></span>
 <span class="line"><span style="color:#24292E">        /></span></span>
 <span class="line"></span>
-<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#005CC5">CardStack</span></span>
-<span class="line"><span style="color:#6F42C1">          items</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">PORTFOLIO</span><span style="color:#24292E">}</span></span>
-<span class="line"><span style="color:#6F42C1">          depth</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">3</span><span style="color:#24292E">}</span></span>
-<span class="line"><span style="color:#6F42C1">          autoplay</span><span style="color:#D73A49">=</span><span style="color:#24292E">{preloaderDone}</span></span>
-<span class="line"><span style="color:#6F42C1">          autoplayInterval</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">4500</span><span style="color:#24292E">}</span></span>
-<span class="line"><span style="color:#24292E">        ></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#005CC5">CardStack</span><span style="color:#6F42C1"> items</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">PORTFOLIO</span><span style="color:#24292E">} </span><span style="color:#6F42C1">depth</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">3</span><span style="color:#24292E">} </span><span style="color:#6F42C1">autoplay</span><span style="color:#D73A49">=</span><span style="color:#24292E">{preloaderDone} </span><span style="color:#6F42C1">autoplayInterval</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">4500</span><span style="color:#24292E">}></span></span>
 <span class="line"><span style="color:#24292E">          &#x3C;</span><span style="color:#22863A">div</span></span>
 <span class="line"><span style="color:#6F42C1">            className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#6F42C1">cn</span><span style="color:#24292E">(</span></span>
-<span class="line"><span style="color:#032F62">              "relative z-20 isolate mx-auto min-h-[calc(100svh-var(--demo-chrome-reserve,5rem))] w-full max-w-[92rem] pb-[var(--demo-chrome-reserve,5rem)]"</span><span style="color:#24292E">,</span></span>
-<span class="line"><span style="color:#005CC5">              LAYOUT</span><span style="color:#24292E">.shell,</span></span>
+<span class="line"><span style="color:#032F62">              "relative z-20 isolate mx-auto flex w-full max-w-[92rem] flex-col md:h-full md:min-h-0 md:flex-1"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#005CC5">              SHELL</span><span style="color:#24292E">,</span></span>
 <span class="line"><span style="color:#24292E">            )}</span></span>
 <span class="line"><span style="color:#24292E">          ></span></span>
 <span class="line"><span style="color:#24292E">            &#x3C;</span><span style="color:#005CC5">PortfolioLayout</span><span style="color:#6F42C1"> stackRef</span><span style="color:#D73A49">=</span><span style="color:#24292E">{stackRef} </span><span style="color:#6F42C1">heroRef</span><span style="color:#D73A49">=</span><span style="color:#24292E">{heroRef} </span><span style="color:#6F42C1">captionRef</span><span style="color:#D73A49">=</span><span style="color:#24292E">{captionRef} /></span></span>
@@ -3375,7 +3369,7 @@ export default function PhotographerPortfolio() {
       htmlDark: `<pre class="shiki github-dark" tabindex="0"><code><span class="line"><span style="color:#9ECBFF">"use client"</span><span style="color:#E1E4E8">;</span></span>
 <span class="line"></span>
 <span class="line"><span style="color:#F97583">import</span><span style="color:#9ECBFF"> "@fontsource-variable/instrument-sans"</span><span style="color:#E1E4E8">;</span></span>
-<span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> { useRef, useState, </span><span style="color:#F97583">type</span><span style="color:#E1E4E8"> CSSProperties, </span><span style="color:#F97583">type</span><span style="color:#E1E4E8"> ReactNode, </span><span style="color:#F97583">type</span><span style="color:#E1E4E8"> RefObject } </span><span style="color:#F97583">from</span><span style="color:#9ECBFF"> "react"</span><span style="color:#E1E4E8">;</span></span>
+<span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> { </span><span style="color:#F97583">type</span><span style="color:#E1E4E8"> CSSProperties, </span><span style="color:#F97583">type</span><span style="color:#E1E4E8"> ReactNode, </span><span style="color:#F97583">type</span><span style="color:#E1E4E8"> RefObject, useRef, useState } </span><span style="color:#F97583">from</span><span style="color:#9ECBFF"> "react"</span><span style="color:#E1E4E8">;</span></span>
 <span class="line"></span>
 <span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> CardStack, {</span></span>
 <span class="line"><span style="color:#E1E4E8">  CARD_STACK_MASK_IDS,</span></span>
@@ -3390,8 +3384,7 @@ export default function PhotographerPortfolio() {
 <span class="line"></span>
 <span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> { PhotographerPortfolioNotes } </span><span style="color:#F97583">from</span><span style="color:#9ECBFF"> "./photographer-portfolio-notes"</span><span style="color:#E1E4E8">;</span></span>
 <span class="line"></span>
-<span class="line"><span style="color:#F97583">const</span><span style="color:#79B8FF"> FONT</span><span style="color:#F97583"> =</span></span>
-<span class="line"><span style="color:#9ECBFF">  '"Instrument Sans Variable", ui-sans-serif, system-ui, sans-serif'</span><span style="color:#E1E4E8">;</span></span>
+<span class="line"><span style="color:#F97583">const</span><span style="color:#79B8FF"> FONT</span><span style="color:#F97583"> =</span><span style="color:#9ECBFF"> '"Instrument Sans Variable", ui-sans-serif, system-ui, sans-serif'</span><span style="color:#E1E4E8">;</span></span>
 <span class="line"></span>
 <span class="line"><span style="color:#F97583">const</span><span style="color:#79B8FF"> CANVAS</span><span style="color:#F97583"> =</span><span style="color:#9ECBFF"> "#fff"</span><span style="color:#E1E4E8">;</span></span>
 <span class="line"><span style="color:#F97583">const</span><span style="color:#79B8FF"> INK</span><span style="color:#F97583"> =</span><span style="color:#9ECBFF"> "#000"</span><span style="color:#E1E4E8">;</span></span>
@@ -3450,7 +3443,6 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#F97583">const</span><span style="color:#79B8FF"> HERO_TONE</span><span style="color:#F97583"> =</span><span style="color:#E1E4E8"> {</span></span>
 <span class="line"><span style="color:#E1E4E8">  mute: </span><span style="color:#9ECBFF">"text-black/40"</span><span style="color:#E1E4E8">,</span></span>
 <span class="line"><span style="color:#E1E4E8">  ink: </span><span style="color:#9ECBFF">"text-black"</span><span style="color:#E1E4E8">,</span></span>
-<span class="line"><span style="color:#E1E4E8">  accent: </span><span style="color:#9ECBFF">"text-[#c2410c]"</span><span style="color:#E1E4E8">,</span></span>
 <span class="line"><span style="color:#E1E4E8">} </span><span style="color:#F97583">as</span><span style="color:#F97583"> const</span><span style="color:#E1E4E8">;</span></span>
 <span class="line"></span>
 <span class="line"><span style="color:#F97583">const</span><span style="color:#79B8FF"> PORTFOLIO</span><span style="color:#F97583">:</span><span style="color:#B392F0"> CardStackItem</span><span style="color:#E1E4E8">[] </span><span style="color:#F97583">=</span><span style="color:#E1E4E8"> [</span></span>
@@ -3505,11 +3497,7 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#E1E4E8">];</span></span>
 <span class="line"></span>
 <span class="line"><span style="color:#F97583">const</span><span style="color:#79B8FF"> PRELOAD_IMAGES</span><span style="color:#F97583"> =</span><span style="color:#E1E4E8"> [</span></span>
-<span class="line"><span style="color:#F97583">  ...new</span><span style="color:#B392F0"> Set</span><span style="color:#E1E4E8">([</span></span>
-<span class="line"><span style="color:#79B8FF">    PHOTOGRAPHER</span><span style="color:#E1E4E8">.avatar,</span></span>
-<span class="line"><span style="color:#F97583">    ...</span><span style="color:#79B8FF">PORTFOLIO</span><span style="color:#E1E4E8">.</span><span style="color:#B392F0">map</span><span style="color:#E1E4E8">((</span><span style="color:#FFAB70">item</span><span style="color:#E1E4E8">) </span><span style="color:#F97583">=></span><span style="color:#E1E4E8"> item.image),</span></span>
-<span class="line"><span style="color:#F97583">    ...</span><span style="color:#79B8FF">TRAIL_IMAGES</span><span style="color:#E1E4E8">,</span></span>
-<span class="line"><span style="color:#E1E4E8">  ]),</span></span>
+<span class="line"><span style="color:#F97583">  ...new</span><span style="color:#B392F0"> Set</span><span style="color:#E1E4E8">([</span><span style="color:#79B8FF">PHOTOGRAPHER</span><span style="color:#E1E4E8">.avatar, </span><span style="color:#F97583">...</span><span style="color:#79B8FF">PORTFOLIO</span><span style="color:#E1E4E8">.</span><span style="color:#B392F0">map</span><span style="color:#E1E4E8">((</span><span style="color:#FFAB70">item</span><span style="color:#E1E4E8">) </span><span style="color:#F97583">=></span><span style="color:#E1E4E8"> item.image), </span><span style="color:#F97583">...</span><span style="color:#79B8FF">TRAIL_IMAGES</span><span style="color:#E1E4E8">]),</span></span>
 <span class="line"><span style="color:#E1E4E8">];</span></span>
 <span class="line"></span>
 <span class="line"><span style="color:#F97583">const</span><span style="color:#79B8FF"> HERO_MARK</span><span style="color:#F97583"> =</span></span>
@@ -3517,9 +3505,9 @@ export default function PhotographerPortfolio() {
 <span class="line"></span>
 <span class="line"><span style="color:#F97583">function</span><span style="color:#B392F0"> HeroMark</span><span style="color:#E1E4E8">({ </span><span style="color:#FFAB70">children</span><span style="color:#E1E4E8">, </span><span style="color:#FFAB70">className</span><span style="color:#E1E4E8"> }</span><span style="color:#F97583">:</span><span style="color:#E1E4E8"> { </span><span style="color:#FFAB70">children</span><span style="color:#F97583">:</span><span style="color:#B392F0"> ReactNode</span><span style="color:#E1E4E8">; </span><span style="color:#FFAB70">className</span><span style="color:#F97583">?:</span><span style="color:#79B8FF"> string</span><span style="color:#E1E4E8"> }) {</span></span>
 <span class="line"><span style="color:#F97583">  return</span><span style="color:#E1E4E8"> (</span></span>
-<span class="line"><span style="color:#E1E4E8">    &#x3C;</span><span style="color:#85E89D">span</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#B392F0">cn</span><span style="color:#E1E4E8">(</span><span style="color:#79B8FF">HERO_MARK</span><span style="color:#E1E4E8">, className)} </span><span style="color:#B392F0">aria-hidden</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">    &#x3C;</span><span style="color:#85E89D">div</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#B392F0">cn</span><span style="color:#E1E4E8">(</span><span style="color:#79B8FF">HERO_MARK</span><span style="color:#E1E4E8">, className)} </span><span style="color:#B392F0">aria-hidden</span><span style="color:#E1E4E8">></span></span>
 <span class="line"><span style="color:#E1E4E8">      {children}</span></span>
-<span class="line"><span style="color:#E1E4E8">    &#x3C;/</span><span style="color:#85E89D">span</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">    &#x3C;/</span><span style="color:#85E89D">div</span><span style="color:#E1E4E8">></span></span>
 <span class="line"><span style="color:#E1E4E8">  );</span></span>
 <span class="line"><span style="color:#E1E4E8">}</span></span>
 <span class="line"></span>
@@ -3532,12 +3520,11 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#E1E4E8">}</span></span>
 <span class="line"></span>
 <span class="line"><span style="color:#F97583">function</span><span style="color:#B392F0"> HeroStory</span><span style="color:#E1E4E8">() {</span></span>
-<span class="line"><span style="color:#F97583">  const</span><span style="color:#79B8FF"> type</span><span style="color:#F97583"> =</span></span>
-<span class="line"><span style="color:#9ECBFF">    "text-[clamp(1.25rem,2vw,1.75rem)] font-medium leading-[1.55] tracking-[-0.02em]"</span><span style="color:#E1E4E8">;</span></span>
+<span class="line"><span style="color:#F97583">  const</span><span style="color:#79B8FF"> type</span><span style="color:#F97583"> =</span><span style="color:#9ECBFF"> "text-[clamp(1.25rem,2vw,1.75rem)] font-medium leading-[1.55] tracking-[-0.02em]"</span><span style="color:#E1E4E8">;</span></span>
 <span class="line"></span>
 <span class="line"><span style="color:#F97583">  return</span><span style="color:#E1E4E8"> (</span></span>
-<span class="line"><span style="color:#E1E4E8">    &#x3C;</span><span style="color:#85E89D">div</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"max-w-[min(100%,36rem)] space-y-6"</span><span style="color:#E1E4E8">></span></span>
-<span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#85E89D">p</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{type}></span></span>
+<span class="line"><span style="color:#E1E4E8">    &#x3C;</span><span style="color:#85E89D">div</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"flex flex-col gap-[1.15em]"</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#85E89D">div</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{type}></span></span>
 <span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">span</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">HERO_TONE</span><span style="color:#E1E4E8">.mute}>Hi, I'm &#x3C;/</span><span style="color:#85E89D">span</span><span style="color:#E1E4E8">></span></span>
 <span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">span</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">HERO_TONE</span><span style="color:#E1E4E8">.ink}>{</span><span style="color:#79B8FF">PHOTOGRAPHER</span><span style="color:#E1E4E8">.name}&#x3C;/</span><span style="color:#85E89D">span</span><span style="color:#E1E4E8">></span></span>
 <span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#79B8FF">ProfileGlyph</span><span style="color:#B392F0"> src</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">PHOTOGRAPHER</span><span style="color:#E1E4E8">.avatar} </span><span style="color:#B392F0">alt</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">PHOTOGRAPHER</span><span style="color:#E1E4E8">.studio} /></span></span>
@@ -3553,15 +3540,11 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#E1E4E8">        &#x3C;/</span><span style="color:#79B8FF">HeroMark</span><span style="color:#E1E4E8">></span></span>
 <span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">span</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">HERO_TONE</span><span style="color:#E1E4E8">.mute}> &#x3C;/</span><span style="color:#85E89D">span</span><span style="color:#E1E4E8">></span></span>
 <span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">span</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">HERO_TONE</span><span style="color:#E1E4E8">.ink}>{</span><span style="color:#79B8FF">PHOTOGRAPHER</span><span style="color:#E1E4E8">.location}&#x3C;/</span><span style="color:#85E89D">span</span><span style="color:#E1E4E8">></span></span>
-<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">span</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">HERO_TONE</span><span style="color:#E1E4E8">.mute}></span></span>
-<span class="line"><span style="color:#E1E4E8">          {</span><span style="color:#9ECBFF">" "</span><span style="color:#E1E4E8">}</span></span>
-<span class="line"><span style="color:#E1E4E8">          — good light, real moments, and photos that don't feel forced.</span></span>
-<span class="line"><span style="color:#E1E4E8">        &#x3C;/</span><span style="color:#85E89D">span</span><span style="color:#E1E4E8">></span></span>
-<span class="line"><span style="color:#E1E4E8">      &#x3C;/</span><span style="color:#85E89D">p</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">span</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">HERO_TONE</span><span style="color:#E1E4E8">.mute}> and capture photos you hang on the wall.&#x3C;/</span><span style="color:#85E89D">span</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">      &#x3C;/</span><span style="color:#85E89D">div</span><span style="color:#E1E4E8">></span></span>
 <span class="line"></span>
-<span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#85E89D">p</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{type}></span></span>
-<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">span</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">HERO_TONE</span><span style="color:#E1E4E8">.accent}>Booking Q3.&#x3C;/</span><span style="color:#85E89D">span</span><span style="color:#E1E4E8">></span></span>
-<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">span</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">HERO_TONE</span><span style="color:#E1E4E8">.mute}> &#x3C;/</span><span style="color:#85E89D">span</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#85E89D">p</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{type} </span><span style="color:#B392F0">style</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{{ textBoxTrim: </span><span style="color:#9ECBFF">"trim-both"</span><span style="color:#E1E4E8"> } </span><span style="color:#F97583">as</span><span style="color:#B392F0"> CSSProperties</span><span style="color:#E1E4E8">}></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">span</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">HERO_TONE</span><span style="color:#E1E4E8">.mute}>Booking Q3. &#x3C;/</span><span style="color:#85E89D">span</span><span style="color:#E1E4E8">></span></span>
 <span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">a</span></span>
 <span class="line"><span style="color:#B392F0">          href</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">PHOTOGRAPHER</span><span style="color:#E1E4E8">.email}</span></span>
 <span class="line"><span style="color:#B392F0">          className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#B392F0">cn</span><span style="color:#E1E4E8">(</span><span style="color:#79B8FF">HERO_TONE</span><span style="color:#E1E4E8">.ink, </span><span style="color:#9ECBFF">"underline-offset-[4px] hover:underline"</span><span style="color:#E1E4E8">)}</span></span>
@@ -3599,9 +3582,14 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#E1E4E8">  }</span></span>
 <span class="line"></span>
 <span class="line"><span style="color:#F97583">  return</span><span style="color:#E1E4E8"> (</span></span>
-<span class="line"><span style="color:#E1E4E8">    &#x3C;</span><span style="color:#85E89D">figcaption</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"relative z-10 shrink-0 border-b border-black/80 bg-transparent pb-3"</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">    &#x3C;</span><span style="color:#85E89D">figcaption</span></span>
+<span class="line"><span style="color:#B392F0">      className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"relative z-10 shrink-0 border-b border-black/80 pb-3"</span></span>
+<span class="line"><span style="color:#B392F0">      style</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{{ backgroundColor: </span><span style="color:#79B8FF">CANVAS</span><span style="color:#E1E4E8"> }}</span></span>
+<span class="line"><span style="color:#E1E4E8">    ></span></span>
 <span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#85E89D">div</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"flex items-baseline justify-between gap-4"</span><span style="color:#E1E4E8">></span></span>
-<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">p</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"text-[11px] font-medium uppercase tracking-[0.1em] text-black"</span><span style="color:#E1E4E8">>{activeItem.title}&#x3C;/</span><span style="color:#85E89D">p</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">p</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"text-[11px] font-medium uppercase tracking-[0.1em] text-black"</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">          {activeItem.title}</span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;/</span><span style="color:#85E89D">p</span><span style="color:#E1E4E8">></span></span>
 <span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">p</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"shrink-0 text-[11px] font-medium tabular-nums tracking-[0.1em] text-black/45"</span><span style="color:#E1E4E8">></span></span>
 <span class="line"><span style="color:#E1E4E8">          {</span><span style="color:#B392F0">String</span><span style="color:#E1E4E8">(index).</span><span style="color:#B392F0">padStart</span><span style="color:#E1E4E8">(</span><span style="color:#79B8FF">2</span><span style="color:#E1E4E8">, </span><span style="color:#9ECBFF">"0"</span><span style="color:#E1E4E8">)}</span></span>
 <span class="line"><span style="color:#E1E4E8">          &#x3C;</span><span style="color:#85E89D">span</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"text-black/20"</span><span style="color:#E1E4E8">>/&#x3C;/</span><span style="color:#85E89D">span</span><span style="color:#E1E4E8">></span></span>
@@ -3619,14 +3607,48 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#E1E4E8">  );</span></span>
 <span class="line"><span style="color:#E1E4E8">}</span></span>
 <span class="line"></span>
-<span class="line"><span style="color:#F97583">const</span><span style="color:#79B8FF"> BASELINE</span><span style="color:#F97583"> =</span><span style="color:#79B8FF"> 8</span><span style="color:#E1E4E8">;</span></span>
-<span class="line"><span style="color:#F97583">const</span><span style="color:#79B8FF"> LAYOUT</span><span style="color:#F97583"> =</span><span style="color:#E1E4E8"> {</span></span>
-<span class="line"><span style="color:#E1E4E8">  shell: </span><span style="color:#9ECBFF">"px-6 sm:px-10 lg:px-14"</span><span style="color:#E1E4E8">,</span></span>
-<span class="line"><span style="color:#E1E4E8">  blockY: </span><span style="color:#9ECBFF">"py-8 lg:py-10"</span><span style="color:#E1E4E8">,</span></span>
-<span class="line"><span style="color:#E1E4E8">  grid: </span><span style="color:#9ECBFF">"gap-x-8 gap-y-8 lg:gap-x-10 lg:gap-y-10"</span><span style="color:#E1E4E8">,</span></span>
-<span class="line"><span style="color:#E1E4E8">} </span><span style="color:#F97583">as</span><span style="color:#F97583"> const</span><span style="color:#E1E4E8">;</span></span>
+<span class="line"><span style="color:#F97583">const</span><span style="color:#79B8FF"> SHELL</span><span style="color:#F97583"> =</span></span>
+<span class="line"><span style="color:#9ECBFF">  "px-6 pt-6 pb-[calc(var(--demo-chrome-reserve,5rem)+1.5rem)] sm:px-10 sm:pt-10 sm:pb-[calc(var(--demo-chrome-reserve,5rem)+2.5rem)] lg:px-14 lg:pt-14 lg:pb-[calc(var(--demo-chrome-reserve,5rem)+3.5rem)]"</span><span style="color:#E1E4E8">;</span></span>
 <span class="line"></span>
-<span class="line"><span style="color:#F97583">function</span><span style="color:#B392F0"> ProofStack</span><span style="color:#E1E4E8">({</span></span>
+<span class="line"><span style="color:#6A737D">/** Stack peek is 10% of print height — at 4:5 that is an 8:1 strip */</span></span>
+<span class="line"><span style="color:#F97583">const</span><span style="color:#79B8FF"> STACK_PEEK</span><span style="color:#F97583"> =</span><span style="color:#9ECBFF"> "aspect-[8/1]"</span><span style="color:#E1E4E8">;</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#F97583">function</span><span style="color:#B392F0"> PrintStack</span><span style="color:#E1E4E8">() {</span></span>
+<span class="line"><span style="color:#F97583">  return</span><span style="color:#E1E4E8"> (</span></span>
+<span class="line"><span style="color:#E1E4E8">    &#x3C;</span><span style="color:#79B8FF">CardStack.Frame</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"absolute inset-0 overflow-visible"</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#79B8FF">CardStack.LiveRegion</span><span style="color:#E1E4E8"> /></span></span>
+<span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#79B8FF">CardStack.Trigger</span><span style="color:#B392F0"> aria-label</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"Show next photo"</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"absolute inset-0 block text-left"</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#79B8FF">CardStack.Viewport</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"size-full overflow-visible !min-h-0 !pt-0"</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">          &#x3C;</span><span style="color:#79B8FF">CardStack.List</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">            {(</span><span style="color:#FFAB70">item</span><span style="color:#E1E4E8">, </span><span style="color:#FFAB70">index</span><span style="color:#E1E4E8">, </span><span style="color:#FFAB70">layer</span><span style="color:#E1E4E8">) </span><span style="color:#F97583">=></span><span style="color:#E1E4E8"> (</span></span>
+<span class="line"><span style="color:#E1E4E8">              &#x3C;</span><span style="color:#79B8FF">CardStack.Card</span></span>
+<span class="line"><span style="color:#B392F0">                key</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{item.id}</span></span>
+<span class="line"><span style="color:#B392F0">                layer</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{layer}</span></span>
+<span class="line"><span style="color:#B392F0">                stackIndex</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{index}</span></span>
+<span class="line"><span style="color:#B392F0">                className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"!inset-x-0 !top-0 !h-fit !w-full gap-0 overflow-visible rounded-none !bg-transparent p-0 shadow-none ring-0"</span></span>
+<span class="line"><span style="color:#E1E4E8">              ></span></span>
+<span class="line"><span style="color:#E1E4E8">                &#x3C;</span><span style="color:#85E89D">figure</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"relative aspect-[4/5] size-full overflow-hidden bg-black/5"</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">                  &#x3C;</span><span style="color:#85E89D">img</span></span>
+<span class="line"><span style="color:#B392F0">                    src</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{item.image}</span></span>
+<span class="line"><span style="color:#B392F0">                    alt</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#9ECBFF">\`\${</span><span style="color:#79B8FF">PHOTOGRAPHER</span><span style="color:#9ECBFF">.</span><span style="color:#E1E4E8">studio</span><span style="color:#9ECBFF">} — \${</span><span style="color:#E1E4E8">item</span><span style="color:#9ECBFF">.</span><span style="color:#E1E4E8">title</span><span style="color:#9ECBFF">}\`</span><span style="color:#E1E4E8">}</span></span>
+<span class="line"><span style="color:#B392F0">                    width</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">PRINT_WIDTH</span><span style="color:#E1E4E8">}</span></span>
+<span class="line"><span style="color:#B392F0">                    height</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">PRINT_HEIGHT</span><span style="color:#E1E4E8">}</span></span>
+<span class="line"><span style="color:#B392F0">                    decoding</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"async"</span></span>
+<span class="line"><span style="color:#B392F0">                    draggable</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">false</span><span style="color:#E1E4E8">}</span></span>
+<span class="line"><span style="color:#B392F0">                    className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"size-full object-cover object-center"</span></span>
+<span class="line"><span style="color:#E1E4E8">                  /></span></span>
+<span class="line"><span style="color:#E1E4E8">                  {index </span><span style="color:#F97583">===</span><span style="color:#79B8FF"> 0</span><span style="color:#F97583"> ?</span><span style="color:#E1E4E8"> &#x3C;</span><span style="color:#79B8FF">ViewfinderFrame</span><span style="color:#E1E4E8"> /> </span><span style="color:#F97583">:</span><span style="color:#79B8FF"> null</span><span style="color:#E1E4E8">}</span></span>
+<span class="line"><span style="color:#E1E4E8">                &#x3C;/</span><span style="color:#85E89D">figure</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">              &#x3C;/</span><span style="color:#79B8FF">CardStack.Card</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">            )}</span></span>
+<span class="line"><span style="color:#E1E4E8">          &#x3C;/</span><span style="color:#79B8FF">CardStack.List</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;/</span><span style="color:#79B8FF">CardStack.Viewport</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">      &#x3C;/</span><span style="color:#79B8FF">CardStack.Trigger</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">    &#x3C;/</span><span style="color:#79B8FF">CardStack.Frame</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">  );</span></span>
+<span class="line"><span style="color:#E1E4E8">}</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#F97583">function</span><span style="color:#B392F0"> PrintProof</span><span style="color:#E1E4E8">({</span></span>
 <span class="line"><span style="color:#FFAB70">  stackRef</span><span style="color:#E1E4E8">,</span></span>
 <span class="line"><span style="color:#FFAB70">  captionRef</span><span style="color:#E1E4E8">,</span></span>
 <span class="line"><span style="color:#E1E4E8">}</span><span style="color:#F97583">:</span><span style="color:#E1E4E8"> {</span></span>
@@ -3634,46 +3656,25 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#FFAB70">  captionRef</span><span style="color:#F97583">:</span><span style="color:#B392F0"> RefObject</span><span style="color:#E1E4E8">&#x3C;</span><span style="color:#B392F0">HTMLDivElement</span><span style="color:#F97583"> |</span><span style="color:#79B8FF"> null</span><span style="color:#E1E4E8">>;</span></span>
 <span class="line"><span style="color:#E1E4E8">}) {</span></span>
 <span class="line"><span style="color:#F97583">  return</span><span style="color:#E1E4E8"> (</span></span>
-<span class="line"><span style="color:#E1E4E8">    &#x3C;</span><span style="color:#85E89D">figure</span></span>
-<span class="line"><span style="color:#B392F0">      ref</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{stackRef}</span></span>
-<span class="line"><span style="color:#B392F0">      className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"ml-auto grid h-full min-h-0 w-full min-w-0 max-w-full grid-rows-[auto_minmax(0,1fr)] gap-y-3 sm:gap-y-4"</span></span>
-<span class="line"><span style="color:#E1E4E8">    ></span></span>
-<span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#85E89D">div</span><span style="color:#B392F0"> ref</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{captionRef} </span><span style="color:#B392F0">className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"relative z-30 w-full shrink-0 bg-transparent"</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">    &#x3C;</span><span style="color:#85E89D">figure</span><span style="color:#B392F0"> ref</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{stackRef} </span><span style="color:#B392F0">className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"flex w-full min-w-0 flex-col"</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#85E89D">div</span></span>
+<span class="line"><span style="color:#B392F0">        ref</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{captionRef}</span></span>
+<span class="line"><span style="color:#B392F0">        className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"relative z-30 w-full shrink-0"</span></span>
+<span class="line"><span style="color:#B392F0">        style</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{{ backgroundColor: </span><span style="color:#79B8FF">CANVAS</span><span style="color:#E1E4E8"> }}</span></span>
+<span class="line"><span style="color:#E1E4E8">      ></span></span>
 <span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#79B8FF">PrintCaption</span><span style="color:#E1E4E8"> /></span></span>
 <span class="line"><span style="color:#E1E4E8">      &#x3C;/</span><span style="color:#85E89D">div</span><span style="color:#E1E4E8">></span></span>
-<span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#85E89D">div</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"@container/stack relative flex min-h-0 flex-1 items-end justify-end pt-[max(2.5rem,11%)]"</span><span style="color:#E1E4E8">></span></span>
-<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#79B8FF">CardStack.Frame</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"relative aspect-[4/5] h-auto w-[min(100cqw,calc(100cqh*4/5))] max-h-full min-h-0 shrink-0 overflow-visible"</span><span style="color:#E1E4E8">></span></span>
-<span class="line"><span style="color:#E1E4E8">          &#x3C;</span><span style="color:#79B8FF">CardStack.LiveRegion</span><span style="color:#E1E4E8"> /></span></span>
-<span class="line"><span style="color:#E1E4E8">          &#x3C;</span><span style="color:#79B8FF">CardStack.Trigger</span><span style="color:#B392F0"> aria-label</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"Show next photo"</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"block size-full text-left"</span><span style="color:#E1E4E8">></span></span>
-<span class="line"><span style="color:#E1E4E8">            &#x3C;</span><span style="color:#79B8FF">CardStack.Viewport</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"relative size-full overflow-visible !min-h-0 !pt-0"</span><span style="color:#E1E4E8">></span></span>
-<span class="line"><span style="color:#E1E4E8">            &#x3C;</span><span style="color:#79B8FF">CardStack.List</span><span style="color:#E1E4E8">></span></span>
-<span class="line"><span style="color:#E1E4E8">              {(</span><span style="color:#FFAB70">item</span><span style="color:#E1E4E8">, </span><span style="color:#FFAB70">index</span><span style="color:#E1E4E8">, </span><span style="color:#FFAB70">layer</span><span style="color:#E1E4E8">) </span><span style="color:#F97583">=></span><span style="color:#E1E4E8"> (</span></span>
-<span class="line"><span style="color:#E1E4E8">                &#x3C;</span><span style="color:#79B8FF">CardStack.Card</span></span>
-<span class="line"><span style="color:#B392F0">                  key</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{item.id}</span></span>
-<span class="line"><span style="color:#B392F0">                  layer</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{layer}</span></span>
-<span class="line"><span style="color:#B392F0">                  stackIndex</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{index}</span></span>
-<span class="line"><span style="color:#B392F0">                  className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"size-full gap-0 overflow-visible rounded-none bg-transparent p-0 shadow-none ring-0 [background-image:none]"</span></span>
-<span class="line"><span style="color:#E1E4E8">                ></span></span>
-<span class="line"><span style="color:#E1E4E8">                  &#x3C;</span><span style="color:#85E89D">figure</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"flex size-full flex-col border-0 bg-transparent p-0"</span><span style="color:#E1E4E8">></span></span>
-<span class="line"><span style="color:#E1E4E8">                    &#x3C;</span><span style="color:#85E89D">div</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"relative min-h-0 w-full flex-1 overflow-hidden bg-black/5"</span><span style="color:#E1E4E8">></span></span>
-<span class="line"><span style="color:#E1E4E8">                      &#x3C;</span><span style="color:#85E89D">img</span></span>
-<span class="line"><span style="color:#B392F0">                        src</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{item.image}</span></span>
-<span class="line"><span style="color:#B392F0">                        alt</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#9ECBFF">\`\${</span><span style="color:#79B8FF">PHOTOGRAPHER</span><span style="color:#9ECBFF">.</span><span style="color:#E1E4E8">studio</span><span style="color:#9ECBFF">} — \${</span><span style="color:#E1E4E8">item</span><span style="color:#9ECBFF">.</span><span style="color:#E1E4E8">title</span><span style="color:#9ECBFF">}\`</span><span style="color:#E1E4E8">}</span></span>
-<span class="line"><span style="color:#B392F0">                        width</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">PRINT_WIDTH</span><span style="color:#E1E4E8">}</span></span>
-<span class="line"><span style="color:#B392F0">                        height</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">PRINT_HEIGHT</span><span style="color:#E1E4E8">}</span></span>
-<span class="line"><span style="color:#B392F0">                        decoding</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"async"</span></span>
-<span class="line"><span style="color:#B392F0">                        draggable</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">false</span><span style="color:#E1E4E8">}</span></span>
-<span class="line"><span style="color:#B392F0">                        className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"absolute inset-0 size-full object-cover object-center"</span></span>
-<span class="line"><span style="color:#E1E4E8">                      /></span></span>
-<span class="line"><span style="color:#E1E4E8">                      {index </span><span style="color:#F97583">===</span><span style="color:#79B8FF"> 0</span><span style="color:#F97583"> ?</span><span style="color:#E1E4E8"> &#x3C;</span><span style="color:#79B8FF">ViewfinderFrame</span><span style="color:#E1E4E8"> /> </span><span style="color:#F97583">:</span><span style="color:#79B8FF"> null</span><span style="color:#E1E4E8">}</span></span>
-<span class="line"><span style="color:#E1E4E8">                    &#x3C;/</span><span style="color:#85E89D">div</span><span style="color:#E1E4E8">></span></span>
-<span class="line"><span style="color:#E1E4E8">                  &#x3C;/</span><span style="color:#85E89D">figure</span><span style="color:#E1E4E8">></span></span>
-<span class="line"><span style="color:#E1E4E8">                &#x3C;/</span><span style="color:#79B8FF">CardStack.Card</span><span style="color:#E1E4E8">></span></span>
-<span class="line"><span style="color:#E1E4E8">              )}</span></span>
-<span class="line"><span style="color:#E1E4E8">            &#x3C;/</span><span style="color:#79B8FF">CardStack.List</span><span style="color:#E1E4E8">></span></span>
-<span class="line"><span style="color:#E1E4E8">          &#x3C;/</span><span style="color:#79B8FF">CardStack.Viewport</span><span style="color:#E1E4E8">></span></span>
-<span class="line"><span style="color:#E1E4E8">        &#x3C;/</span><span style="color:#79B8FF">CardStack.Trigger</span><span style="color:#E1E4E8">></span></span>
-<span class="line"><span style="color:#E1E4E8">      &#x3C;/</span><span style="color:#79B8FF">CardStack.Frame</span><span style="color:#E1E4E8">></span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#85E89D">div</span></span>
+<span class="line"><span style="color:#B392F0">        className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#B392F0">cn</span><span style="color:#E1E4E8">(</span></span>
+<span class="line"><span style="color:#9ECBFF">          "flex w-full flex-col"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#9ECBFF">          "md:ml-auto md:w-[min(100cqw,calc((100cqh-4.5rem)*8/11))]"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">        )}</span></span>
+<span class="line"><span style="color:#E1E4E8">      ></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">div</span><span style="color:#B392F0"> aria-hidden</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"true"</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#B392F0">cn</span><span style="color:#E1E4E8">(</span><span style="color:#9ECBFF">"w-full shrink-0"</span><span style="color:#E1E4E8">, </span><span style="color:#79B8FF">STACK_PEEK</span><span style="color:#E1E4E8">)} /></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">div</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"relative aspect-[4/5] w-full shrink-0 overflow-visible"</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">          &#x3C;</span><span style="color:#79B8FF">PrintStack</span><span style="color:#E1E4E8"> /></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;/</span><span style="color:#85E89D">div</span><span style="color:#E1E4E8">></span></span>
 <span class="line"><span style="color:#E1E4E8">      &#x3C;/</span><span style="color:#85E89D">div</span><span style="color:#E1E4E8">></span></span>
 <span class="line"><span style="color:#E1E4E8">    &#x3C;/</span><span style="color:#85E89D">figure</span><span style="color:#E1E4E8">></span></span>
 <span class="line"><span style="color:#E1E4E8">  );</span></span>
@@ -3690,22 +3691,17 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#E1E4E8">}) {</span></span>
 <span class="line"><span style="color:#F97583">  return</span><span style="color:#E1E4E8"> (</span></span>
 <span class="line"><span style="color:#E1E4E8">    &#x3C;</span><span style="color:#85E89D">div</span></span>
-<span class="line"><span style="color:#B392F0">      className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#B392F0">cn</span><span style="color:#E1E4E8">(</span></span>
-<span class="line"><span style="color:#9ECBFF">        "grid h-[calc(100svh-var(--demo-chrome-reserve,5rem))] min-h-0 grid-cols-1 grid-rows-[auto_minmax(18rem,1fr)]"</span><span style="color:#E1E4E8">,</span></span>
-<span class="line"><span style="color:#9ECBFF">        "md:grid-cols-[minmax(0,2fr)_minmax(0,3fr)] md:grid-rows-1"</span><span style="color:#E1E4E8">,</span></span>
-<span class="line"><span style="color:#79B8FF">        LAYOUT</span><span style="color:#E1E4E8">.grid,</span></span>
-<span class="line"><span style="color:#79B8FF">        LAYOUT</span><span style="color:#E1E4E8">.blockY,</span></span>
-<span class="line"><span style="color:#E1E4E8">      )}</span></span>
-<span class="line"><span style="color:#B392F0">      style</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{{ </span><span style="color:#9ECBFF">"--layout-baseline"</span><span style="color:#E1E4E8">: </span><span style="color:#9ECBFF">\`\${</span><span style="color:#79B8FF">BASELINE</span><span style="color:#9ECBFF">}px\`</span><span style="color:#E1E4E8"> } </span><span style="color:#F97583">as</span><span style="color:#B392F0"> CSSProperties</span><span style="color:#E1E4E8">}</span></span>
+<span class="line"><span style="color:#B392F0">      className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#B392F0">cn</span><span style="color:#E1E4E8">(</span><span style="color:#9ECBFF">"flex flex-col gap-8"</span><span style="color:#E1E4E8">, </span><span style="color:#9ECBFF">"md:h-full md:min-h-0 md:flex-1 md:flex-row md:gap-6"</span><span style="color:#E1E4E8">)}</span></span>
 <span class="line"><span style="color:#E1E4E8">    ></span></span>
-<span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#85E89D">div</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"flex min-h-0 flex-col justify-end md:col-start-1 md:row-start-1 md:pt-[clamp(3rem,11vh,8rem)]"</span><span style="color:#E1E4E8">></span></span>
-<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">div</span><span style="color:#B392F0"> ref</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{heroRef} </span><span style="color:#B392F0">className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"relative z-20 w-fit max-w-full bg-transparent"</span><span style="color:#E1E4E8">></span></span>
-<span class="line"><span style="color:#E1E4E8">          &#x3C;</span><span style="color:#79B8FF">HeroStory</span><span style="color:#E1E4E8"> /></span></span>
-<span class="line"><span style="color:#E1E4E8">        &#x3C;/</span><span style="color:#85E89D">div</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#85E89D">div</span></span>
+<span class="line"><span style="color:#B392F0">        ref</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{heroRef}</span></span>
+<span class="line"><span style="color:#B392F0">        className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"relative z-20 min-w-0 md:flex md:flex-[2] md:basis-0 md:flex-col md:justify-end"</span></span>
+<span class="line"><span style="color:#E1E4E8">      ></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#79B8FF">HeroStory</span><span style="color:#E1E4E8"> /></span></span>
 <span class="line"><span style="color:#E1E4E8">      &#x3C;/</span><span style="color:#85E89D">div</span><span style="color:#E1E4E8">></span></span>
 <span class="line"></span>
-<span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#85E89D">div</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"relative z-20 flex min-h-0 min-w-0 flex-col overflow-visible md:col-start-2 md:row-start-1 md:h-full md:pl-6 md:pt-[clamp(3rem,11vh,8rem)] lg:pl-10"</span><span style="color:#E1E4E8">></span></span>
-<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#79B8FF">ProofStack</span><span style="color:#B392F0"> stackRef</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{stackRef} </span><span style="color:#B392F0">captionRef</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{captionRef} /></span></span>
+<span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#85E89D">div</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"w-full min-w-0 md:flex md:min-h-0 md:flex-[3] md:basis-0 md:flex-col md:justify-end md:@container/print md:[container-type:size]"</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#79B8FF">PrintProof</span><span style="color:#B392F0"> stackRef</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{stackRef} </span><span style="color:#B392F0">captionRef</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{captionRef} /></span></span>
 <span class="line"><span style="color:#E1E4E8">      &#x3C;/</span><span style="color:#85E89D">div</span><span style="color:#E1E4E8">></span></span>
 <span class="line"><span style="color:#E1E4E8">    &#x3C;/</span><span style="color:#85E89D">div</span><span style="color:#E1E4E8">></span></span>
 <span class="line"><span style="color:#E1E4E8">  );</span></span>
@@ -3720,7 +3716,7 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#F97583">  return</span><span style="color:#E1E4E8"> (</span></span>
 <span class="line"><span style="color:#E1E4E8">    &#x3C;></span></span>
 <span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#85E89D">section</span></span>
-<span class="line"><span style="color:#B392F0">        className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"relative isolate min-h-[calc(100svh-var(--demo-chrome-reserve,5rem))] overflow-hidden"</span></span>
+<span class="line"><span style="color:#B392F0">        className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"relative isolate min-h-svh overflow-x-hidden overflow-y-auto md:h-svh md:overflow-hidden"</span></span>
 <span class="line"><span style="color:#B392F0">        style</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{{ backgroundColor: </span><span style="color:#79B8FF">CANVAS</span><span style="color:#E1E4E8">, color: </span><span style="color:#79B8FF">INK</span><span style="color:#E1E4E8">, fontFamily: </span><span style="color:#79B8FF">FONT</span><span style="color:#E1E4E8"> }}</span></span>
 <span class="line"><span style="color:#E1E4E8">      ></span></span>
 <span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#79B8FF">TrailingImage</span></span>
@@ -3734,16 +3730,11 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#B392F0">          excludeRefs</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{[heroRef, captionRef]}</span></span>
 <span class="line"><span style="color:#E1E4E8">        /></span></span>
 <span class="line"></span>
-<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#79B8FF">CardStack</span></span>
-<span class="line"><span style="color:#B392F0">          items</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">PORTFOLIO</span><span style="color:#E1E4E8">}</span></span>
-<span class="line"><span style="color:#B392F0">          depth</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">3</span><span style="color:#E1E4E8">}</span></span>
-<span class="line"><span style="color:#B392F0">          autoplay</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{preloaderDone}</span></span>
-<span class="line"><span style="color:#B392F0">          autoplayInterval</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">4500</span><span style="color:#E1E4E8">}</span></span>
-<span class="line"><span style="color:#E1E4E8">        ></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#79B8FF">CardStack</span><span style="color:#B392F0"> items</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">PORTFOLIO</span><span style="color:#E1E4E8">} </span><span style="color:#B392F0">depth</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">3</span><span style="color:#E1E4E8">} </span><span style="color:#B392F0">autoplay</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{preloaderDone} </span><span style="color:#B392F0">autoplayInterval</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">4500</span><span style="color:#E1E4E8">}></span></span>
 <span class="line"><span style="color:#E1E4E8">          &#x3C;</span><span style="color:#85E89D">div</span></span>
 <span class="line"><span style="color:#B392F0">            className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#B392F0">cn</span><span style="color:#E1E4E8">(</span></span>
-<span class="line"><span style="color:#9ECBFF">              "relative z-20 isolate mx-auto min-h-[calc(100svh-var(--demo-chrome-reserve,5rem))] w-full max-w-[92rem] pb-[var(--demo-chrome-reserve,5rem)]"</span><span style="color:#E1E4E8">,</span></span>
-<span class="line"><span style="color:#79B8FF">              LAYOUT</span><span style="color:#E1E4E8">.shell,</span></span>
+<span class="line"><span style="color:#9ECBFF">              "relative z-20 isolate mx-auto flex w-full max-w-[92rem] flex-col md:h-full md:min-h-0 md:flex-1"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#79B8FF">              SHELL</span><span style="color:#E1E4E8">,</span></span>
 <span class="line"><span style="color:#E1E4E8">            )}</span></span>
 <span class="line"><span style="color:#E1E4E8">          ></span></span>
 <span class="line"><span style="color:#E1E4E8">            &#x3C;</span><span style="color:#79B8FF">PortfolioLayout</span><span style="color:#B392F0"> stackRef</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{stackRef} </span><span style="color:#B392F0">heroRef</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{heroRef} </span><span style="color:#B392F0">captionRef</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{captionRef} /></span></span>

--- a/app/demo/generated/demo-sources.ts
+++ b/app/demo/generated/demo-sources.ts
@@ -2627,7 +2627,9 @@ const PHOTOGRAPHER = {
 
 const TRAIL_IMAGES = LUMMI_ASSETS.trail.map((id) => lummi(id));
 
-const SHOT_SETTINGS: Record<string, { aperture: string; shutter: string; stock: string }> = {
+type PortfolioId = keyof typeof LUMMI_ASSETS.portfolio;
+
+const SHOT_SETTINGS: Record<PortfolioId, { aperture: string; shutter: string; stock: string }> = {
   vows: { aperture: "2", shutter: "1/500", stock: "Portra 400" },
   ceremony: { aperture: "2.8", shutter: "1/250", stock: "Portra 160" },
   reception: { aperture: "2", shutter: "1/125", stock: "Portra 800" },
@@ -2647,7 +2649,6 @@ const PORTFOLIO: CardStackItem[] = [
     image: lummi(LUMMI_ASSETS.portfolio.vows),
     title: "Vows",
     tagline: "Cliffside ceremony",
-    counts: { like: 0, comment: 0 },
     maskId: CARD_STACK_MASK_IDS[0],
   },
   {
@@ -2655,7 +2656,6 @@ const PORTFOLIO: CardStackItem[] = [
     image: lummi(LUMMI_ASSETS.portfolio.ceremony),
     title: "Ceremony",
     tagline: "Church exit",
-    counts: { like: 0, comment: 0 },
     maskId: CARD_STACK_MASK_IDS[0],
   },
   {
@@ -2663,7 +2663,6 @@ const PORTFOLIO: CardStackItem[] = [
     image: lummi(LUMMI_ASSETS.portfolio.reception),
     title: "Reception",
     tagline: "Evening dance",
-    counts: { like: 0, comment: 0 },
     maskId: CARD_STACK_MASK_IDS[0],
   },
   {
@@ -2671,7 +2670,6 @@ const PORTFOLIO: CardStackItem[] = [
     image: lummi(LUMMI_ASSETS.portfolio.candid),
     title: "Candid",
     tagline: "Real laughter",
-    counts: { like: 0, comment: 0 },
     maskId: CARD_STACK_MASK_IDS[0],
   },
   {
@@ -2679,7 +2677,6 @@ const PORTFOLIO: CardStackItem[] = [
     image: lummi(LUMMI_ASSETS.portfolio.florals),
     title: "Florals",
     tagline: "Bouquet detail",
-    counts: { like: 0, comment: 0 },
     maskId: CARD_STACK_MASK_IDS[0],
   },
   {
@@ -2687,7 +2684,6 @@ const PORTFOLIO: CardStackItem[] = [
     image: lummi(LUMMI_ASSETS.portfolio.festival),
     title: "Event",
     tagline: "Summer festival",
-    counts: { like: 0, comment: 0 },
     maskId: CARD_STACK_MASK_IDS[0],
   },
 ];
@@ -2770,8 +2766,12 @@ function ViewfinderFrame() {
 
 function PrintCaption() {
   const { activeItem } = useCardStack();
-  const index = activeItem ? PORTFOLIO.findIndex((item) => item.id === activeItem.id) + 1 : 1;
-  const settings = activeItem ? SHOT_SETTINGS[activeItem.id] : SHOT_SETTINGS.vows;
+  const rawIndex = activeItem ? PORTFOLIO.findIndex((item) => item.id === activeItem.id) : -1;
+  const index = rawIndex === -1 ? 1 : rawIndex + 1;
+  const settings =
+    activeItem && activeItem.id in SHOT_SETTINGS
+      ? SHOT_SETTINGS[activeItem.id as PortfolioId]
+      : SHOT_SETTINGS.vows;
 
   if (!activeItem || !settings) {
     return null;
@@ -2889,12 +2889,8 @@ function PortfolioLayout({
     <div
       className={cn("flex flex-col gap-8", "md:h-full md:min-h-0 md:flex-1 md:flex-row md:gap-6")}
     >
-      <div
-        className="relative z-20 min-w-0 md:flex md:flex-[2] md:basis-0 md:flex-col md:justify-end"
-      >
-        <div
-          ref={heroRef}
-        >
+      <div className="relative z-20 min-w-0 md:flex md:flex-[2] md:basis-0 md:flex-col md:justify-end">
+        <div ref={heroRef}>
           <HeroStory />
         </div>
       </div>
@@ -3032,7 +3028,9 @@ export default function PhotographerPortfolio() {
 <span class="line"></span>
 <span class="line"><span style="color:#D73A49">const</span><span style="color:#005CC5"> TRAIL_IMAGES</span><span style="color:#D73A49"> =</span><span style="color:#005CC5"> LUMMI_ASSETS</span><span style="color:#24292E">.trail.</span><span style="color:#6F42C1">map</span><span style="color:#24292E">((</span><span style="color:#E36209">id</span><span style="color:#24292E">) </span><span style="color:#D73A49">=></span><span style="color:#6F42C1"> lummi</span><span style="color:#24292E">(id));</span></span>
 <span class="line"></span>
-<span class="line"><span style="color:#D73A49">const</span><span style="color:#005CC5"> SHOT_SETTINGS</span><span style="color:#D73A49">:</span><span style="color:#6F42C1"> Record</span><span style="color:#24292E">&#x3C;</span><span style="color:#005CC5">string</span><span style="color:#24292E">, { </span><span style="color:#E36209">aperture</span><span style="color:#D73A49">:</span><span style="color:#005CC5"> string</span><span style="color:#24292E">; </span><span style="color:#E36209">shutter</span><span style="color:#D73A49">:</span><span style="color:#005CC5"> string</span><span style="color:#24292E">; </span><span style="color:#E36209">stock</span><span style="color:#D73A49">:</span><span style="color:#005CC5"> string</span><span style="color:#24292E"> }> </span><span style="color:#D73A49">=</span><span style="color:#24292E"> {</span></span>
+<span class="line"><span style="color:#D73A49">type</span><span style="color:#6F42C1"> PortfolioId</span><span style="color:#D73A49"> =</span><span style="color:#D73A49"> keyof</span><span style="color:#D73A49"> typeof</span><span style="color:#005CC5"> LUMMI_ASSETS</span><span style="color:#24292E">.portfolio;</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#D73A49">const</span><span style="color:#005CC5"> SHOT_SETTINGS</span><span style="color:#D73A49">:</span><span style="color:#6F42C1"> Record</span><span style="color:#24292E">&#x3C;</span><span style="color:#6F42C1">PortfolioId</span><span style="color:#24292E">, { </span><span style="color:#E36209">aperture</span><span style="color:#D73A49">:</span><span style="color:#005CC5"> string</span><span style="color:#24292E">; </span><span style="color:#E36209">shutter</span><span style="color:#D73A49">:</span><span style="color:#005CC5"> string</span><span style="color:#24292E">; </span><span style="color:#E36209">stock</span><span style="color:#D73A49">:</span><span style="color:#005CC5"> string</span><span style="color:#24292E"> }> </span><span style="color:#D73A49">=</span><span style="color:#24292E"> {</span></span>
 <span class="line"><span style="color:#24292E">  vows: { aperture: </span><span style="color:#032F62">"2"</span><span style="color:#24292E">, shutter: </span><span style="color:#032F62">"1/500"</span><span style="color:#24292E">, stock: </span><span style="color:#032F62">"Portra 400"</span><span style="color:#24292E"> },</span></span>
 <span class="line"><span style="color:#24292E">  ceremony: { aperture: </span><span style="color:#032F62">"2.8"</span><span style="color:#24292E">, shutter: </span><span style="color:#032F62">"1/250"</span><span style="color:#24292E">, stock: </span><span style="color:#032F62">"Portra 160"</span><span style="color:#24292E"> },</span></span>
 <span class="line"><span style="color:#24292E">  reception: { aperture: </span><span style="color:#032F62">"2"</span><span style="color:#24292E">, shutter: </span><span style="color:#032F62">"1/125"</span><span style="color:#24292E">, stock: </span><span style="color:#032F62">"Portra 800"</span><span style="color:#24292E"> },</span></span>
@@ -3052,7 +3050,6 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#24292E">    image: </span><span style="color:#6F42C1">lummi</span><span style="color:#24292E">(</span><span style="color:#005CC5">LUMMI_ASSETS</span><span style="color:#24292E">.portfolio.vows),</span></span>
 <span class="line"><span style="color:#24292E">    title: </span><span style="color:#032F62">"Vows"</span><span style="color:#24292E">,</span></span>
 <span class="line"><span style="color:#24292E">    tagline: </span><span style="color:#032F62">"Cliffside ceremony"</span><span style="color:#24292E">,</span></span>
-<span class="line"><span style="color:#24292E">    counts: { like: </span><span style="color:#005CC5">0</span><span style="color:#24292E">, comment: </span><span style="color:#005CC5">0</span><span style="color:#24292E"> },</span></span>
 <span class="line"><span style="color:#24292E">    maskId: </span><span style="color:#005CC5">CARD_STACK_MASK_IDS</span><span style="color:#24292E">[</span><span style="color:#005CC5">0</span><span style="color:#24292E">],</span></span>
 <span class="line"><span style="color:#24292E">  },</span></span>
 <span class="line"><span style="color:#24292E">  {</span></span>
@@ -3060,7 +3057,6 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#24292E">    image: </span><span style="color:#6F42C1">lummi</span><span style="color:#24292E">(</span><span style="color:#005CC5">LUMMI_ASSETS</span><span style="color:#24292E">.portfolio.ceremony),</span></span>
 <span class="line"><span style="color:#24292E">    title: </span><span style="color:#032F62">"Ceremony"</span><span style="color:#24292E">,</span></span>
 <span class="line"><span style="color:#24292E">    tagline: </span><span style="color:#032F62">"Church exit"</span><span style="color:#24292E">,</span></span>
-<span class="line"><span style="color:#24292E">    counts: { like: </span><span style="color:#005CC5">0</span><span style="color:#24292E">, comment: </span><span style="color:#005CC5">0</span><span style="color:#24292E"> },</span></span>
 <span class="line"><span style="color:#24292E">    maskId: </span><span style="color:#005CC5">CARD_STACK_MASK_IDS</span><span style="color:#24292E">[</span><span style="color:#005CC5">0</span><span style="color:#24292E">],</span></span>
 <span class="line"><span style="color:#24292E">  },</span></span>
 <span class="line"><span style="color:#24292E">  {</span></span>
@@ -3068,7 +3064,6 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#24292E">    image: </span><span style="color:#6F42C1">lummi</span><span style="color:#24292E">(</span><span style="color:#005CC5">LUMMI_ASSETS</span><span style="color:#24292E">.portfolio.reception),</span></span>
 <span class="line"><span style="color:#24292E">    title: </span><span style="color:#032F62">"Reception"</span><span style="color:#24292E">,</span></span>
 <span class="line"><span style="color:#24292E">    tagline: </span><span style="color:#032F62">"Evening dance"</span><span style="color:#24292E">,</span></span>
-<span class="line"><span style="color:#24292E">    counts: { like: </span><span style="color:#005CC5">0</span><span style="color:#24292E">, comment: </span><span style="color:#005CC5">0</span><span style="color:#24292E"> },</span></span>
 <span class="line"><span style="color:#24292E">    maskId: </span><span style="color:#005CC5">CARD_STACK_MASK_IDS</span><span style="color:#24292E">[</span><span style="color:#005CC5">0</span><span style="color:#24292E">],</span></span>
 <span class="line"><span style="color:#24292E">  },</span></span>
 <span class="line"><span style="color:#24292E">  {</span></span>
@@ -3076,7 +3071,6 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#24292E">    image: </span><span style="color:#6F42C1">lummi</span><span style="color:#24292E">(</span><span style="color:#005CC5">LUMMI_ASSETS</span><span style="color:#24292E">.portfolio.candid),</span></span>
 <span class="line"><span style="color:#24292E">    title: </span><span style="color:#032F62">"Candid"</span><span style="color:#24292E">,</span></span>
 <span class="line"><span style="color:#24292E">    tagline: </span><span style="color:#032F62">"Real laughter"</span><span style="color:#24292E">,</span></span>
-<span class="line"><span style="color:#24292E">    counts: { like: </span><span style="color:#005CC5">0</span><span style="color:#24292E">, comment: </span><span style="color:#005CC5">0</span><span style="color:#24292E"> },</span></span>
 <span class="line"><span style="color:#24292E">    maskId: </span><span style="color:#005CC5">CARD_STACK_MASK_IDS</span><span style="color:#24292E">[</span><span style="color:#005CC5">0</span><span style="color:#24292E">],</span></span>
 <span class="line"><span style="color:#24292E">  },</span></span>
 <span class="line"><span style="color:#24292E">  {</span></span>
@@ -3084,7 +3078,6 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#24292E">    image: </span><span style="color:#6F42C1">lummi</span><span style="color:#24292E">(</span><span style="color:#005CC5">LUMMI_ASSETS</span><span style="color:#24292E">.portfolio.florals),</span></span>
 <span class="line"><span style="color:#24292E">    title: </span><span style="color:#032F62">"Florals"</span><span style="color:#24292E">,</span></span>
 <span class="line"><span style="color:#24292E">    tagline: </span><span style="color:#032F62">"Bouquet detail"</span><span style="color:#24292E">,</span></span>
-<span class="line"><span style="color:#24292E">    counts: { like: </span><span style="color:#005CC5">0</span><span style="color:#24292E">, comment: </span><span style="color:#005CC5">0</span><span style="color:#24292E"> },</span></span>
 <span class="line"><span style="color:#24292E">    maskId: </span><span style="color:#005CC5">CARD_STACK_MASK_IDS</span><span style="color:#24292E">[</span><span style="color:#005CC5">0</span><span style="color:#24292E">],</span></span>
 <span class="line"><span style="color:#24292E">  },</span></span>
 <span class="line"><span style="color:#24292E">  {</span></span>
@@ -3092,7 +3085,6 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#24292E">    image: </span><span style="color:#6F42C1">lummi</span><span style="color:#24292E">(</span><span style="color:#005CC5">LUMMI_ASSETS</span><span style="color:#24292E">.portfolio.festival),</span></span>
 <span class="line"><span style="color:#24292E">    title: </span><span style="color:#032F62">"Event"</span><span style="color:#24292E">,</span></span>
 <span class="line"><span style="color:#24292E">    tagline: </span><span style="color:#032F62">"Summer festival"</span><span style="color:#24292E">,</span></span>
-<span class="line"><span style="color:#24292E">    counts: { like: </span><span style="color:#005CC5">0</span><span style="color:#24292E">, comment: </span><span style="color:#005CC5">0</span><span style="color:#24292E"> },</span></span>
 <span class="line"><span style="color:#24292E">    maskId: </span><span style="color:#005CC5">CARD_STACK_MASK_IDS</span><span style="color:#24292E">[</span><span style="color:#005CC5">0</span><span style="color:#24292E">],</span></span>
 <span class="line"><span style="color:#24292E">  },</span></span>
 <span class="line"><span style="color:#24292E">];</span></span>
@@ -3175,8 +3167,12 @@ export default function PhotographerPortfolio() {
 <span class="line"></span>
 <span class="line"><span style="color:#D73A49">function</span><span style="color:#6F42C1"> PrintCaption</span><span style="color:#24292E">() {</span></span>
 <span class="line"><span style="color:#D73A49">  const</span><span style="color:#24292E"> { </span><span style="color:#005CC5">activeItem</span><span style="color:#24292E"> } </span><span style="color:#D73A49">=</span><span style="color:#6F42C1"> useCardStack</span><span style="color:#24292E">();</span></span>
-<span class="line"><span style="color:#D73A49">  const</span><span style="color:#005CC5"> index</span><span style="color:#D73A49"> =</span><span style="color:#24292E"> activeItem </span><span style="color:#D73A49">?</span><span style="color:#005CC5"> PORTFOLIO</span><span style="color:#24292E">.</span><span style="color:#6F42C1">findIndex</span><span style="color:#24292E">((</span><span style="color:#E36209">item</span><span style="color:#24292E">) </span><span style="color:#D73A49">=></span><span style="color:#24292E"> item.id </span><span style="color:#D73A49">===</span><span style="color:#24292E"> activeItem.id) </span><span style="color:#D73A49">+</span><span style="color:#005CC5"> 1</span><span style="color:#D73A49"> :</span><span style="color:#005CC5"> 1</span><span style="color:#24292E">;</span></span>
-<span class="line"><span style="color:#D73A49">  const</span><span style="color:#005CC5"> settings</span><span style="color:#D73A49"> =</span><span style="color:#24292E"> activeItem </span><span style="color:#D73A49">?</span><span style="color:#005CC5"> SHOT_SETTINGS</span><span style="color:#24292E">[activeItem.id] </span><span style="color:#D73A49">:</span><span style="color:#005CC5"> SHOT_SETTINGS</span><span style="color:#24292E">.vows;</span></span>
+<span class="line"><span style="color:#D73A49">  const</span><span style="color:#005CC5"> rawIndex</span><span style="color:#D73A49"> =</span><span style="color:#24292E"> activeItem </span><span style="color:#D73A49">?</span><span style="color:#005CC5"> PORTFOLIO</span><span style="color:#24292E">.</span><span style="color:#6F42C1">findIndex</span><span style="color:#24292E">((</span><span style="color:#E36209">item</span><span style="color:#24292E">) </span><span style="color:#D73A49">=></span><span style="color:#24292E"> item.id </span><span style="color:#D73A49">===</span><span style="color:#24292E"> activeItem.id) </span><span style="color:#D73A49">:</span><span style="color:#D73A49"> -</span><span style="color:#005CC5">1</span><span style="color:#24292E">;</span></span>
+<span class="line"><span style="color:#D73A49">  const</span><span style="color:#005CC5"> index</span><span style="color:#D73A49"> =</span><span style="color:#24292E"> rawIndex </span><span style="color:#D73A49">===</span><span style="color:#D73A49"> -</span><span style="color:#005CC5">1</span><span style="color:#D73A49"> ?</span><span style="color:#005CC5"> 1</span><span style="color:#D73A49"> :</span><span style="color:#24292E"> rawIndex </span><span style="color:#D73A49">+</span><span style="color:#005CC5"> 1</span><span style="color:#24292E">;</span></span>
+<span class="line"><span style="color:#D73A49">  const</span><span style="color:#005CC5"> settings</span><span style="color:#D73A49"> =</span></span>
+<span class="line"><span style="color:#24292E">    activeItem </span><span style="color:#D73A49">&#x26;&#x26;</span><span style="color:#24292E"> activeItem.id </span><span style="color:#D73A49">in</span><span style="color:#005CC5"> SHOT_SETTINGS</span></span>
+<span class="line"><span style="color:#D73A49">      ?</span><span style="color:#005CC5"> SHOT_SETTINGS</span><span style="color:#24292E">[activeItem.id </span><span style="color:#D73A49">as</span><span style="color:#6F42C1"> PortfolioId</span><span style="color:#24292E">]</span></span>
+<span class="line"><span style="color:#D73A49">      :</span><span style="color:#005CC5"> SHOT_SETTINGS</span><span style="color:#24292E">.vows;</span></span>
 <span class="line"></span>
 <span class="line"><span style="color:#D73A49">  if</span><span style="color:#24292E"> (</span><span style="color:#D73A49">!</span><span style="color:#24292E">activeItem </span><span style="color:#D73A49">||</span><span style="color:#D73A49"> !</span><span style="color:#24292E">settings) {</span></span>
 <span class="line"><span style="color:#D73A49">    return</span><span style="color:#005CC5"> null</span><span style="color:#24292E">;</span></span>
@@ -3294,12 +3290,8 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#24292E">    &#x3C;</span><span style="color:#22863A">div</span></span>
 <span class="line"><span style="color:#6F42C1">      className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#6F42C1">cn</span><span style="color:#24292E">(</span><span style="color:#032F62">"flex flex-col gap-8"</span><span style="color:#24292E">, </span><span style="color:#032F62">"md:h-full md:min-h-0 md:flex-1 md:flex-row md:gap-6"</span><span style="color:#24292E">)}</span></span>
 <span class="line"><span style="color:#24292E">    ></span></span>
-<span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#22863A">div</span></span>
-<span class="line"><span style="color:#6F42C1">        className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"relative z-20 min-w-0 md:flex md:flex-[2] md:basis-0 md:flex-col md:justify-end"</span></span>
-<span class="line"><span style="color:#24292E">      ></span></span>
-<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">div</span></span>
-<span class="line"><span style="color:#6F42C1">          ref</span><span style="color:#D73A49">=</span><span style="color:#24292E">{heroRef}</span></span>
-<span class="line"><span style="color:#24292E">        ></span></span>
+<span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#22863A">div</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"relative z-20 min-w-0 md:flex md:flex-[2] md:basis-0 md:flex-col md:justify-end"</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">div</span><span style="color:#6F42C1"> ref</span><span style="color:#D73A49">=</span><span style="color:#24292E">{heroRef}></span></span>
 <span class="line"><span style="color:#24292E">          &#x3C;</span><span style="color:#005CC5">HeroStory</span><span style="color:#24292E"> /></span></span>
 <span class="line"><span style="color:#24292E">        &#x3C;/</span><span style="color:#22863A">div</span><span style="color:#24292E">></span></span>
 <span class="line"><span style="color:#24292E">      &#x3C;/</span><span style="color:#22863A">div</span><span style="color:#24292E">></span></span>
@@ -3437,7 +3429,9 @@ export default function PhotographerPortfolio() {
 <span class="line"></span>
 <span class="line"><span style="color:#F97583">const</span><span style="color:#79B8FF"> TRAIL_IMAGES</span><span style="color:#F97583"> =</span><span style="color:#79B8FF"> LUMMI_ASSETS</span><span style="color:#E1E4E8">.trail.</span><span style="color:#B392F0">map</span><span style="color:#E1E4E8">((</span><span style="color:#FFAB70">id</span><span style="color:#E1E4E8">) </span><span style="color:#F97583">=></span><span style="color:#B392F0"> lummi</span><span style="color:#E1E4E8">(id));</span></span>
 <span class="line"></span>
-<span class="line"><span style="color:#F97583">const</span><span style="color:#79B8FF"> SHOT_SETTINGS</span><span style="color:#F97583">:</span><span style="color:#B392F0"> Record</span><span style="color:#E1E4E8">&#x3C;</span><span style="color:#79B8FF">string</span><span style="color:#E1E4E8">, { </span><span style="color:#FFAB70">aperture</span><span style="color:#F97583">:</span><span style="color:#79B8FF"> string</span><span style="color:#E1E4E8">; </span><span style="color:#FFAB70">shutter</span><span style="color:#F97583">:</span><span style="color:#79B8FF"> string</span><span style="color:#E1E4E8">; </span><span style="color:#FFAB70">stock</span><span style="color:#F97583">:</span><span style="color:#79B8FF"> string</span><span style="color:#E1E4E8"> }> </span><span style="color:#F97583">=</span><span style="color:#E1E4E8"> {</span></span>
+<span class="line"><span style="color:#F97583">type</span><span style="color:#B392F0"> PortfolioId</span><span style="color:#F97583"> =</span><span style="color:#F97583"> keyof</span><span style="color:#F97583"> typeof</span><span style="color:#79B8FF"> LUMMI_ASSETS</span><span style="color:#E1E4E8">.portfolio;</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#F97583">const</span><span style="color:#79B8FF"> SHOT_SETTINGS</span><span style="color:#F97583">:</span><span style="color:#B392F0"> Record</span><span style="color:#E1E4E8">&#x3C;</span><span style="color:#B392F0">PortfolioId</span><span style="color:#E1E4E8">, { </span><span style="color:#FFAB70">aperture</span><span style="color:#F97583">:</span><span style="color:#79B8FF"> string</span><span style="color:#E1E4E8">; </span><span style="color:#FFAB70">shutter</span><span style="color:#F97583">:</span><span style="color:#79B8FF"> string</span><span style="color:#E1E4E8">; </span><span style="color:#FFAB70">stock</span><span style="color:#F97583">:</span><span style="color:#79B8FF"> string</span><span style="color:#E1E4E8"> }> </span><span style="color:#F97583">=</span><span style="color:#E1E4E8"> {</span></span>
 <span class="line"><span style="color:#E1E4E8">  vows: { aperture: </span><span style="color:#9ECBFF">"2"</span><span style="color:#E1E4E8">, shutter: </span><span style="color:#9ECBFF">"1/500"</span><span style="color:#E1E4E8">, stock: </span><span style="color:#9ECBFF">"Portra 400"</span><span style="color:#E1E4E8"> },</span></span>
 <span class="line"><span style="color:#E1E4E8">  ceremony: { aperture: </span><span style="color:#9ECBFF">"2.8"</span><span style="color:#E1E4E8">, shutter: </span><span style="color:#9ECBFF">"1/250"</span><span style="color:#E1E4E8">, stock: </span><span style="color:#9ECBFF">"Portra 160"</span><span style="color:#E1E4E8"> },</span></span>
 <span class="line"><span style="color:#E1E4E8">  reception: { aperture: </span><span style="color:#9ECBFF">"2"</span><span style="color:#E1E4E8">, shutter: </span><span style="color:#9ECBFF">"1/125"</span><span style="color:#E1E4E8">, stock: </span><span style="color:#9ECBFF">"Portra 800"</span><span style="color:#E1E4E8"> },</span></span>
@@ -3457,7 +3451,6 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#E1E4E8">    image: </span><span style="color:#B392F0">lummi</span><span style="color:#E1E4E8">(</span><span style="color:#79B8FF">LUMMI_ASSETS</span><span style="color:#E1E4E8">.portfolio.vows),</span></span>
 <span class="line"><span style="color:#E1E4E8">    title: </span><span style="color:#9ECBFF">"Vows"</span><span style="color:#E1E4E8">,</span></span>
 <span class="line"><span style="color:#E1E4E8">    tagline: </span><span style="color:#9ECBFF">"Cliffside ceremony"</span><span style="color:#E1E4E8">,</span></span>
-<span class="line"><span style="color:#E1E4E8">    counts: { like: </span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8">, comment: </span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8"> },</span></span>
 <span class="line"><span style="color:#E1E4E8">    maskId: </span><span style="color:#79B8FF">CARD_STACK_MASK_IDS</span><span style="color:#E1E4E8">[</span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8">],</span></span>
 <span class="line"><span style="color:#E1E4E8">  },</span></span>
 <span class="line"><span style="color:#E1E4E8">  {</span></span>
@@ -3465,7 +3458,6 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#E1E4E8">    image: </span><span style="color:#B392F0">lummi</span><span style="color:#E1E4E8">(</span><span style="color:#79B8FF">LUMMI_ASSETS</span><span style="color:#E1E4E8">.portfolio.ceremony),</span></span>
 <span class="line"><span style="color:#E1E4E8">    title: </span><span style="color:#9ECBFF">"Ceremony"</span><span style="color:#E1E4E8">,</span></span>
 <span class="line"><span style="color:#E1E4E8">    tagline: </span><span style="color:#9ECBFF">"Church exit"</span><span style="color:#E1E4E8">,</span></span>
-<span class="line"><span style="color:#E1E4E8">    counts: { like: </span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8">, comment: </span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8"> },</span></span>
 <span class="line"><span style="color:#E1E4E8">    maskId: </span><span style="color:#79B8FF">CARD_STACK_MASK_IDS</span><span style="color:#E1E4E8">[</span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8">],</span></span>
 <span class="line"><span style="color:#E1E4E8">  },</span></span>
 <span class="line"><span style="color:#E1E4E8">  {</span></span>
@@ -3473,7 +3465,6 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#E1E4E8">    image: </span><span style="color:#B392F0">lummi</span><span style="color:#E1E4E8">(</span><span style="color:#79B8FF">LUMMI_ASSETS</span><span style="color:#E1E4E8">.portfolio.reception),</span></span>
 <span class="line"><span style="color:#E1E4E8">    title: </span><span style="color:#9ECBFF">"Reception"</span><span style="color:#E1E4E8">,</span></span>
 <span class="line"><span style="color:#E1E4E8">    tagline: </span><span style="color:#9ECBFF">"Evening dance"</span><span style="color:#E1E4E8">,</span></span>
-<span class="line"><span style="color:#E1E4E8">    counts: { like: </span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8">, comment: </span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8"> },</span></span>
 <span class="line"><span style="color:#E1E4E8">    maskId: </span><span style="color:#79B8FF">CARD_STACK_MASK_IDS</span><span style="color:#E1E4E8">[</span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8">],</span></span>
 <span class="line"><span style="color:#E1E4E8">  },</span></span>
 <span class="line"><span style="color:#E1E4E8">  {</span></span>
@@ -3481,7 +3472,6 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#E1E4E8">    image: </span><span style="color:#B392F0">lummi</span><span style="color:#E1E4E8">(</span><span style="color:#79B8FF">LUMMI_ASSETS</span><span style="color:#E1E4E8">.portfolio.candid),</span></span>
 <span class="line"><span style="color:#E1E4E8">    title: </span><span style="color:#9ECBFF">"Candid"</span><span style="color:#E1E4E8">,</span></span>
 <span class="line"><span style="color:#E1E4E8">    tagline: </span><span style="color:#9ECBFF">"Real laughter"</span><span style="color:#E1E4E8">,</span></span>
-<span class="line"><span style="color:#E1E4E8">    counts: { like: </span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8">, comment: </span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8"> },</span></span>
 <span class="line"><span style="color:#E1E4E8">    maskId: </span><span style="color:#79B8FF">CARD_STACK_MASK_IDS</span><span style="color:#E1E4E8">[</span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8">],</span></span>
 <span class="line"><span style="color:#E1E4E8">  },</span></span>
 <span class="line"><span style="color:#E1E4E8">  {</span></span>
@@ -3489,7 +3479,6 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#E1E4E8">    image: </span><span style="color:#B392F0">lummi</span><span style="color:#E1E4E8">(</span><span style="color:#79B8FF">LUMMI_ASSETS</span><span style="color:#E1E4E8">.portfolio.florals),</span></span>
 <span class="line"><span style="color:#E1E4E8">    title: </span><span style="color:#9ECBFF">"Florals"</span><span style="color:#E1E4E8">,</span></span>
 <span class="line"><span style="color:#E1E4E8">    tagline: </span><span style="color:#9ECBFF">"Bouquet detail"</span><span style="color:#E1E4E8">,</span></span>
-<span class="line"><span style="color:#E1E4E8">    counts: { like: </span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8">, comment: </span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8"> },</span></span>
 <span class="line"><span style="color:#E1E4E8">    maskId: </span><span style="color:#79B8FF">CARD_STACK_MASK_IDS</span><span style="color:#E1E4E8">[</span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8">],</span></span>
 <span class="line"><span style="color:#E1E4E8">  },</span></span>
 <span class="line"><span style="color:#E1E4E8">  {</span></span>
@@ -3497,7 +3486,6 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#E1E4E8">    image: </span><span style="color:#B392F0">lummi</span><span style="color:#E1E4E8">(</span><span style="color:#79B8FF">LUMMI_ASSETS</span><span style="color:#E1E4E8">.portfolio.festival),</span></span>
 <span class="line"><span style="color:#E1E4E8">    title: </span><span style="color:#9ECBFF">"Event"</span><span style="color:#E1E4E8">,</span></span>
 <span class="line"><span style="color:#E1E4E8">    tagline: </span><span style="color:#9ECBFF">"Summer festival"</span><span style="color:#E1E4E8">,</span></span>
-<span class="line"><span style="color:#E1E4E8">    counts: { like: </span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8">, comment: </span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8"> },</span></span>
 <span class="line"><span style="color:#E1E4E8">    maskId: </span><span style="color:#79B8FF">CARD_STACK_MASK_IDS</span><span style="color:#E1E4E8">[</span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8">],</span></span>
 <span class="line"><span style="color:#E1E4E8">  },</span></span>
 <span class="line"><span style="color:#E1E4E8">];</span></span>
@@ -3580,8 +3568,12 @@ export default function PhotographerPortfolio() {
 <span class="line"></span>
 <span class="line"><span style="color:#F97583">function</span><span style="color:#B392F0"> PrintCaption</span><span style="color:#E1E4E8">() {</span></span>
 <span class="line"><span style="color:#F97583">  const</span><span style="color:#E1E4E8"> { </span><span style="color:#79B8FF">activeItem</span><span style="color:#E1E4E8"> } </span><span style="color:#F97583">=</span><span style="color:#B392F0"> useCardStack</span><span style="color:#E1E4E8">();</span></span>
-<span class="line"><span style="color:#F97583">  const</span><span style="color:#79B8FF"> index</span><span style="color:#F97583"> =</span><span style="color:#E1E4E8"> activeItem </span><span style="color:#F97583">?</span><span style="color:#79B8FF"> PORTFOLIO</span><span style="color:#E1E4E8">.</span><span style="color:#B392F0">findIndex</span><span style="color:#E1E4E8">((</span><span style="color:#FFAB70">item</span><span style="color:#E1E4E8">) </span><span style="color:#F97583">=></span><span style="color:#E1E4E8"> item.id </span><span style="color:#F97583">===</span><span style="color:#E1E4E8"> activeItem.id) </span><span style="color:#F97583">+</span><span style="color:#79B8FF"> 1</span><span style="color:#F97583"> :</span><span style="color:#79B8FF"> 1</span><span style="color:#E1E4E8">;</span></span>
-<span class="line"><span style="color:#F97583">  const</span><span style="color:#79B8FF"> settings</span><span style="color:#F97583"> =</span><span style="color:#E1E4E8"> activeItem </span><span style="color:#F97583">?</span><span style="color:#79B8FF"> SHOT_SETTINGS</span><span style="color:#E1E4E8">[activeItem.id] </span><span style="color:#F97583">:</span><span style="color:#79B8FF"> SHOT_SETTINGS</span><span style="color:#E1E4E8">.vows;</span></span>
+<span class="line"><span style="color:#F97583">  const</span><span style="color:#79B8FF"> rawIndex</span><span style="color:#F97583"> =</span><span style="color:#E1E4E8"> activeItem </span><span style="color:#F97583">?</span><span style="color:#79B8FF"> PORTFOLIO</span><span style="color:#E1E4E8">.</span><span style="color:#B392F0">findIndex</span><span style="color:#E1E4E8">((</span><span style="color:#FFAB70">item</span><span style="color:#E1E4E8">) </span><span style="color:#F97583">=></span><span style="color:#E1E4E8"> item.id </span><span style="color:#F97583">===</span><span style="color:#E1E4E8"> activeItem.id) </span><span style="color:#F97583">:</span><span style="color:#F97583"> -</span><span style="color:#79B8FF">1</span><span style="color:#E1E4E8">;</span></span>
+<span class="line"><span style="color:#F97583">  const</span><span style="color:#79B8FF"> index</span><span style="color:#F97583"> =</span><span style="color:#E1E4E8"> rawIndex </span><span style="color:#F97583">===</span><span style="color:#F97583"> -</span><span style="color:#79B8FF">1</span><span style="color:#F97583"> ?</span><span style="color:#79B8FF"> 1</span><span style="color:#F97583"> :</span><span style="color:#E1E4E8"> rawIndex </span><span style="color:#F97583">+</span><span style="color:#79B8FF"> 1</span><span style="color:#E1E4E8">;</span></span>
+<span class="line"><span style="color:#F97583">  const</span><span style="color:#79B8FF"> settings</span><span style="color:#F97583"> =</span></span>
+<span class="line"><span style="color:#E1E4E8">    activeItem </span><span style="color:#F97583">&#x26;&#x26;</span><span style="color:#E1E4E8"> activeItem.id </span><span style="color:#F97583">in</span><span style="color:#79B8FF"> SHOT_SETTINGS</span></span>
+<span class="line"><span style="color:#F97583">      ?</span><span style="color:#79B8FF"> SHOT_SETTINGS</span><span style="color:#E1E4E8">[activeItem.id </span><span style="color:#F97583">as</span><span style="color:#B392F0"> PortfolioId</span><span style="color:#E1E4E8">]</span></span>
+<span class="line"><span style="color:#F97583">      :</span><span style="color:#79B8FF"> SHOT_SETTINGS</span><span style="color:#E1E4E8">.vows;</span></span>
 <span class="line"></span>
 <span class="line"><span style="color:#F97583">  if</span><span style="color:#E1E4E8"> (</span><span style="color:#F97583">!</span><span style="color:#E1E4E8">activeItem </span><span style="color:#F97583">||</span><span style="color:#F97583"> !</span><span style="color:#E1E4E8">settings) {</span></span>
 <span class="line"><span style="color:#F97583">    return</span><span style="color:#79B8FF"> null</span><span style="color:#E1E4E8">;</span></span>
@@ -3699,12 +3691,8 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#E1E4E8">    &#x3C;</span><span style="color:#85E89D">div</span></span>
 <span class="line"><span style="color:#B392F0">      className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#B392F0">cn</span><span style="color:#E1E4E8">(</span><span style="color:#9ECBFF">"flex flex-col gap-8"</span><span style="color:#E1E4E8">, </span><span style="color:#9ECBFF">"md:h-full md:min-h-0 md:flex-1 md:flex-row md:gap-6"</span><span style="color:#E1E4E8">)}</span></span>
 <span class="line"><span style="color:#E1E4E8">    ></span></span>
-<span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#85E89D">div</span></span>
-<span class="line"><span style="color:#B392F0">        className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"relative z-20 min-w-0 md:flex md:flex-[2] md:basis-0 md:flex-col md:justify-end"</span></span>
-<span class="line"><span style="color:#E1E4E8">      ></span></span>
-<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">div</span></span>
-<span class="line"><span style="color:#B392F0">          ref</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{heroRef}</span></span>
-<span class="line"><span style="color:#E1E4E8">        ></span></span>
+<span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#85E89D">div</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"relative z-20 min-w-0 md:flex md:flex-[2] md:basis-0 md:flex-col md:justify-end"</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">div</span><span style="color:#B392F0"> ref</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{heroRef}></span></span>
 <span class="line"><span style="color:#E1E4E8">          &#x3C;</span><span style="color:#79B8FF">HeroStory</span><span style="color:#E1E4E8"> /></span></span>
 <span class="line"><span style="color:#E1E4E8">        &#x3C;/</span><span style="color:#85E89D">div</span><span style="color:#E1E4E8">></span></span>
 <span class="line"><span style="color:#E1E4E8">      &#x3C;/</span><span style="color:#85E89D">div</span><span style="color:#E1E4E8">></span></span>

--- a/app/demo/generated/demo-sources.ts
+++ b/app/demo/generated/demo-sources.ts
@@ -2557,4 +2557,1226 @@ export default function CinemaRow() {
 <span class="line"></span></code></pre>`,
     },
   ],
+  "hero/photographer-portfolio": [
+    {
+      name: "photographer-portfolio.tsx",
+      path: "app/demo/library/hero/photographer-portfolio.tsx",
+      language: "tsx",
+      code: `"use client";
+
+import "@fontsource-variable/instrument-sans";
+import { useRef, useState, type CSSProperties, type ReactNode, type RefObject } from "react";
+
+import CardStack, {
+  CARD_STACK_MASK_IDS,
+  type CardStackItem,
+  useCardStack,
+} from "@/animata/card/card-stack";
+import TrailingImage from "@/animata/image/trailing-image";
+import SplitReveal from "@/animata/preloader/split-reveal";
+import { MapPinIcon } from "@/components/ui/map-pin";
+import { SwitchCameraIcon } from "@/components/ui/switch-camera";
+import { cn } from "@/lib/utils";
+
+import { PhotographerPortfolioNotes } from "./photographer-portfolio-notes";
+
+const FONT =
+  '"Instrument Sans Variable", ui-sans-serif, system-ui, sans-serif';
+
+const CANVAS = "#fff";
+const INK = "#000";
+const PRINT_WIDTH = 900;
+const PRINT_HEIGHT = 1125;
+
+const lummi = (assetId: string) =>
+  \`https://assets.lummi.ai/assets/\${assetId}?auto=format&fit=crop&w=\${PRINT_WIDTH}&h=\${PRINT_HEIGHT}&q=85\`;
+
+/** Wedding + event frames from https://lummi.ai — see demo notes for credits */
+const LUMMI_ASSETS = {
+  avatar: "QmXp6StB1i36XHbbmppop5AwtQgnyom8bYTZqPkLVNGJnk",
+  portfolio: {
+    vows: "QmabCfDwG7NUco1UhMnAE7NiHSK63MNKmPxAA2mc8Xrh8j",
+    ceremony: "QmS6CSjJ3hc82mvhNtYGWmcAZ1coJUdEkrAVmJ6PPEH2Q3",
+    reception: "QmaCT6boTGzVxo9ii5JYcnAuakoVhso3esFDA9Y58Nm7Le",
+    candid: "QmY8f1t5PS7b6fVhd6R7s1AFQMVERRKmgE8gNataeweAS4",
+    florals: "QmYerGQMAkWiRYDyYMwVfZQSKy8FGy2Js4G83vf1vyBGdR",
+    festival: "QmZnV56e2xNN5kqUWRVMupeiUExehkWKqo5X5ewgMpA19C",
+  },
+  trail: [
+    "QmVufjyFaAWjZYr4kdM8JLxr68EDky5V9YnwkhRbeD3jVb",
+    "QmTfDd4u2rHboSjREqrmM2AX8uamVhgURW5iKAJmTpe3Rz",
+    "QmcVMDiPtnnxCKgLCppm4iHQNp8L2zX8NF1xzV1Ch7nBtk",
+    "QmSXefvUey7N617ro5dG1mjRXFm9iUN5uUmwBTS63DEApS",
+    "QmVgzYXYEaShMjw87vVZZv1J7PjhaNKy92XY2uTrB59o9R",
+    "QmcioeKGZKuCeauwteg4DEu2edo6qe3HeK99Y9FywsYk8i",
+    "QmUB7fgmDhst3VZKU5R5uUkfvbcXvZ3FDKFvkNk5TkRvqD",
+    "QmeL2wx9Sdw4dGPawgxUBenthP9jt8ff8Ux4uog45NL95j",
+    "QmTXHjCens6Bg4Q7J4LjzU9fyKVec3t1ziqT32ShpXa93r",
+    "QmV1pUNAsa1orHnyBWFWki6qZvatRQpgbQnDCVdV1EzRGd",
+    "QmZAgYih2jUqmKJz4wUoTARdijpv7bveUFYrjvacV66KXp",
+    "QmQMun9ag4MrBC8man7bQC9xNupf4oCufwvCj2VpU7rXDi",
+  ],
+} as const;
+
+const PHOTOGRAPHER = {
+  studio: "Maya Chen",
+  name: "Maya",
+  location: "Brooklyn",
+  email: "mailto:hello@mayachen.studio",
+  avatar: lummi(LUMMI_ASSETS.avatar),
+};
+
+const TRAIL_IMAGES = LUMMI_ASSETS.trail.map((id) => lummi(id));
+
+const SHOT_SETTINGS: Record<string, { aperture: string; shutter: string; stock: string }> = {
+  vows: { aperture: "2", shutter: "1/500", stock: "Portra 400" },
+  ceremony: { aperture: "2.8", shutter: "1/250", stock: "Portra 160" },
+  reception: { aperture: "2", shutter: "1/125", stock: "Portra 800" },
+  candid: { aperture: "1.8", shutter: "1/320", stock: "Tri-X 400" },
+  florals: { aperture: "4", shutter: "1/200", stock: "Ektar 100" },
+  festival: { aperture: "2.8", shutter: "1/160", stock: "Portra 800" },
+};
+
+const HERO_TONE = {
+  mute: "text-black/40",
+  ink: "text-black",
+  accent: "text-[#c2410c]",
+} as const;
+
+const PORTFOLIO: CardStackItem[] = [
+  {
+    id: "vows",
+    image: lummi(LUMMI_ASSETS.portfolio.vows),
+    title: "Vows",
+    tagline: "Cliffside ceremony",
+    counts: { like: 0, comment: 0 },
+    maskId: CARD_STACK_MASK_IDS[0],
+  },
+  {
+    id: "ceremony",
+    image: lummi(LUMMI_ASSETS.portfolio.ceremony),
+    title: "Ceremony",
+    tagline: "Church exit",
+    counts: { like: 0, comment: 0 },
+    maskId: CARD_STACK_MASK_IDS[0],
+  },
+  {
+    id: "reception",
+    image: lummi(LUMMI_ASSETS.portfolio.reception),
+    title: "Reception",
+    tagline: "Evening dance",
+    counts: { like: 0, comment: 0 },
+    maskId: CARD_STACK_MASK_IDS[0],
+  },
+  {
+    id: "candid",
+    image: lummi(LUMMI_ASSETS.portfolio.candid),
+    title: "Candid",
+    tagline: "Real laughter",
+    counts: { like: 0, comment: 0 },
+    maskId: CARD_STACK_MASK_IDS[0],
+  },
+  {
+    id: "florals",
+    image: lummi(LUMMI_ASSETS.portfolio.florals),
+    title: "Florals",
+    tagline: "Bouquet detail",
+    counts: { like: 0, comment: 0 },
+    maskId: CARD_STACK_MASK_IDS[0],
+  },
+  {
+    id: "festival",
+    image: lummi(LUMMI_ASSETS.portfolio.festival),
+    title: "Event",
+    tagline: "Summer festival",
+    counts: { like: 0, comment: 0 },
+    maskId: CARD_STACK_MASK_IDS[0],
+  },
+];
+
+const PRELOAD_IMAGES = [
+  ...new Set([
+    PHOTOGRAPHER.avatar,
+    ...PORTFOLIO.map((item) => item.image),
+    ...TRAIL_IMAGES,
+  ]),
+];
+
+const HERO_MARK =
+  "mx-1 inline-flex size-[clamp(1.75rem,1.286em,2.25rem)] shrink-0 items-center justify-center align-middle";
+
+function HeroMark({ children, className }: { children: ReactNode; className?: string }) {
+  return (
+    <span className={cn(HERO_MARK, className)} aria-hidden>
+      {children}
+    </span>
+  );
+}
+
+function ProfileGlyph({ src, alt }: { src: string; alt: string }) {
+  return (
+    <span className={cn(HERO_MARK, "overflow-hidden rounded-full ring-1 ring-black/10")}>
+      <img src={src} alt={alt} className="size-full object-cover" decoding="async" />
+    </span>
+  );
+}
+
+function HeroStory() {
+  const type =
+    "text-[clamp(1.25rem,2vw,1.75rem)] font-medium leading-[1.55] tracking-[-0.02em]";
+
+  return (
+    <div className="max-w-[min(100%,36rem)] space-y-6">
+      <p className={type}>
+        <span className={HERO_TONE.mute}>Hi, I'm </span>
+        <span className={HERO_TONE.ink}>{PHOTOGRAPHER.name}</span>
+        <ProfileGlyph src={PHOTOGRAPHER.avatar} alt={PHOTOGRAPHER.studio} />
+        <span className={HERO_TONE.mute}>. I shoot </span>
+        <HeroMark className="text-black">
+          <SwitchCameraIcon className="size-full [&_svg]:size-full" />
+        </HeroMark>
+        <span className={HERO_TONE.mute}> </span>
+        <span className={HERO_TONE.ink}>weddings and events</span>
+        <span className={HERO_TONE.mute}> in </span>
+        <HeroMark className="text-black/55">
+          <MapPinIcon className="size-full [&_svg]:size-full" />
+        </HeroMark>
+        <span className={HERO_TONE.mute}> </span>
+        <span className={HERO_TONE.ink}>{PHOTOGRAPHER.location}</span>
+        <span className={HERO_TONE.mute}>
+          {" "}
+          — good light, real moments, and photos that don't feel forced.
+        </span>
+      </p>
+
+      <p className={type}>
+        <span className={HERO_TONE.accent}>Booking Q3.</span>
+        <span className={HERO_TONE.mute}> </span>
+        <a
+          href={PHOTOGRAPHER.email}
+          className={cn(HERO_TONE.ink, "underline-offset-[4px] hover:underline")}
+        >
+          Send me your date.
+        </a>
+      </p>
+    </div>
+  );
+}
+
+function ViewfinderFrame() {
+  const corner = "absolute size-4 border-white/80";
+  return (
+    <div className="pointer-events-none absolute inset-3 sm:inset-4" aria-hidden>
+      <span className={cn(corner, "left-0 top-0 border-l-2 border-t-2")} />
+      <span className={cn(corner, "right-0 top-0 border-r-2 border-t-2")} />
+      <span className={cn(corner, "bottom-0 left-0 border-b-2 border-l-2")} />
+      <span className={cn(corner, "bottom-0 right-0 border-b-2 border-r-2")} />
+      <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 opacity-[0.16]">
+        <span className="absolute left-1/2 top-1/2 h-px w-5 -translate-x-1/2 -translate-y-1/2 bg-white" />
+        <span className="absolute left-1/2 top-1/2 h-5 w-px -translate-x-1/2 -translate-y-1/2 bg-white" />
+      </div>
+    </div>
+  );
+}
+
+function PrintCaption() {
+  const { activeItem } = useCardStack();
+  const index = activeItem ? PORTFOLIO.findIndex((item) => item.id === activeItem.id) + 1 : 1;
+  const settings = activeItem ? SHOT_SETTINGS[activeItem.id] : SHOT_SETTINGS.vows;
+
+  if (!activeItem || !settings) {
+    return null;
+  }
+
+  return (
+    <figcaption className="relative z-10 shrink-0 border-b border-black/80 bg-transparent pb-3">
+      <div className="flex items-baseline justify-between gap-4">
+        <p className="text-[11px] font-medium uppercase tracking-[0.1em] text-black">{activeItem.title}</p>
+        <p className="shrink-0 text-[11px] font-medium tabular-nums tracking-[0.1em] text-black/45">
+          {String(index).padStart(2, "0")}
+          <span className="text-black/20">/</span>
+          {String(PORTFOLIO.length).padStart(2, "0")}
+        </p>
+      </div>
+      <p className="mt-2 text-[11px] font-medium uppercase tracking-[0.1em] text-black/45">
+        ƒ/{settings.aperture}
+        <span className="px-1.5 text-black/20">·</span>
+        {settings.shutter}
+        <span className="px-1.5 text-black/20">·</span>
+        {settings.stock}
+      </p>
+    </figcaption>
+  );
+}
+
+const BASELINE = 8;
+const LAYOUT = {
+  shell: "px-6 sm:px-10 lg:px-14",
+  blockY: "py-8 lg:py-10",
+  grid: "gap-x-8 gap-y-8 lg:gap-x-10 lg:gap-y-10",
+} as const;
+
+function ProofStack({
+  stackRef,
+  captionRef,
+}: {
+  stackRef: RefObject<HTMLElement | null>;
+  captionRef: RefObject<HTMLDivElement | null>;
+}) {
+  return (
+    <figure
+      ref={stackRef}
+      className="ml-auto grid h-full min-h-0 w-full min-w-0 max-w-full grid-rows-[auto_minmax(0,1fr)] gap-y-3 sm:gap-y-4"
+    >
+      <div ref={captionRef} className="relative z-30 w-full shrink-0 bg-transparent">
+        <PrintCaption />
+      </div>
+      <div className="@container/stack relative flex min-h-0 flex-1 items-end justify-end pt-[max(2.5rem,11%)]">
+        <CardStack.Frame className="relative aspect-[4/5] h-auto w-[min(100cqw,calc(100cqh*4/5))] max-h-full min-h-0 shrink-0 overflow-visible">
+          <CardStack.LiveRegion />
+          <CardStack.Trigger aria-label="Show next photo" className="block size-full text-left">
+            <CardStack.Viewport className="relative size-full overflow-visible !min-h-0 !pt-0">
+            <CardStack.List>
+              {(item, index, layer) => (
+                <CardStack.Card
+                  key={item.id}
+                  layer={layer}
+                  stackIndex={index}
+                  className="size-full gap-0 overflow-visible rounded-none bg-transparent p-0 shadow-none ring-0 [background-image:none]"
+                >
+                  <figure className="flex size-full flex-col border-0 bg-transparent p-0">
+                    <div className="relative min-h-0 w-full flex-1 overflow-hidden bg-black/5">
+                      <img
+                        src={item.image}
+                        alt={\`\${PHOTOGRAPHER.studio} — \${item.title}\`}
+                        width={PRINT_WIDTH}
+                        height={PRINT_HEIGHT}
+                        decoding="async"
+                        draggable={false}
+                        className="absolute inset-0 size-full object-cover object-center"
+                      />
+                      {index === 0 ? <ViewfinderFrame /> : null}
+                    </div>
+                  </figure>
+                </CardStack.Card>
+              )}
+            </CardStack.List>
+          </CardStack.Viewport>
+        </CardStack.Trigger>
+      </CardStack.Frame>
+      </div>
+    </figure>
+  );
+}
+
+function PortfolioLayout({
+  stackRef,
+  heroRef,
+  captionRef,
+}: {
+  stackRef: RefObject<HTMLElement | null>;
+  heroRef: RefObject<HTMLDivElement | null>;
+  captionRef: RefObject<HTMLDivElement | null>;
+}) {
+  return (
+    <div
+      className={cn(
+        "grid h-[calc(100svh-var(--demo-chrome-reserve,5rem))] min-h-0 grid-cols-1 grid-rows-[auto_minmax(18rem,1fr)]",
+        "md:grid-cols-[minmax(0,2fr)_minmax(0,3fr)] md:grid-rows-1",
+        LAYOUT.grid,
+        LAYOUT.blockY,
+      )}
+      style={{ "--layout-baseline": \`\${BASELINE}px\` } as CSSProperties}
+    >
+      <div className="flex min-h-0 flex-col justify-end md:col-start-1 md:row-start-1 md:pt-[clamp(3rem,11vh,8rem)]">
+        <div ref={heroRef} className="relative z-20 w-fit max-w-full bg-transparent">
+          <HeroStory />
+        </div>
+      </div>
+
+      <div className="relative z-20 flex min-h-0 min-w-0 flex-col overflow-visible md:col-start-2 md:row-start-1 md:h-full md:pl-6 md:pt-[clamp(3rem,11vh,8rem)] lg:pl-10">
+        <ProofStack stackRef={stackRef} captionRef={captionRef} />
+      </div>
+    </div>
+  );
+}
+
+export default function PhotographerPortfolio() {
+  const stackRef = useRef<HTMLElement>(null);
+  const heroRef = useRef<HTMLDivElement>(null);
+  const captionRef = useRef<HTMLDivElement>(null);
+  const [preloaderDone, setPreloaderDone] = useState(false);
+
+  return (
+    <>
+      <section
+        className="relative isolate min-h-[calc(100svh-var(--demo-chrome-reserve,5rem))] overflow-hidden"
+        style={{ backgroundColor: CANVAS, color: INK, fontFamily: FONT }}
+      >
+        <TrailingImage
+          edgeToEdge
+          layerOnly
+          contained
+          className="z-10 isolate"
+          images={TRAIL_IMAGES}
+          threshold={88}
+          maxTrailZIndex={12}
+          excludeRefs={[heroRef, captionRef]}
+        />
+
+        <CardStack
+          items={PORTFOLIO}
+          depth={3}
+          autoplay={preloaderDone}
+          autoplayInterval={4500}
+        >
+          <div
+            className={cn(
+              "relative z-20 isolate mx-auto min-h-[calc(100svh-var(--demo-chrome-reserve,5rem))] w-full max-w-[92rem] pb-[var(--demo-chrome-reserve,5rem)]",
+              LAYOUT.shell,
+            )}
+          >
+            <PortfolioLayout stackRef={stackRef} heroRef={heroRef} captionRef={captionRef} />
+          </div>
+        </CardStack>
+      </section>
+
+      <SplitReveal
+        images={PRELOAD_IMAGES}
+        backgroundColor={CANVAS}
+        foregroundColor={INK}
+        zIndex={120}
+        lockScroll
+        onComplete={() => setPreloaderDone(true)}
+        renderProgress={({ loaded, total, progress }) => (
+          <>
+            <SplitReveal.ProgressTrack progress={progress} foregroundColor={INK} />
+            <p className="mt-3 text-center text-[11px] font-medium uppercase tracking-[0.12em] text-black/45">
+              Loading frames
+              <span className="px-1.5 text-black/20">·</span>
+              {String(loaded).padStart(2, "0")}
+              <span className="text-black/20">/</span>
+              {String(total).padStart(2, "0")}
+            </p>
+          </>
+        )}
+      />
+
+      <PhotographerPortfolioNotes />
+    </>
+  );
+}
+`,
+      htmlLight: `<pre class="shiki github-light" tabindex="0"><code><span class="line"><span style="color:#032F62">"use client"</span><span style="color:#24292E">;</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#D73A49">import</span><span style="color:#032F62"> "@fontsource-variable/instrument-sans"</span><span style="color:#24292E">;</span></span>
+<span class="line"><span style="color:#D73A49">import</span><span style="color:#24292E"> { useRef, useState, </span><span style="color:#D73A49">type</span><span style="color:#24292E"> CSSProperties, </span><span style="color:#D73A49">type</span><span style="color:#24292E"> ReactNode, </span><span style="color:#D73A49">type</span><span style="color:#24292E"> RefObject } </span><span style="color:#D73A49">from</span><span style="color:#032F62"> "react"</span><span style="color:#24292E">;</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#D73A49">import</span><span style="color:#24292E"> CardStack, {</span></span>
+<span class="line"><span style="color:#24292E">  CARD_STACK_MASK_IDS,</span></span>
+<span class="line"><span style="color:#D73A49">  type</span><span style="color:#24292E"> CardStackItem,</span></span>
+<span class="line"><span style="color:#24292E">  useCardStack,</span></span>
+<span class="line"><span style="color:#24292E">} </span><span style="color:#D73A49">from</span><span style="color:#032F62"> "@/animata/card/card-stack"</span><span style="color:#24292E">;</span></span>
+<span class="line"><span style="color:#D73A49">import</span><span style="color:#24292E"> TrailingImage </span><span style="color:#D73A49">from</span><span style="color:#032F62"> "@/animata/image/trailing-image"</span><span style="color:#24292E">;</span></span>
+<span class="line"><span style="color:#D73A49">import</span><span style="color:#24292E"> SplitReveal </span><span style="color:#D73A49">from</span><span style="color:#032F62"> "@/animata/preloader/split-reveal"</span><span style="color:#24292E">;</span></span>
+<span class="line"><span style="color:#D73A49">import</span><span style="color:#24292E"> { MapPinIcon } </span><span style="color:#D73A49">from</span><span style="color:#032F62"> "@/components/ui/map-pin"</span><span style="color:#24292E">;</span></span>
+<span class="line"><span style="color:#D73A49">import</span><span style="color:#24292E"> { SwitchCameraIcon } </span><span style="color:#D73A49">from</span><span style="color:#032F62"> "@/components/ui/switch-camera"</span><span style="color:#24292E">;</span></span>
+<span class="line"><span style="color:#D73A49">import</span><span style="color:#24292E"> { cn } </span><span style="color:#D73A49">from</span><span style="color:#032F62"> "@/lib/utils"</span><span style="color:#24292E">;</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#D73A49">import</span><span style="color:#24292E"> { PhotographerPortfolioNotes } </span><span style="color:#D73A49">from</span><span style="color:#032F62"> "./photographer-portfolio-notes"</span><span style="color:#24292E">;</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#D73A49">const</span><span style="color:#005CC5"> FONT</span><span style="color:#D73A49"> =</span></span>
+<span class="line"><span style="color:#032F62">  '"Instrument Sans Variable", ui-sans-serif, system-ui, sans-serif'</span><span style="color:#24292E">;</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#D73A49">const</span><span style="color:#005CC5"> CANVAS</span><span style="color:#D73A49"> =</span><span style="color:#032F62"> "#fff"</span><span style="color:#24292E">;</span></span>
+<span class="line"><span style="color:#D73A49">const</span><span style="color:#005CC5"> INK</span><span style="color:#D73A49"> =</span><span style="color:#032F62"> "#000"</span><span style="color:#24292E">;</span></span>
+<span class="line"><span style="color:#D73A49">const</span><span style="color:#005CC5"> PRINT_WIDTH</span><span style="color:#D73A49"> =</span><span style="color:#005CC5"> 900</span><span style="color:#24292E">;</span></span>
+<span class="line"><span style="color:#D73A49">const</span><span style="color:#005CC5"> PRINT_HEIGHT</span><span style="color:#D73A49"> =</span><span style="color:#005CC5"> 1125</span><span style="color:#24292E">;</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#D73A49">const</span><span style="color:#6F42C1"> lummi</span><span style="color:#D73A49"> =</span><span style="color:#24292E"> (</span><span style="color:#E36209">assetId</span><span style="color:#D73A49">:</span><span style="color:#005CC5"> string</span><span style="color:#24292E">) </span><span style="color:#D73A49">=></span></span>
+<span class="line"><span style="color:#032F62">  \`https://assets.lummi.ai/assets/\${</span><span style="color:#24292E">assetId</span><span style="color:#032F62">}?auto=format&#x26;fit=crop&#x26;w=\${</span><span style="color:#005CC5">PRINT_WIDTH</span><span style="color:#032F62">}&#x26;h=\${</span><span style="color:#005CC5">PRINT_HEIGHT</span><span style="color:#032F62">}&#x26;q=85\`</span><span style="color:#24292E">;</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#6A737D">/** Wedding + event frames from https://lummi.ai — see demo notes for credits */</span></span>
+<span class="line"><span style="color:#D73A49">const</span><span style="color:#005CC5"> LUMMI_ASSETS</span><span style="color:#D73A49"> =</span><span style="color:#24292E"> {</span></span>
+<span class="line"><span style="color:#24292E">  avatar: </span><span style="color:#032F62">"QmXp6StB1i36XHbbmppop5AwtQgnyom8bYTZqPkLVNGJnk"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#24292E">  portfolio: {</span></span>
+<span class="line"><span style="color:#24292E">    vows: </span><span style="color:#032F62">"QmabCfDwG7NUco1UhMnAE7NiHSK63MNKmPxAA2mc8Xrh8j"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#24292E">    ceremony: </span><span style="color:#032F62">"QmS6CSjJ3hc82mvhNtYGWmcAZ1coJUdEkrAVmJ6PPEH2Q3"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#24292E">    reception: </span><span style="color:#032F62">"QmaCT6boTGzVxo9ii5JYcnAuakoVhso3esFDA9Y58Nm7Le"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#24292E">    candid: </span><span style="color:#032F62">"QmY8f1t5PS7b6fVhd6R7s1AFQMVERRKmgE8gNataeweAS4"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#24292E">    florals: </span><span style="color:#032F62">"QmYerGQMAkWiRYDyYMwVfZQSKy8FGy2Js4G83vf1vyBGdR"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#24292E">    festival: </span><span style="color:#032F62">"QmZnV56e2xNN5kqUWRVMupeiUExehkWKqo5X5ewgMpA19C"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#24292E">  },</span></span>
+<span class="line"><span style="color:#24292E">  trail: [</span></span>
+<span class="line"><span style="color:#032F62">    "QmVufjyFaAWjZYr4kdM8JLxr68EDky5V9YnwkhRbeD3jVb"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#032F62">    "QmTfDd4u2rHboSjREqrmM2AX8uamVhgURW5iKAJmTpe3Rz"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#032F62">    "QmcVMDiPtnnxCKgLCppm4iHQNp8L2zX8NF1xzV1Ch7nBtk"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#032F62">    "QmSXefvUey7N617ro5dG1mjRXFm9iUN5uUmwBTS63DEApS"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#032F62">    "QmVgzYXYEaShMjw87vVZZv1J7PjhaNKy92XY2uTrB59o9R"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#032F62">    "QmcioeKGZKuCeauwteg4DEu2edo6qe3HeK99Y9FywsYk8i"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#032F62">    "QmUB7fgmDhst3VZKU5R5uUkfvbcXvZ3FDKFvkNk5TkRvqD"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#032F62">    "QmeL2wx9Sdw4dGPawgxUBenthP9jt8ff8Ux4uog45NL95j"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#032F62">    "QmTXHjCens6Bg4Q7J4LjzU9fyKVec3t1ziqT32ShpXa93r"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#032F62">    "QmV1pUNAsa1orHnyBWFWki6qZvatRQpgbQnDCVdV1EzRGd"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#032F62">    "QmZAgYih2jUqmKJz4wUoTARdijpv7bveUFYrjvacV66KXp"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#032F62">    "QmQMun9ag4MrBC8man7bQC9xNupf4oCufwvCj2VpU7rXDi"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#24292E">  ],</span></span>
+<span class="line"><span style="color:#24292E">} </span><span style="color:#D73A49">as</span><span style="color:#D73A49"> const</span><span style="color:#24292E">;</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#D73A49">const</span><span style="color:#005CC5"> PHOTOGRAPHER</span><span style="color:#D73A49"> =</span><span style="color:#24292E"> {</span></span>
+<span class="line"><span style="color:#24292E">  studio: </span><span style="color:#032F62">"Maya Chen"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#24292E">  name: </span><span style="color:#032F62">"Maya"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#24292E">  location: </span><span style="color:#032F62">"Brooklyn"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#24292E">  email: </span><span style="color:#032F62">"mailto:hello@mayachen.studio"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#24292E">  avatar: </span><span style="color:#6F42C1">lummi</span><span style="color:#24292E">(</span><span style="color:#005CC5">LUMMI_ASSETS</span><span style="color:#24292E">.avatar),</span></span>
+<span class="line"><span style="color:#24292E">};</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#D73A49">const</span><span style="color:#005CC5"> TRAIL_IMAGES</span><span style="color:#D73A49"> =</span><span style="color:#005CC5"> LUMMI_ASSETS</span><span style="color:#24292E">.trail.</span><span style="color:#6F42C1">map</span><span style="color:#24292E">((</span><span style="color:#E36209">id</span><span style="color:#24292E">) </span><span style="color:#D73A49">=></span><span style="color:#6F42C1"> lummi</span><span style="color:#24292E">(id));</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#D73A49">const</span><span style="color:#005CC5"> SHOT_SETTINGS</span><span style="color:#D73A49">:</span><span style="color:#6F42C1"> Record</span><span style="color:#24292E">&#x3C;</span><span style="color:#005CC5">string</span><span style="color:#24292E">, { </span><span style="color:#E36209">aperture</span><span style="color:#D73A49">:</span><span style="color:#005CC5"> string</span><span style="color:#24292E">; </span><span style="color:#E36209">shutter</span><span style="color:#D73A49">:</span><span style="color:#005CC5"> string</span><span style="color:#24292E">; </span><span style="color:#E36209">stock</span><span style="color:#D73A49">:</span><span style="color:#005CC5"> string</span><span style="color:#24292E"> }> </span><span style="color:#D73A49">=</span><span style="color:#24292E"> {</span></span>
+<span class="line"><span style="color:#24292E">  vows: { aperture: </span><span style="color:#032F62">"2"</span><span style="color:#24292E">, shutter: </span><span style="color:#032F62">"1/500"</span><span style="color:#24292E">, stock: </span><span style="color:#032F62">"Portra 400"</span><span style="color:#24292E"> },</span></span>
+<span class="line"><span style="color:#24292E">  ceremony: { aperture: </span><span style="color:#032F62">"2.8"</span><span style="color:#24292E">, shutter: </span><span style="color:#032F62">"1/250"</span><span style="color:#24292E">, stock: </span><span style="color:#032F62">"Portra 160"</span><span style="color:#24292E"> },</span></span>
+<span class="line"><span style="color:#24292E">  reception: { aperture: </span><span style="color:#032F62">"2"</span><span style="color:#24292E">, shutter: </span><span style="color:#032F62">"1/125"</span><span style="color:#24292E">, stock: </span><span style="color:#032F62">"Portra 800"</span><span style="color:#24292E"> },</span></span>
+<span class="line"><span style="color:#24292E">  candid: { aperture: </span><span style="color:#032F62">"1.8"</span><span style="color:#24292E">, shutter: </span><span style="color:#032F62">"1/320"</span><span style="color:#24292E">, stock: </span><span style="color:#032F62">"Tri-X 400"</span><span style="color:#24292E"> },</span></span>
+<span class="line"><span style="color:#24292E">  florals: { aperture: </span><span style="color:#032F62">"4"</span><span style="color:#24292E">, shutter: </span><span style="color:#032F62">"1/200"</span><span style="color:#24292E">, stock: </span><span style="color:#032F62">"Ektar 100"</span><span style="color:#24292E"> },</span></span>
+<span class="line"><span style="color:#24292E">  festival: { aperture: </span><span style="color:#032F62">"2.8"</span><span style="color:#24292E">, shutter: </span><span style="color:#032F62">"1/160"</span><span style="color:#24292E">, stock: </span><span style="color:#032F62">"Portra 800"</span><span style="color:#24292E"> },</span></span>
+<span class="line"><span style="color:#24292E">};</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#D73A49">const</span><span style="color:#005CC5"> HERO_TONE</span><span style="color:#D73A49"> =</span><span style="color:#24292E"> {</span></span>
+<span class="line"><span style="color:#24292E">  mute: </span><span style="color:#032F62">"text-black/40"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#24292E">  ink: </span><span style="color:#032F62">"text-black"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#24292E">  accent: </span><span style="color:#032F62">"text-[#c2410c]"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#24292E">} </span><span style="color:#D73A49">as</span><span style="color:#D73A49"> const</span><span style="color:#24292E">;</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#D73A49">const</span><span style="color:#005CC5"> PORTFOLIO</span><span style="color:#D73A49">:</span><span style="color:#6F42C1"> CardStackItem</span><span style="color:#24292E">[] </span><span style="color:#D73A49">=</span><span style="color:#24292E"> [</span></span>
+<span class="line"><span style="color:#24292E">  {</span></span>
+<span class="line"><span style="color:#24292E">    id: </span><span style="color:#032F62">"vows"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#24292E">    image: </span><span style="color:#6F42C1">lummi</span><span style="color:#24292E">(</span><span style="color:#005CC5">LUMMI_ASSETS</span><span style="color:#24292E">.portfolio.vows),</span></span>
+<span class="line"><span style="color:#24292E">    title: </span><span style="color:#032F62">"Vows"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#24292E">    tagline: </span><span style="color:#032F62">"Cliffside ceremony"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#24292E">    counts: { like: </span><span style="color:#005CC5">0</span><span style="color:#24292E">, comment: </span><span style="color:#005CC5">0</span><span style="color:#24292E"> },</span></span>
+<span class="line"><span style="color:#24292E">    maskId: </span><span style="color:#005CC5">CARD_STACK_MASK_IDS</span><span style="color:#24292E">[</span><span style="color:#005CC5">0</span><span style="color:#24292E">],</span></span>
+<span class="line"><span style="color:#24292E">  },</span></span>
+<span class="line"><span style="color:#24292E">  {</span></span>
+<span class="line"><span style="color:#24292E">    id: </span><span style="color:#032F62">"ceremony"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#24292E">    image: </span><span style="color:#6F42C1">lummi</span><span style="color:#24292E">(</span><span style="color:#005CC5">LUMMI_ASSETS</span><span style="color:#24292E">.portfolio.ceremony),</span></span>
+<span class="line"><span style="color:#24292E">    title: </span><span style="color:#032F62">"Ceremony"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#24292E">    tagline: </span><span style="color:#032F62">"Church exit"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#24292E">    counts: { like: </span><span style="color:#005CC5">0</span><span style="color:#24292E">, comment: </span><span style="color:#005CC5">0</span><span style="color:#24292E"> },</span></span>
+<span class="line"><span style="color:#24292E">    maskId: </span><span style="color:#005CC5">CARD_STACK_MASK_IDS</span><span style="color:#24292E">[</span><span style="color:#005CC5">0</span><span style="color:#24292E">],</span></span>
+<span class="line"><span style="color:#24292E">  },</span></span>
+<span class="line"><span style="color:#24292E">  {</span></span>
+<span class="line"><span style="color:#24292E">    id: </span><span style="color:#032F62">"reception"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#24292E">    image: </span><span style="color:#6F42C1">lummi</span><span style="color:#24292E">(</span><span style="color:#005CC5">LUMMI_ASSETS</span><span style="color:#24292E">.portfolio.reception),</span></span>
+<span class="line"><span style="color:#24292E">    title: </span><span style="color:#032F62">"Reception"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#24292E">    tagline: </span><span style="color:#032F62">"Evening dance"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#24292E">    counts: { like: </span><span style="color:#005CC5">0</span><span style="color:#24292E">, comment: </span><span style="color:#005CC5">0</span><span style="color:#24292E"> },</span></span>
+<span class="line"><span style="color:#24292E">    maskId: </span><span style="color:#005CC5">CARD_STACK_MASK_IDS</span><span style="color:#24292E">[</span><span style="color:#005CC5">0</span><span style="color:#24292E">],</span></span>
+<span class="line"><span style="color:#24292E">  },</span></span>
+<span class="line"><span style="color:#24292E">  {</span></span>
+<span class="line"><span style="color:#24292E">    id: </span><span style="color:#032F62">"candid"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#24292E">    image: </span><span style="color:#6F42C1">lummi</span><span style="color:#24292E">(</span><span style="color:#005CC5">LUMMI_ASSETS</span><span style="color:#24292E">.portfolio.candid),</span></span>
+<span class="line"><span style="color:#24292E">    title: </span><span style="color:#032F62">"Candid"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#24292E">    tagline: </span><span style="color:#032F62">"Real laughter"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#24292E">    counts: { like: </span><span style="color:#005CC5">0</span><span style="color:#24292E">, comment: </span><span style="color:#005CC5">0</span><span style="color:#24292E"> },</span></span>
+<span class="line"><span style="color:#24292E">    maskId: </span><span style="color:#005CC5">CARD_STACK_MASK_IDS</span><span style="color:#24292E">[</span><span style="color:#005CC5">0</span><span style="color:#24292E">],</span></span>
+<span class="line"><span style="color:#24292E">  },</span></span>
+<span class="line"><span style="color:#24292E">  {</span></span>
+<span class="line"><span style="color:#24292E">    id: </span><span style="color:#032F62">"florals"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#24292E">    image: </span><span style="color:#6F42C1">lummi</span><span style="color:#24292E">(</span><span style="color:#005CC5">LUMMI_ASSETS</span><span style="color:#24292E">.portfolio.florals),</span></span>
+<span class="line"><span style="color:#24292E">    title: </span><span style="color:#032F62">"Florals"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#24292E">    tagline: </span><span style="color:#032F62">"Bouquet detail"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#24292E">    counts: { like: </span><span style="color:#005CC5">0</span><span style="color:#24292E">, comment: </span><span style="color:#005CC5">0</span><span style="color:#24292E"> },</span></span>
+<span class="line"><span style="color:#24292E">    maskId: </span><span style="color:#005CC5">CARD_STACK_MASK_IDS</span><span style="color:#24292E">[</span><span style="color:#005CC5">0</span><span style="color:#24292E">],</span></span>
+<span class="line"><span style="color:#24292E">  },</span></span>
+<span class="line"><span style="color:#24292E">  {</span></span>
+<span class="line"><span style="color:#24292E">    id: </span><span style="color:#032F62">"festival"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#24292E">    image: </span><span style="color:#6F42C1">lummi</span><span style="color:#24292E">(</span><span style="color:#005CC5">LUMMI_ASSETS</span><span style="color:#24292E">.portfolio.festival),</span></span>
+<span class="line"><span style="color:#24292E">    title: </span><span style="color:#032F62">"Event"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#24292E">    tagline: </span><span style="color:#032F62">"Summer festival"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#24292E">    counts: { like: </span><span style="color:#005CC5">0</span><span style="color:#24292E">, comment: </span><span style="color:#005CC5">0</span><span style="color:#24292E"> },</span></span>
+<span class="line"><span style="color:#24292E">    maskId: </span><span style="color:#005CC5">CARD_STACK_MASK_IDS</span><span style="color:#24292E">[</span><span style="color:#005CC5">0</span><span style="color:#24292E">],</span></span>
+<span class="line"><span style="color:#24292E">  },</span></span>
+<span class="line"><span style="color:#24292E">];</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#D73A49">const</span><span style="color:#005CC5"> PRELOAD_IMAGES</span><span style="color:#D73A49"> =</span><span style="color:#24292E"> [</span></span>
+<span class="line"><span style="color:#D73A49">  ...new</span><span style="color:#6F42C1"> Set</span><span style="color:#24292E">([</span></span>
+<span class="line"><span style="color:#005CC5">    PHOTOGRAPHER</span><span style="color:#24292E">.avatar,</span></span>
+<span class="line"><span style="color:#D73A49">    ...</span><span style="color:#005CC5">PORTFOLIO</span><span style="color:#24292E">.</span><span style="color:#6F42C1">map</span><span style="color:#24292E">((</span><span style="color:#E36209">item</span><span style="color:#24292E">) </span><span style="color:#D73A49">=></span><span style="color:#24292E"> item.image),</span></span>
+<span class="line"><span style="color:#D73A49">    ...</span><span style="color:#005CC5">TRAIL_IMAGES</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#24292E">  ]),</span></span>
+<span class="line"><span style="color:#24292E">];</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#D73A49">const</span><span style="color:#005CC5"> HERO_MARK</span><span style="color:#D73A49"> =</span></span>
+<span class="line"><span style="color:#032F62">  "mx-1 inline-flex size-[clamp(1.75rem,1.286em,2.25rem)] shrink-0 items-center justify-center align-middle"</span><span style="color:#24292E">;</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#D73A49">function</span><span style="color:#6F42C1"> HeroMark</span><span style="color:#24292E">({ </span><span style="color:#E36209">children</span><span style="color:#24292E">, </span><span style="color:#E36209">className</span><span style="color:#24292E"> }</span><span style="color:#D73A49">:</span><span style="color:#24292E"> { </span><span style="color:#E36209">children</span><span style="color:#D73A49">:</span><span style="color:#6F42C1"> ReactNode</span><span style="color:#24292E">; </span><span style="color:#E36209">className</span><span style="color:#D73A49">?:</span><span style="color:#005CC5"> string</span><span style="color:#24292E"> }) {</span></span>
+<span class="line"><span style="color:#D73A49">  return</span><span style="color:#24292E"> (</span></span>
+<span class="line"><span style="color:#24292E">    &#x3C;</span><span style="color:#22863A">span</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#6F42C1">cn</span><span style="color:#24292E">(</span><span style="color:#005CC5">HERO_MARK</span><span style="color:#24292E">, className)} </span><span style="color:#6F42C1">aria-hidden</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">      {children}</span></span>
+<span class="line"><span style="color:#24292E">    &#x3C;/</span><span style="color:#22863A">span</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">  );</span></span>
+<span class="line"><span style="color:#24292E">}</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#D73A49">function</span><span style="color:#6F42C1"> ProfileGlyph</span><span style="color:#24292E">({ </span><span style="color:#E36209">src</span><span style="color:#24292E">, </span><span style="color:#E36209">alt</span><span style="color:#24292E"> }</span><span style="color:#D73A49">:</span><span style="color:#24292E"> { </span><span style="color:#E36209">src</span><span style="color:#D73A49">:</span><span style="color:#005CC5"> string</span><span style="color:#24292E">; </span><span style="color:#E36209">alt</span><span style="color:#D73A49">:</span><span style="color:#005CC5"> string</span><span style="color:#24292E"> }) {</span></span>
+<span class="line"><span style="color:#D73A49">  return</span><span style="color:#24292E"> (</span></span>
+<span class="line"><span style="color:#24292E">    &#x3C;</span><span style="color:#22863A">span</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#6F42C1">cn</span><span style="color:#24292E">(</span><span style="color:#005CC5">HERO_MARK</span><span style="color:#24292E">, </span><span style="color:#032F62">"overflow-hidden rounded-full ring-1 ring-black/10"</span><span style="color:#24292E">)}></span></span>
+<span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#22863A">img</span><span style="color:#6F42C1"> src</span><span style="color:#D73A49">=</span><span style="color:#24292E">{src} </span><span style="color:#6F42C1">alt</span><span style="color:#D73A49">=</span><span style="color:#24292E">{alt} </span><span style="color:#6F42C1">className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"size-full object-cover"</span><span style="color:#6F42C1"> decoding</span><span style="color:#D73A49">=</span><span style="color:#032F62">"async"</span><span style="color:#24292E"> /></span></span>
+<span class="line"><span style="color:#24292E">    &#x3C;/</span><span style="color:#22863A">span</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">  );</span></span>
+<span class="line"><span style="color:#24292E">}</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#D73A49">function</span><span style="color:#6F42C1"> HeroStory</span><span style="color:#24292E">() {</span></span>
+<span class="line"><span style="color:#D73A49">  const</span><span style="color:#005CC5"> type</span><span style="color:#D73A49"> =</span></span>
+<span class="line"><span style="color:#032F62">    "text-[clamp(1.25rem,2vw,1.75rem)] font-medium leading-[1.55] tracking-[-0.02em]"</span><span style="color:#24292E">;</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#D73A49">  return</span><span style="color:#24292E"> (</span></span>
+<span class="line"><span style="color:#24292E">    &#x3C;</span><span style="color:#22863A">div</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"max-w-[min(100%,36rem)] space-y-6"</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#22863A">p</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{type}></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">span</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">HERO_TONE</span><span style="color:#24292E">.mute}>Hi, I'm &#x3C;/</span><span style="color:#22863A">span</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">span</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">HERO_TONE</span><span style="color:#24292E">.ink}>{</span><span style="color:#005CC5">PHOTOGRAPHER</span><span style="color:#24292E">.name}&#x3C;/</span><span style="color:#22863A">span</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#005CC5">ProfileGlyph</span><span style="color:#6F42C1"> src</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">PHOTOGRAPHER</span><span style="color:#24292E">.avatar} </span><span style="color:#6F42C1">alt</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">PHOTOGRAPHER</span><span style="color:#24292E">.studio} /></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">span</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">HERO_TONE</span><span style="color:#24292E">.mute}>. I shoot &#x3C;/</span><span style="color:#22863A">span</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#005CC5">HeroMark</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"text-black"</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">          &#x3C;</span><span style="color:#005CC5">SwitchCameraIcon</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"size-full [&#x26;_svg]:size-full"</span><span style="color:#24292E"> /></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;/</span><span style="color:#005CC5">HeroMark</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">span</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">HERO_TONE</span><span style="color:#24292E">.mute}> &#x3C;/</span><span style="color:#22863A">span</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">span</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">HERO_TONE</span><span style="color:#24292E">.ink}>weddings and events&#x3C;/</span><span style="color:#22863A">span</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">span</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">HERO_TONE</span><span style="color:#24292E">.mute}> in &#x3C;/</span><span style="color:#22863A">span</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#005CC5">HeroMark</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"text-black/55"</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">          &#x3C;</span><span style="color:#005CC5">MapPinIcon</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"size-full [&#x26;_svg]:size-full"</span><span style="color:#24292E"> /></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;/</span><span style="color:#005CC5">HeroMark</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">span</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">HERO_TONE</span><span style="color:#24292E">.mute}> &#x3C;/</span><span style="color:#22863A">span</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">span</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">HERO_TONE</span><span style="color:#24292E">.ink}>{</span><span style="color:#005CC5">PHOTOGRAPHER</span><span style="color:#24292E">.location}&#x3C;/</span><span style="color:#22863A">span</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">span</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">HERO_TONE</span><span style="color:#24292E">.mute}></span></span>
+<span class="line"><span style="color:#24292E">          {</span><span style="color:#032F62">" "</span><span style="color:#24292E">}</span></span>
+<span class="line"><span style="color:#24292E">          — good light, real moments, and photos that don't feel forced.</span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;/</span><span style="color:#22863A">span</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">      &#x3C;/</span><span style="color:#22863A">p</span><span style="color:#24292E">></span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#22863A">p</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{type}></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">span</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">HERO_TONE</span><span style="color:#24292E">.accent}>Booking Q3.&#x3C;/</span><span style="color:#22863A">span</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">span</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">HERO_TONE</span><span style="color:#24292E">.mute}> &#x3C;/</span><span style="color:#22863A">span</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">a</span></span>
+<span class="line"><span style="color:#6F42C1">          href</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">PHOTOGRAPHER</span><span style="color:#24292E">.email}</span></span>
+<span class="line"><span style="color:#6F42C1">          className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#6F42C1">cn</span><span style="color:#24292E">(</span><span style="color:#005CC5">HERO_TONE</span><span style="color:#24292E">.ink, </span><span style="color:#032F62">"underline-offset-[4px] hover:underline"</span><span style="color:#24292E">)}</span></span>
+<span class="line"><span style="color:#24292E">        ></span></span>
+<span class="line"><span style="color:#24292E">          Send me your date.</span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;/</span><span style="color:#22863A">a</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">      &#x3C;/</span><span style="color:#22863A">p</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">    &#x3C;/</span><span style="color:#22863A">div</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">  );</span></span>
+<span class="line"><span style="color:#24292E">}</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#D73A49">function</span><span style="color:#6F42C1"> ViewfinderFrame</span><span style="color:#24292E">() {</span></span>
+<span class="line"><span style="color:#D73A49">  const</span><span style="color:#005CC5"> corner</span><span style="color:#D73A49"> =</span><span style="color:#032F62"> "absolute size-4 border-white/80"</span><span style="color:#24292E">;</span></span>
+<span class="line"><span style="color:#D73A49">  return</span><span style="color:#24292E"> (</span></span>
+<span class="line"><span style="color:#24292E">    &#x3C;</span><span style="color:#22863A">div</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"pointer-events-none absolute inset-3 sm:inset-4"</span><span style="color:#6F42C1"> aria-hidden</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#22863A">span</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#6F42C1">cn</span><span style="color:#24292E">(corner, </span><span style="color:#032F62">"left-0 top-0 border-l-2 border-t-2"</span><span style="color:#24292E">)} /></span></span>
+<span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#22863A">span</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#6F42C1">cn</span><span style="color:#24292E">(corner, </span><span style="color:#032F62">"right-0 top-0 border-r-2 border-t-2"</span><span style="color:#24292E">)} /></span></span>
+<span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#22863A">span</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#6F42C1">cn</span><span style="color:#24292E">(corner, </span><span style="color:#032F62">"bottom-0 left-0 border-b-2 border-l-2"</span><span style="color:#24292E">)} /></span></span>
+<span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#22863A">span</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#6F42C1">cn</span><span style="color:#24292E">(corner, </span><span style="color:#032F62">"bottom-0 right-0 border-b-2 border-r-2"</span><span style="color:#24292E">)} /></span></span>
+<span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#22863A">div</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 opacity-[0.16]"</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">span</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"absolute left-1/2 top-1/2 h-px w-5 -translate-x-1/2 -translate-y-1/2 bg-white"</span><span style="color:#24292E"> /></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">span</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"absolute left-1/2 top-1/2 h-5 w-px -translate-x-1/2 -translate-y-1/2 bg-white"</span><span style="color:#24292E"> /></span></span>
+<span class="line"><span style="color:#24292E">      &#x3C;/</span><span style="color:#22863A">div</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">    &#x3C;/</span><span style="color:#22863A">div</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">  );</span></span>
+<span class="line"><span style="color:#24292E">}</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#D73A49">function</span><span style="color:#6F42C1"> PrintCaption</span><span style="color:#24292E">() {</span></span>
+<span class="line"><span style="color:#D73A49">  const</span><span style="color:#24292E"> { </span><span style="color:#005CC5">activeItem</span><span style="color:#24292E"> } </span><span style="color:#D73A49">=</span><span style="color:#6F42C1"> useCardStack</span><span style="color:#24292E">();</span></span>
+<span class="line"><span style="color:#D73A49">  const</span><span style="color:#005CC5"> index</span><span style="color:#D73A49"> =</span><span style="color:#24292E"> activeItem </span><span style="color:#D73A49">?</span><span style="color:#005CC5"> PORTFOLIO</span><span style="color:#24292E">.</span><span style="color:#6F42C1">findIndex</span><span style="color:#24292E">((</span><span style="color:#E36209">item</span><span style="color:#24292E">) </span><span style="color:#D73A49">=></span><span style="color:#24292E"> item.id </span><span style="color:#D73A49">===</span><span style="color:#24292E"> activeItem.id) </span><span style="color:#D73A49">+</span><span style="color:#005CC5"> 1</span><span style="color:#D73A49"> :</span><span style="color:#005CC5"> 1</span><span style="color:#24292E">;</span></span>
+<span class="line"><span style="color:#D73A49">  const</span><span style="color:#005CC5"> settings</span><span style="color:#D73A49"> =</span><span style="color:#24292E"> activeItem </span><span style="color:#D73A49">?</span><span style="color:#005CC5"> SHOT_SETTINGS</span><span style="color:#24292E">[activeItem.id] </span><span style="color:#D73A49">:</span><span style="color:#005CC5"> SHOT_SETTINGS</span><span style="color:#24292E">.vows;</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#D73A49">  if</span><span style="color:#24292E"> (</span><span style="color:#D73A49">!</span><span style="color:#24292E">activeItem </span><span style="color:#D73A49">||</span><span style="color:#D73A49"> !</span><span style="color:#24292E">settings) {</span></span>
+<span class="line"><span style="color:#D73A49">    return</span><span style="color:#005CC5"> null</span><span style="color:#24292E">;</span></span>
+<span class="line"><span style="color:#24292E">  }</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#D73A49">  return</span><span style="color:#24292E"> (</span></span>
+<span class="line"><span style="color:#24292E">    &#x3C;</span><span style="color:#22863A">figcaption</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"relative z-10 shrink-0 border-b border-black/80 bg-transparent pb-3"</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#22863A">div</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"flex items-baseline justify-between gap-4"</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">p</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"text-[11px] font-medium uppercase tracking-[0.1em] text-black"</span><span style="color:#24292E">>{activeItem.title}&#x3C;/</span><span style="color:#22863A">p</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">p</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"shrink-0 text-[11px] font-medium tabular-nums tracking-[0.1em] text-black/45"</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">          {</span><span style="color:#6F42C1">String</span><span style="color:#24292E">(index).</span><span style="color:#6F42C1">padStart</span><span style="color:#24292E">(</span><span style="color:#005CC5">2</span><span style="color:#24292E">, </span><span style="color:#032F62">"0"</span><span style="color:#24292E">)}</span></span>
+<span class="line"><span style="color:#24292E">          &#x3C;</span><span style="color:#22863A">span</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"text-black/20"</span><span style="color:#24292E">>/&#x3C;/</span><span style="color:#22863A">span</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">          {</span><span style="color:#6F42C1">String</span><span style="color:#24292E">(</span><span style="color:#005CC5">PORTFOLIO</span><span style="color:#24292E">.</span><span style="color:#005CC5">length</span><span style="color:#24292E">).</span><span style="color:#6F42C1">padStart</span><span style="color:#24292E">(</span><span style="color:#005CC5">2</span><span style="color:#24292E">, </span><span style="color:#032F62">"0"</span><span style="color:#24292E">)}</span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;/</span><span style="color:#22863A">p</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">      &#x3C;/</span><span style="color:#22863A">div</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#22863A">p</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"mt-2 text-[11px] font-medium uppercase tracking-[0.1em] text-black/45"</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">        ƒ/{settings.aperture}</span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">span</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"px-1.5 text-black/20"</span><span style="color:#24292E">>·&#x3C;/</span><span style="color:#22863A">span</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">        {settings.shutter}</span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">span</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"px-1.5 text-black/20"</span><span style="color:#24292E">>·&#x3C;/</span><span style="color:#22863A">span</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">        {settings.stock}</span></span>
+<span class="line"><span style="color:#24292E">      &#x3C;/</span><span style="color:#22863A">p</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">    &#x3C;/</span><span style="color:#22863A">figcaption</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">  );</span></span>
+<span class="line"><span style="color:#24292E">}</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#D73A49">const</span><span style="color:#005CC5"> BASELINE</span><span style="color:#D73A49"> =</span><span style="color:#005CC5"> 8</span><span style="color:#24292E">;</span></span>
+<span class="line"><span style="color:#D73A49">const</span><span style="color:#005CC5"> LAYOUT</span><span style="color:#D73A49"> =</span><span style="color:#24292E"> {</span></span>
+<span class="line"><span style="color:#24292E">  shell: </span><span style="color:#032F62">"px-6 sm:px-10 lg:px-14"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#24292E">  blockY: </span><span style="color:#032F62">"py-8 lg:py-10"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#24292E">  grid: </span><span style="color:#032F62">"gap-x-8 gap-y-8 lg:gap-x-10 lg:gap-y-10"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#24292E">} </span><span style="color:#D73A49">as</span><span style="color:#D73A49"> const</span><span style="color:#24292E">;</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#D73A49">function</span><span style="color:#6F42C1"> ProofStack</span><span style="color:#24292E">({</span></span>
+<span class="line"><span style="color:#E36209">  stackRef</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#E36209">  captionRef</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#24292E">}</span><span style="color:#D73A49">:</span><span style="color:#24292E"> {</span></span>
+<span class="line"><span style="color:#E36209">  stackRef</span><span style="color:#D73A49">:</span><span style="color:#6F42C1"> RefObject</span><span style="color:#24292E">&#x3C;</span><span style="color:#6F42C1">HTMLElement</span><span style="color:#D73A49"> |</span><span style="color:#005CC5"> null</span><span style="color:#24292E">>;</span></span>
+<span class="line"><span style="color:#E36209">  captionRef</span><span style="color:#D73A49">:</span><span style="color:#6F42C1"> RefObject</span><span style="color:#24292E">&#x3C;</span><span style="color:#6F42C1">HTMLDivElement</span><span style="color:#D73A49"> |</span><span style="color:#005CC5"> null</span><span style="color:#24292E">>;</span></span>
+<span class="line"><span style="color:#24292E">}) {</span></span>
+<span class="line"><span style="color:#D73A49">  return</span><span style="color:#24292E"> (</span></span>
+<span class="line"><span style="color:#24292E">    &#x3C;</span><span style="color:#22863A">figure</span></span>
+<span class="line"><span style="color:#6F42C1">      ref</span><span style="color:#D73A49">=</span><span style="color:#24292E">{stackRef}</span></span>
+<span class="line"><span style="color:#6F42C1">      className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"ml-auto grid h-full min-h-0 w-full min-w-0 max-w-full grid-rows-[auto_minmax(0,1fr)] gap-y-3 sm:gap-y-4"</span></span>
+<span class="line"><span style="color:#24292E">    ></span></span>
+<span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#22863A">div</span><span style="color:#6F42C1"> ref</span><span style="color:#D73A49">=</span><span style="color:#24292E">{captionRef} </span><span style="color:#6F42C1">className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"relative z-30 w-full shrink-0 bg-transparent"</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#005CC5">PrintCaption</span><span style="color:#24292E"> /></span></span>
+<span class="line"><span style="color:#24292E">      &#x3C;/</span><span style="color:#22863A">div</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#22863A">div</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"@container/stack relative flex min-h-0 flex-1 items-end justify-end pt-[max(2.5rem,11%)]"</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#005CC5">CardStack.Frame</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"relative aspect-[4/5] h-auto w-[min(100cqw,calc(100cqh*4/5))] max-h-full min-h-0 shrink-0 overflow-visible"</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">          &#x3C;</span><span style="color:#005CC5">CardStack.LiveRegion</span><span style="color:#24292E"> /></span></span>
+<span class="line"><span style="color:#24292E">          &#x3C;</span><span style="color:#005CC5">CardStack.Trigger</span><span style="color:#6F42C1"> aria-label</span><span style="color:#D73A49">=</span><span style="color:#032F62">"Show next photo"</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"block size-full text-left"</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">            &#x3C;</span><span style="color:#005CC5">CardStack.Viewport</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"relative size-full overflow-visible !min-h-0 !pt-0"</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">            &#x3C;</span><span style="color:#005CC5">CardStack.List</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">              {(</span><span style="color:#E36209">item</span><span style="color:#24292E">, </span><span style="color:#E36209">index</span><span style="color:#24292E">, </span><span style="color:#E36209">layer</span><span style="color:#24292E">) </span><span style="color:#D73A49">=></span><span style="color:#24292E"> (</span></span>
+<span class="line"><span style="color:#24292E">                &#x3C;</span><span style="color:#005CC5">CardStack.Card</span></span>
+<span class="line"><span style="color:#6F42C1">                  key</span><span style="color:#D73A49">=</span><span style="color:#24292E">{item.id}</span></span>
+<span class="line"><span style="color:#6F42C1">                  layer</span><span style="color:#D73A49">=</span><span style="color:#24292E">{layer}</span></span>
+<span class="line"><span style="color:#6F42C1">                  stackIndex</span><span style="color:#D73A49">=</span><span style="color:#24292E">{index}</span></span>
+<span class="line"><span style="color:#6F42C1">                  className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"size-full gap-0 overflow-visible rounded-none bg-transparent p-0 shadow-none ring-0 [background-image:none]"</span></span>
+<span class="line"><span style="color:#24292E">                ></span></span>
+<span class="line"><span style="color:#24292E">                  &#x3C;</span><span style="color:#22863A">figure</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"flex size-full flex-col border-0 bg-transparent p-0"</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">                    &#x3C;</span><span style="color:#22863A">div</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"relative min-h-0 w-full flex-1 overflow-hidden bg-black/5"</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">                      &#x3C;</span><span style="color:#22863A">img</span></span>
+<span class="line"><span style="color:#6F42C1">                        src</span><span style="color:#D73A49">=</span><span style="color:#24292E">{item.image}</span></span>
+<span class="line"><span style="color:#6F42C1">                        alt</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#032F62">\`\${</span><span style="color:#005CC5">PHOTOGRAPHER</span><span style="color:#032F62">.</span><span style="color:#24292E">studio</span><span style="color:#032F62">} — \${</span><span style="color:#24292E">item</span><span style="color:#032F62">.</span><span style="color:#24292E">title</span><span style="color:#032F62">}\`</span><span style="color:#24292E">}</span></span>
+<span class="line"><span style="color:#6F42C1">                        width</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">PRINT_WIDTH</span><span style="color:#24292E">}</span></span>
+<span class="line"><span style="color:#6F42C1">                        height</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">PRINT_HEIGHT</span><span style="color:#24292E">}</span></span>
+<span class="line"><span style="color:#6F42C1">                        decoding</span><span style="color:#D73A49">=</span><span style="color:#032F62">"async"</span></span>
+<span class="line"><span style="color:#6F42C1">                        draggable</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">false</span><span style="color:#24292E">}</span></span>
+<span class="line"><span style="color:#6F42C1">                        className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"absolute inset-0 size-full object-cover object-center"</span></span>
+<span class="line"><span style="color:#24292E">                      /></span></span>
+<span class="line"><span style="color:#24292E">                      {index </span><span style="color:#D73A49">===</span><span style="color:#005CC5"> 0</span><span style="color:#D73A49"> ?</span><span style="color:#24292E"> &#x3C;</span><span style="color:#005CC5">ViewfinderFrame</span><span style="color:#24292E"> /> </span><span style="color:#D73A49">:</span><span style="color:#005CC5"> null</span><span style="color:#24292E">}</span></span>
+<span class="line"><span style="color:#24292E">                    &#x3C;/</span><span style="color:#22863A">div</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">                  &#x3C;/</span><span style="color:#22863A">figure</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">                &#x3C;/</span><span style="color:#005CC5">CardStack.Card</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">              )}</span></span>
+<span class="line"><span style="color:#24292E">            &#x3C;/</span><span style="color:#005CC5">CardStack.List</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">          &#x3C;/</span><span style="color:#005CC5">CardStack.Viewport</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;/</span><span style="color:#005CC5">CardStack.Trigger</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">      &#x3C;/</span><span style="color:#005CC5">CardStack.Frame</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">      &#x3C;/</span><span style="color:#22863A">div</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">    &#x3C;/</span><span style="color:#22863A">figure</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">  );</span></span>
+<span class="line"><span style="color:#24292E">}</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#D73A49">function</span><span style="color:#6F42C1"> PortfolioLayout</span><span style="color:#24292E">({</span></span>
+<span class="line"><span style="color:#E36209">  stackRef</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#E36209">  heroRef</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#E36209">  captionRef</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#24292E">}</span><span style="color:#D73A49">:</span><span style="color:#24292E"> {</span></span>
+<span class="line"><span style="color:#E36209">  stackRef</span><span style="color:#D73A49">:</span><span style="color:#6F42C1"> RefObject</span><span style="color:#24292E">&#x3C;</span><span style="color:#6F42C1">HTMLElement</span><span style="color:#D73A49"> |</span><span style="color:#005CC5"> null</span><span style="color:#24292E">>;</span></span>
+<span class="line"><span style="color:#E36209">  heroRef</span><span style="color:#D73A49">:</span><span style="color:#6F42C1"> RefObject</span><span style="color:#24292E">&#x3C;</span><span style="color:#6F42C1">HTMLDivElement</span><span style="color:#D73A49"> |</span><span style="color:#005CC5"> null</span><span style="color:#24292E">>;</span></span>
+<span class="line"><span style="color:#E36209">  captionRef</span><span style="color:#D73A49">:</span><span style="color:#6F42C1"> RefObject</span><span style="color:#24292E">&#x3C;</span><span style="color:#6F42C1">HTMLDivElement</span><span style="color:#D73A49"> |</span><span style="color:#005CC5"> null</span><span style="color:#24292E">>;</span></span>
+<span class="line"><span style="color:#24292E">}) {</span></span>
+<span class="line"><span style="color:#D73A49">  return</span><span style="color:#24292E"> (</span></span>
+<span class="line"><span style="color:#24292E">    &#x3C;</span><span style="color:#22863A">div</span></span>
+<span class="line"><span style="color:#6F42C1">      className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#6F42C1">cn</span><span style="color:#24292E">(</span></span>
+<span class="line"><span style="color:#032F62">        "grid h-[calc(100svh-var(--demo-chrome-reserve,5rem))] min-h-0 grid-cols-1 grid-rows-[auto_minmax(18rem,1fr)]"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#032F62">        "md:grid-cols-[minmax(0,2fr)_minmax(0,3fr)] md:grid-rows-1"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#005CC5">        LAYOUT</span><span style="color:#24292E">.grid,</span></span>
+<span class="line"><span style="color:#005CC5">        LAYOUT</span><span style="color:#24292E">.blockY,</span></span>
+<span class="line"><span style="color:#24292E">      )}</span></span>
+<span class="line"><span style="color:#6F42C1">      style</span><span style="color:#D73A49">=</span><span style="color:#24292E">{{ </span><span style="color:#032F62">"--layout-baseline"</span><span style="color:#24292E">: </span><span style="color:#032F62">\`\${</span><span style="color:#005CC5">BASELINE</span><span style="color:#032F62">}px\`</span><span style="color:#24292E"> } </span><span style="color:#D73A49">as</span><span style="color:#6F42C1"> CSSProperties</span><span style="color:#24292E">}</span></span>
+<span class="line"><span style="color:#24292E">    ></span></span>
+<span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#22863A">div</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"flex min-h-0 flex-col justify-end md:col-start-1 md:row-start-1 md:pt-[clamp(3rem,11vh,8rem)]"</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#22863A">div</span><span style="color:#6F42C1"> ref</span><span style="color:#D73A49">=</span><span style="color:#24292E">{heroRef} </span><span style="color:#6F42C1">className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"relative z-20 w-fit max-w-full bg-transparent"</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">          &#x3C;</span><span style="color:#005CC5">HeroStory</span><span style="color:#24292E"> /></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;/</span><span style="color:#22863A">div</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">      &#x3C;/</span><span style="color:#22863A">div</span><span style="color:#24292E">></span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#22863A">div</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"relative z-20 flex min-h-0 min-w-0 flex-col overflow-visible md:col-start-2 md:row-start-1 md:h-full md:pl-6 md:pt-[clamp(3rem,11vh,8rem)] lg:pl-10"</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#005CC5">ProofStack</span><span style="color:#6F42C1"> stackRef</span><span style="color:#D73A49">=</span><span style="color:#24292E">{stackRef} </span><span style="color:#6F42C1">captionRef</span><span style="color:#D73A49">=</span><span style="color:#24292E">{captionRef} /></span></span>
+<span class="line"><span style="color:#24292E">      &#x3C;/</span><span style="color:#22863A">div</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">    &#x3C;/</span><span style="color:#22863A">div</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">  );</span></span>
+<span class="line"><span style="color:#24292E">}</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#D73A49">export</span><span style="color:#D73A49"> default</span><span style="color:#D73A49"> function</span><span style="color:#6F42C1"> PhotographerPortfolio</span><span style="color:#24292E">() {</span></span>
+<span class="line"><span style="color:#D73A49">  const</span><span style="color:#005CC5"> stackRef</span><span style="color:#D73A49"> =</span><span style="color:#6F42C1"> useRef</span><span style="color:#24292E">&#x3C;</span><span style="color:#6F42C1">HTMLElement</span><span style="color:#24292E">>(</span><span style="color:#005CC5">null</span><span style="color:#24292E">);</span></span>
+<span class="line"><span style="color:#D73A49">  const</span><span style="color:#005CC5"> heroRef</span><span style="color:#D73A49"> =</span><span style="color:#6F42C1"> useRef</span><span style="color:#24292E">&#x3C;</span><span style="color:#6F42C1">HTMLDivElement</span><span style="color:#24292E">>(</span><span style="color:#005CC5">null</span><span style="color:#24292E">);</span></span>
+<span class="line"><span style="color:#D73A49">  const</span><span style="color:#005CC5"> captionRef</span><span style="color:#D73A49"> =</span><span style="color:#6F42C1"> useRef</span><span style="color:#24292E">&#x3C;</span><span style="color:#6F42C1">HTMLDivElement</span><span style="color:#24292E">>(</span><span style="color:#005CC5">null</span><span style="color:#24292E">);</span></span>
+<span class="line"><span style="color:#D73A49">  const</span><span style="color:#24292E"> [</span><span style="color:#005CC5">preloaderDone</span><span style="color:#24292E">, </span><span style="color:#005CC5">setPreloaderDone</span><span style="color:#24292E">] </span><span style="color:#D73A49">=</span><span style="color:#6F42C1"> useState</span><span style="color:#24292E">(</span><span style="color:#005CC5">false</span><span style="color:#24292E">);</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#D73A49">  return</span><span style="color:#24292E"> (</span></span>
+<span class="line"><span style="color:#24292E">    &#x3C;></span></span>
+<span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#22863A">section</span></span>
+<span class="line"><span style="color:#6F42C1">        className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"relative isolate min-h-[calc(100svh-var(--demo-chrome-reserve,5rem))] overflow-hidden"</span></span>
+<span class="line"><span style="color:#6F42C1">        style</span><span style="color:#D73A49">=</span><span style="color:#24292E">{{ backgroundColor: </span><span style="color:#005CC5">CANVAS</span><span style="color:#24292E">, color: </span><span style="color:#005CC5">INK</span><span style="color:#24292E">, fontFamily: </span><span style="color:#005CC5">FONT</span><span style="color:#24292E"> }}</span></span>
+<span class="line"><span style="color:#24292E">      ></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#005CC5">TrailingImage</span></span>
+<span class="line"><span style="color:#6F42C1">          edgeToEdge</span></span>
+<span class="line"><span style="color:#6F42C1">          layerOnly</span></span>
+<span class="line"><span style="color:#6F42C1">          contained</span></span>
+<span class="line"><span style="color:#6F42C1">          className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"z-10 isolate"</span></span>
+<span class="line"><span style="color:#6F42C1">          images</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">TRAIL_IMAGES</span><span style="color:#24292E">}</span></span>
+<span class="line"><span style="color:#6F42C1">          threshold</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">88</span><span style="color:#24292E">}</span></span>
+<span class="line"><span style="color:#6F42C1">          maxTrailZIndex</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">12</span><span style="color:#24292E">}</span></span>
+<span class="line"><span style="color:#6F42C1">          excludeRefs</span><span style="color:#D73A49">=</span><span style="color:#24292E">{[heroRef, captionRef]}</span></span>
+<span class="line"><span style="color:#24292E">        /></span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#005CC5">CardStack</span></span>
+<span class="line"><span style="color:#6F42C1">          items</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">PORTFOLIO</span><span style="color:#24292E">}</span></span>
+<span class="line"><span style="color:#6F42C1">          depth</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">3</span><span style="color:#24292E">}</span></span>
+<span class="line"><span style="color:#6F42C1">          autoplay</span><span style="color:#D73A49">=</span><span style="color:#24292E">{preloaderDone}</span></span>
+<span class="line"><span style="color:#6F42C1">          autoplayInterval</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">4500</span><span style="color:#24292E">}</span></span>
+<span class="line"><span style="color:#24292E">        ></span></span>
+<span class="line"><span style="color:#24292E">          &#x3C;</span><span style="color:#22863A">div</span></span>
+<span class="line"><span style="color:#6F42C1">            className</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#6F42C1">cn</span><span style="color:#24292E">(</span></span>
+<span class="line"><span style="color:#032F62">              "relative z-20 isolate mx-auto min-h-[calc(100svh-var(--demo-chrome-reserve,5rem))] w-full max-w-[92rem] pb-[var(--demo-chrome-reserve,5rem)]"</span><span style="color:#24292E">,</span></span>
+<span class="line"><span style="color:#005CC5">              LAYOUT</span><span style="color:#24292E">.shell,</span></span>
+<span class="line"><span style="color:#24292E">            )}</span></span>
+<span class="line"><span style="color:#24292E">          ></span></span>
+<span class="line"><span style="color:#24292E">            &#x3C;</span><span style="color:#005CC5">PortfolioLayout</span><span style="color:#6F42C1"> stackRef</span><span style="color:#D73A49">=</span><span style="color:#24292E">{stackRef} </span><span style="color:#6F42C1">heroRef</span><span style="color:#D73A49">=</span><span style="color:#24292E">{heroRef} </span><span style="color:#6F42C1">captionRef</span><span style="color:#D73A49">=</span><span style="color:#24292E">{captionRef} /></span></span>
+<span class="line"><span style="color:#24292E">          &#x3C;/</span><span style="color:#22863A">div</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;/</span><span style="color:#005CC5">CardStack</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">      &#x3C;/</span><span style="color:#22863A">section</span><span style="color:#24292E">></span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#005CC5">SplitReveal</span></span>
+<span class="line"><span style="color:#6F42C1">        images</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">PRELOAD_IMAGES</span><span style="color:#24292E">}</span></span>
+<span class="line"><span style="color:#6F42C1">        backgroundColor</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">CANVAS</span><span style="color:#24292E">}</span></span>
+<span class="line"><span style="color:#6F42C1">        foregroundColor</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">INK</span><span style="color:#24292E">}</span></span>
+<span class="line"><span style="color:#6F42C1">        zIndex</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">120</span><span style="color:#24292E">}</span></span>
+<span class="line"><span style="color:#6F42C1">        lockScroll</span></span>
+<span class="line"><span style="color:#6F42C1">        onComplete</span><span style="color:#D73A49">=</span><span style="color:#24292E">{() </span><span style="color:#D73A49">=></span><span style="color:#6F42C1"> setPreloaderDone</span><span style="color:#24292E">(</span><span style="color:#005CC5">true</span><span style="color:#24292E">)}</span></span>
+<span class="line"><span style="color:#6F42C1">        renderProgress</span><span style="color:#D73A49">=</span><span style="color:#24292E">{({ </span><span style="color:#E36209">loaded</span><span style="color:#24292E">, </span><span style="color:#E36209">total</span><span style="color:#24292E">, </span><span style="color:#E36209">progress</span><span style="color:#24292E"> }) </span><span style="color:#D73A49">=></span><span style="color:#24292E"> (</span></span>
+<span class="line"><span style="color:#24292E">          &#x3C;></span></span>
+<span class="line"><span style="color:#24292E">            &#x3C;</span><span style="color:#005CC5">SplitReveal.ProgressTrack</span><span style="color:#6F42C1"> progress</span><span style="color:#D73A49">=</span><span style="color:#24292E">{progress} </span><span style="color:#6F42C1">foregroundColor</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">INK</span><span style="color:#24292E">} /></span></span>
+<span class="line"><span style="color:#24292E">            &#x3C;</span><span style="color:#22863A">p</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"mt-3 text-center text-[11px] font-medium uppercase tracking-[0.12em] text-black/45"</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">              Loading frames</span></span>
+<span class="line"><span style="color:#24292E">              &#x3C;</span><span style="color:#22863A">span</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"px-1.5 text-black/20"</span><span style="color:#24292E">>·&#x3C;/</span><span style="color:#22863A">span</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">              {</span><span style="color:#6F42C1">String</span><span style="color:#24292E">(loaded).</span><span style="color:#6F42C1">padStart</span><span style="color:#24292E">(</span><span style="color:#005CC5">2</span><span style="color:#24292E">, </span><span style="color:#032F62">"0"</span><span style="color:#24292E">)}</span></span>
+<span class="line"><span style="color:#24292E">              &#x3C;</span><span style="color:#22863A">span</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"text-black/20"</span><span style="color:#24292E">>/&#x3C;/</span><span style="color:#22863A">span</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">              {</span><span style="color:#6F42C1">String</span><span style="color:#24292E">(total).</span><span style="color:#6F42C1">padStart</span><span style="color:#24292E">(</span><span style="color:#005CC5">2</span><span style="color:#24292E">, </span><span style="color:#032F62">"0"</span><span style="color:#24292E">)}</span></span>
+<span class="line"><span style="color:#24292E">            &#x3C;/</span><span style="color:#22863A">p</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">          &#x3C;/></span></span>
+<span class="line"><span style="color:#24292E">        )}</span></span>
+<span class="line"><span style="color:#24292E">      /></span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#005CC5">PhotographerPortfolioNotes</span><span style="color:#24292E"> /></span></span>
+<span class="line"><span style="color:#24292E">    &#x3C;/></span></span>
+<span class="line"><span style="color:#24292E">  );</span></span>
+<span class="line"><span style="color:#24292E">}</span></span>
+<span class="line"></span></code></pre>`,
+      htmlDark: `<pre class="shiki github-dark" tabindex="0"><code><span class="line"><span style="color:#9ECBFF">"use client"</span><span style="color:#E1E4E8">;</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#F97583">import</span><span style="color:#9ECBFF"> "@fontsource-variable/instrument-sans"</span><span style="color:#E1E4E8">;</span></span>
+<span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> { useRef, useState, </span><span style="color:#F97583">type</span><span style="color:#E1E4E8"> CSSProperties, </span><span style="color:#F97583">type</span><span style="color:#E1E4E8"> ReactNode, </span><span style="color:#F97583">type</span><span style="color:#E1E4E8"> RefObject } </span><span style="color:#F97583">from</span><span style="color:#9ECBFF"> "react"</span><span style="color:#E1E4E8">;</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> CardStack, {</span></span>
+<span class="line"><span style="color:#E1E4E8">  CARD_STACK_MASK_IDS,</span></span>
+<span class="line"><span style="color:#F97583">  type</span><span style="color:#E1E4E8"> CardStackItem,</span></span>
+<span class="line"><span style="color:#E1E4E8">  useCardStack,</span></span>
+<span class="line"><span style="color:#E1E4E8">} </span><span style="color:#F97583">from</span><span style="color:#9ECBFF"> "@/animata/card/card-stack"</span><span style="color:#E1E4E8">;</span></span>
+<span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> TrailingImage </span><span style="color:#F97583">from</span><span style="color:#9ECBFF"> "@/animata/image/trailing-image"</span><span style="color:#E1E4E8">;</span></span>
+<span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> SplitReveal </span><span style="color:#F97583">from</span><span style="color:#9ECBFF"> "@/animata/preloader/split-reveal"</span><span style="color:#E1E4E8">;</span></span>
+<span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> { MapPinIcon } </span><span style="color:#F97583">from</span><span style="color:#9ECBFF"> "@/components/ui/map-pin"</span><span style="color:#E1E4E8">;</span></span>
+<span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> { SwitchCameraIcon } </span><span style="color:#F97583">from</span><span style="color:#9ECBFF"> "@/components/ui/switch-camera"</span><span style="color:#E1E4E8">;</span></span>
+<span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> { cn } </span><span style="color:#F97583">from</span><span style="color:#9ECBFF"> "@/lib/utils"</span><span style="color:#E1E4E8">;</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> { PhotographerPortfolioNotes } </span><span style="color:#F97583">from</span><span style="color:#9ECBFF"> "./photographer-portfolio-notes"</span><span style="color:#E1E4E8">;</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#F97583">const</span><span style="color:#79B8FF"> FONT</span><span style="color:#F97583"> =</span></span>
+<span class="line"><span style="color:#9ECBFF">  '"Instrument Sans Variable", ui-sans-serif, system-ui, sans-serif'</span><span style="color:#E1E4E8">;</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#F97583">const</span><span style="color:#79B8FF"> CANVAS</span><span style="color:#F97583"> =</span><span style="color:#9ECBFF"> "#fff"</span><span style="color:#E1E4E8">;</span></span>
+<span class="line"><span style="color:#F97583">const</span><span style="color:#79B8FF"> INK</span><span style="color:#F97583"> =</span><span style="color:#9ECBFF"> "#000"</span><span style="color:#E1E4E8">;</span></span>
+<span class="line"><span style="color:#F97583">const</span><span style="color:#79B8FF"> PRINT_WIDTH</span><span style="color:#F97583"> =</span><span style="color:#79B8FF"> 900</span><span style="color:#E1E4E8">;</span></span>
+<span class="line"><span style="color:#F97583">const</span><span style="color:#79B8FF"> PRINT_HEIGHT</span><span style="color:#F97583"> =</span><span style="color:#79B8FF"> 1125</span><span style="color:#E1E4E8">;</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#F97583">const</span><span style="color:#B392F0"> lummi</span><span style="color:#F97583"> =</span><span style="color:#E1E4E8"> (</span><span style="color:#FFAB70">assetId</span><span style="color:#F97583">:</span><span style="color:#79B8FF"> string</span><span style="color:#E1E4E8">) </span><span style="color:#F97583">=></span></span>
+<span class="line"><span style="color:#9ECBFF">  \`https://assets.lummi.ai/assets/\${</span><span style="color:#E1E4E8">assetId</span><span style="color:#9ECBFF">}?auto=format&#x26;fit=crop&#x26;w=\${</span><span style="color:#79B8FF">PRINT_WIDTH</span><span style="color:#9ECBFF">}&#x26;h=\${</span><span style="color:#79B8FF">PRINT_HEIGHT</span><span style="color:#9ECBFF">}&#x26;q=85\`</span><span style="color:#E1E4E8">;</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#6A737D">/** Wedding + event frames from https://lummi.ai — see demo notes for credits */</span></span>
+<span class="line"><span style="color:#F97583">const</span><span style="color:#79B8FF"> LUMMI_ASSETS</span><span style="color:#F97583"> =</span><span style="color:#E1E4E8"> {</span></span>
+<span class="line"><span style="color:#E1E4E8">  avatar: </span><span style="color:#9ECBFF">"QmXp6StB1i36XHbbmppop5AwtQgnyom8bYTZqPkLVNGJnk"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">  portfolio: {</span></span>
+<span class="line"><span style="color:#E1E4E8">    vows: </span><span style="color:#9ECBFF">"QmabCfDwG7NUco1UhMnAE7NiHSK63MNKmPxAA2mc8Xrh8j"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">    ceremony: </span><span style="color:#9ECBFF">"QmS6CSjJ3hc82mvhNtYGWmcAZ1coJUdEkrAVmJ6PPEH2Q3"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">    reception: </span><span style="color:#9ECBFF">"QmaCT6boTGzVxo9ii5JYcnAuakoVhso3esFDA9Y58Nm7Le"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">    candid: </span><span style="color:#9ECBFF">"QmY8f1t5PS7b6fVhd6R7s1AFQMVERRKmgE8gNataeweAS4"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">    florals: </span><span style="color:#9ECBFF">"QmYerGQMAkWiRYDyYMwVfZQSKy8FGy2Js4G83vf1vyBGdR"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">    festival: </span><span style="color:#9ECBFF">"QmZnV56e2xNN5kqUWRVMupeiUExehkWKqo5X5ewgMpA19C"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">  },</span></span>
+<span class="line"><span style="color:#E1E4E8">  trail: [</span></span>
+<span class="line"><span style="color:#9ECBFF">    "QmVufjyFaAWjZYr4kdM8JLxr68EDky5V9YnwkhRbeD3jVb"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#9ECBFF">    "QmTfDd4u2rHboSjREqrmM2AX8uamVhgURW5iKAJmTpe3Rz"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#9ECBFF">    "QmcVMDiPtnnxCKgLCppm4iHQNp8L2zX8NF1xzV1Ch7nBtk"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#9ECBFF">    "QmSXefvUey7N617ro5dG1mjRXFm9iUN5uUmwBTS63DEApS"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#9ECBFF">    "QmVgzYXYEaShMjw87vVZZv1J7PjhaNKy92XY2uTrB59o9R"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#9ECBFF">    "QmcioeKGZKuCeauwteg4DEu2edo6qe3HeK99Y9FywsYk8i"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#9ECBFF">    "QmUB7fgmDhst3VZKU5R5uUkfvbcXvZ3FDKFvkNk5TkRvqD"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#9ECBFF">    "QmeL2wx9Sdw4dGPawgxUBenthP9jt8ff8Ux4uog45NL95j"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#9ECBFF">    "QmTXHjCens6Bg4Q7J4LjzU9fyKVec3t1ziqT32ShpXa93r"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#9ECBFF">    "QmV1pUNAsa1orHnyBWFWki6qZvatRQpgbQnDCVdV1EzRGd"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#9ECBFF">    "QmZAgYih2jUqmKJz4wUoTARdijpv7bveUFYrjvacV66KXp"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#9ECBFF">    "QmQMun9ag4MrBC8man7bQC9xNupf4oCufwvCj2VpU7rXDi"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">  ],</span></span>
+<span class="line"><span style="color:#E1E4E8">} </span><span style="color:#F97583">as</span><span style="color:#F97583"> const</span><span style="color:#E1E4E8">;</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#F97583">const</span><span style="color:#79B8FF"> PHOTOGRAPHER</span><span style="color:#F97583"> =</span><span style="color:#E1E4E8"> {</span></span>
+<span class="line"><span style="color:#E1E4E8">  studio: </span><span style="color:#9ECBFF">"Maya Chen"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">  name: </span><span style="color:#9ECBFF">"Maya"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">  location: </span><span style="color:#9ECBFF">"Brooklyn"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">  email: </span><span style="color:#9ECBFF">"mailto:hello@mayachen.studio"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">  avatar: </span><span style="color:#B392F0">lummi</span><span style="color:#E1E4E8">(</span><span style="color:#79B8FF">LUMMI_ASSETS</span><span style="color:#E1E4E8">.avatar),</span></span>
+<span class="line"><span style="color:#E1E4E8">};</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#F97583">const</span><span style="color:#79B8FF"> TRAIL_IMAGES</span><span style="color:#F97583"> =</span><span style="color:#79B8FF"> LUMMI_ASSETS</span><span style="color:#E1E4E8">.trail.</span><span style="color:#B392F0">map</span><span style="color:#E1E4E8">((</span><span style="color:#FFAB70">id</span><span style="color:#E1E4E8">) </span><span style="color:#F97583">=></span><span style="color:#B392F0"> lummi</span><span style="color:#E1E4E8">(id));</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#F97583">const</span><span style="color:#79B8FF"> SHOT_SETTINGS</span><span style="color:#F97583">:</span><span style="color:#B392F0"> Record</span><span style="color:#E1E4E8">&#x3C;</span><span style="color:#79B8FF">string</span><span style="color:#E1E4E8">, { </span><span style="color:#FFAB70">aperture</span><span style="color:#F97583">:</span><span style="color:#79B8FF"> string</span><span style="color:#E1E4E8">; </span><span style="color:#FFAB70">shutter</span><span style="color:#F97583">:</span><span style="color:#79B8FF"> string</span><span style="color:#E1E4E8">; </span><span style="color:#FFAB70">stock</span><span style="color:#F97583">:</span><span style="color:#79B8FF"> string</span><span style="color:#E1E4E8"> }> </span><span style="color:#F97583">=</span><span style="color:#E1E4E8"> {</span></span>
+<span class="line"><span style="color:#E1E4E8">  vows: { aperture: </span><span style="color:#9ECBFF">"2"</span><span style="color:#E1E4E8">, shutter: </span><span style="color:#9ECBFF">"1/500"</span><span style="color:#E1E4E8">, stock: </span><span style="color:#9ECBFF">"Portra 400"</span><span style="color:#E1E4E8"> },</span></span>
+<span class="line"><span style="color:#E1E4E8">  ceremony: { aperture: </span><span style="color:#9ECBFF">"2.8"</span><span style="color:#E1E4E8">, shutter: </span><span style="color:#9ECBFF">"1/250"</span><span style="color:#E1E4E8">, stock: </span><span style="color:#9ECBFF">"Portra 160"</span><span style="color:#E1E4E8"> },</span></span>
+<span class="line"><span style="color:#E1E4E8">  reception: { aperture: </span><span style="color:#9ECBFF">"2"</span><span style="color:#E1E4E8">, shutter: </span><span style="color:#9ECBFF">"1/125"</span><span style="color:#E1E4E8">, stock: </span><span style="color:#9ECBFF">"Portra 800"</span><span style="color:#E1E4E8"> },</span></span>
+<span class="line"><span style="color:#E1E4E8">  candid: { aperture: </span><span style="color:#9ECBFF">"1.8"</span><span style="color:#E1E4E8">, shutter: </span><span style="color:#9ECBFF">"1/320"</span><span style="color:#E1E4E8">, stock: </span><span style="color:#9ECBFF">"Tri-X 400"</span><span style="color:#E1E4E8"> },</span></span>
+<span class="line"><span style="color:#E1E4E8">  florals: { aperture: </span><span style="color:#9ECBFF">"4"</span><span style="color:#E1E4E8">, shutter: </span><span style="color:#9ECBFF">"1/200"</span><span style="color:#E1E4E8">, stock: </span><span style="color:#9ECBFF">"Ektar 100"</span><span style="color:#E1E4E8"> },</span></span>
+<span class="line"><span style="color:#E1E4E8">  festival: { aperture: </span><span style="color:#9ECBFF">"2.8"</span><span style="color:#E1E4E8">, shutter: </span><span style="color:#9ECBFF">"1/160"</span><span style="color:#E1E4E8">, stock: </span><span style="color:#9ECBFF">"Portra 800"</span><span style="color:#E1E4E8"> },</span></span>
+<span class="line"><span style="color:#E1E4E8">};</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#F97583">const</span><span style="color:#79B8FF"> HERO_TONE</span><span style="color:#F97583"> =</span><span style="color:#E1E4E8"> {</span></span>
+<span class="line"><span style="color:#E1E4E8">  mute: </span><span style="color:#9ECBFF">"text-black/40"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">  ink: </span><span style="color:#9ECBFF">"text-black"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">  accent: </span><span style="color:#9ECBFF">"text-[#c2410c]"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">} </span><span style="color:#F97583">as</span><span style="color:#F97583"> const</span><span style="color:#E1E4E8">;</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#F97583">const</span><span style="color:#79B8FF"> PORTFOLIO</span><span style="color:#F97583">:</span><span style="color:#B392F0"> CardStackItem</span><span style="color:#E1E4E8">[] </span><span style="color:#F97583">=</span><span style="color:#E1E4E8"> [</span></span>
+<span class="line"><span style="color:#E1E4E8">  {</span></span>
+<span class="line"><span style="color:#E1E4E8">    id: </span><span style="color:#9ECBFF">"vows"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">    image: </span><span style="color:#B392F0">lummi</span><span style="color:#E1E4E8">(</span><span style="color:#79B8FF">LUMMI_ASSETS</span><span style="color:#E1E4E8">.portfolio.vows),</span></span>
+<span class="line"><span style="color:#E1E4E8">    title: </span><span style="color:#9ECBFF">"Vows"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">    tagline: </span><span style="color:#9ECBFF">"Cliffside ceremony"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">    counts: { like: </span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8">, comment: </span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8"> },</span></span>
+<span class="line"><span style="color:#E1E4E8">    maskId: </span><span style="color:#79B8FF">CARD_STACK_MASK_IDS</span><span style="color:#E1E4E8">[</span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8">],</span></span>
+<span class="line"><span style="color:#E1E4E8">  },</span></span>
+<span class="line"><span style="color:#E1E4E8">  {</span></span>
+<span class="line"><span style="color:#E1E4E8">    id: </span><span style="color:#9ECBFF">"ceremony"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">    image: </span><span style="color:#B392F0">lummi</span><span style="color:#E1E4E8">(</span><span style="color:#79B8FF">LUMMI_ASSETS</span><span style="color:#E1E4E8">.portfolio.ceremony),</span></span>
+<span class="line"><span style="color:#E1E4E8">    title: </span><span style="color:#9ECBFF">"Ceremony"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">    tagline: </span><span style="color:#9ECBFF">"Church exit"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">    counts: { like: </span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8">, comment: </span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8"> },</span></span>
+<span class="line"><span style="color:#E1E4E8">    maskId: </span><span style="color:#79B8FF">CARD_STACK_MASK_IDS</span><span style="color:#E1E4E8">[</span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8">],</span></span>
+<span class="line"><span style="color:#E1E4E8">  },</span></span>
+<span class="line"><span style="color:#E1E4E8">  {</span></span>
+<span class="line"><span style="color:#E1E4E8">    id: </span><span style="color:#9ECBFF">"reception"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">    image: </span><span style="color:#B392F0">lummi</span><span style="color:#E1E4E8">(</span><span style="color:#79B8FF">LUMMI_ASSETS</span><span style="color:#E1E4E8">.portfolio.reception),</span></span>
+<span class="line"><span style="color:#E1E4E8">    title: </span><span style="color:#9ECBFF">"Reception"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">    tagline: </span><span style="color:#9ECBFF">"Evening dance"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">    counts: { like: </span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8">, comment: </span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8"> },</span></span>
+<span class="line"><span style="color:#E1E4E8">    maskId: </span><span style="color:#79B8FF">CARD_STACK_MASK_IDS</span><span style="color:#E1E4E8">[</span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8">],</span></span>
+<span class="line"><span style="color:#E1E4E8">  },</span></span>
+<span class="line"><span style="color:#E1E4E8">  {</span></span>
+<span class="line"><span style="color:#E1E4E8">    id: </span><span style="color:#9ECBFF">"candid"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">    image: </span><span style="color:#B392F0">lummi</span><span style="color:#E1E4E8">(</span><span style="color:#79B8FF">LUMMI_ASSETS</span><span style="color:#E1E4E8">.portfolio.candid),</span></span>
+<span class="line"><span style="color:#E1E4E8">    title: </span><span style="color:#9ECBFF">"Candid"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">    tagline: </span><span style="color:#9ECBFF">"Real laughter"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">    counts: { like: </span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8">, comment: </span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8"> },</span></span>
+<span class="line"><span style="color:#E1E4E8">    maskId: </span><span style="color:#79B8FF">CARD_STACK_MASK_IDS</span><span style="color:#E1E4E8">[</span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8">],</span></span>
+<span class="line"><span style="color:#E1E4E8">  },</span></span>
+<span class="line"><span style="color:#E1E4E8">  {</span></span>
+<span class="line"><span style="color:#E1E4E8">    id: </span><span style="color:#9ECBFF">"florals"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">    image: </span><span style="color:#B392F0">lummi</span><span style="color:#E1E4E8">(</span><span style="color:#79B8FF">LUMMI_ASSETS</span><span style="color:#E1E4E8">.portfolio.florals),</span></span>
+<span class="line"><span style="color:#E1E4E8">    title: </span><span style="color:#9ECBFF">"Florals"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">    tagline: </span><span style="color:#9ECBFF">"Bouquet detail"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">    counts: { like: </span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8">, comment: </span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8"> },</span></span>
+<span class="line"><span style="color:#E1E4E8">    maskId: </span><span style="color:#79B8FF">CARD_STACK_MASK_IDS</span><span style="color:#E1E4E8">[</span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8">],</span></span>
+<span class="line"><span style="color:#E1E4E8">  },</span></span>
+<span class="line"><span style="color:#E1E4E8">  {</span></span>
+<span class="line"><span style="color:#E1E4E8">    id: </span><span style="color:#9ECBFF">"festival"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">    image: </span><span style="color:#B392F0">lummi</span><span style="color:#E1E4E8">(</span><span style="color:#79B8FF">LUMMI_ASSETS</span><span style="color:#E1E4E8">.portfolio.festival),</span></span>
+<span class="line"><span style="color:#E1E4E8">    title: </span><span style="color:#9ECBFF">"Event"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">    tagline: </span><span style="color:#9ECBFF">"Summer festival"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">    counts: { like: </span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8">, comment: </span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8"> },</span></span>
+<span class="line"><span style="color:#E1E4E8">    maskId: </span><span style="color:#79B8FF">CARD_STACK_MASK_IDS</span><span style="color:#E1E4E8">[</span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8">],</span></span>
+<span class="line"><span style="color:#E1E4E8">  },</span></span>
+<span class="line"><span style="color:#E1E4E8">];</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#F97583">const</span><span style="color:#79B8FF"> PRELOAD_IMAGES</span><span style="color:#F97583"> =</span><span style="color:#E1E4E8"> [</span></span>
+<span class="line"><span style="color:#F97583">  ...new</span><span style="color:#B392F0"> Set</span><span style="color:#E1E4E8">([</span></span>
+<span class="line"><span style="color:#79B8FF">    PHOTOGRAPHER</span><span style="color:#E1E4E8">.avatar,</span></span>
+<span class="line"><span style="color:#F97583">    ...</span><span style="color:#79B8FF">PORTFOLIO</span><span style="color:#E1E4E8">.</span><span style="color:#B392F0">map</span><span style="color:#E1E4E8">((</span><span style="color:#FFAB70">item</span><span style="color:#E1E4E8">) </span><span style="color:#F97583">=></span><span style="color:#E1E4E8"> item.image),</span></span>
+<span class="line"><span style="color:#F97583">    ...</span><span style="color:#79B8FF">TRAIL_IMAGES</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">  ]),</span></span>
+<span class="line"><span style="color:#E1E4E8">];</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#F97583">const</span><span style="color:#79B8FF"> HERO_MARK</span><span style="color:#F97583"> =</span></span>
+<span class="line"><span style="color:#9ECBFF">  "mx-1 inline-flex size-[clamp(1.75rem,1.286em,2.25rem)] shrink-0 items-center justify-center align-middle"</span><span style="color:#E1E4E8">;</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#F97583">function</span><span style="color:#B392F0"> HeroMark</span><span style="color:#E1E4E8">({ </span><span style="color:#FFAB70">children</span><span style="color:#E1E4E8">, </span><span style="color:#FFAB70">className</span><span style="color:#E1E4E8"> }</span><span style="color:#F97583">:</span><span style="color:#E1E4E8"> { </span><span style="color:#FFAB70">children</span><span style="color:#F97583">:</span><span style="color:#B392F0"> ReactNode</span><span style="color:#E1E4E8">; </span><span style="color:#FFAB70">className</span><span style="color:#F97583">?:</span><span style="color:#79B8FF"> string</span><span style="color:#E1E4E8"> }) {</span></span>
+<span class="line"><span style="color:#F97583">  return</span><span style="color:#E1E4E8"> (</span></span>
+<span class="line"><span style="color:#E1E4E8">    &#x3C;</span><span style="color:#85E89D">span</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#B392F0">cn</span><span style="color:#E1E4E8">(</span><span style="color:#79B8FF">HERO_MARK</span><span style="color:#E1E4E8">, className)} </span><span style="color:#B392F0">aria-hidden</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">      {children}</span></span>
+<span class="line"><span style="color:#E1E4E8">    &#x3C;/</span><span style="color:#85E89D">span</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">  );</span></span>
+<span class="line"><span style="color:#E1E4E8">}</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#F97583">function</span><span style="color:#B392F0"> ProfileGlyph</span><span style="color:#E1E4E8">({ </span><span style="color:#FFAB70">src</span><span style="color:#E1E4E8">, </span><span style="color:#FFAB70">alt</span><span style="color:#E1E4E8"> }</span><span style="color:#F97583">:</span><span style="color:#E1E4E8"> { </span><span style="color:#FFAB70">src</span><span style="color:#F97583">:</span><span style="color:#79B8FF"> string</span><span style="color:#E1E4E8">; </span><span style="color:#FFAB70">alt</span><span style="color:#F97583">:</span><span style="color:#79B8FF"> string</span><span style="color:#E1E4E8"> }) {</span></span>
+<span class="line"><span style="color:#F97583">  return</span><span style="color:#E1E4E8"> (</span></span>
+<span class="line"><span style="color:#E1E4E8">    &#x3C;</span><span style="color:#85E89D">span</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#B392F0">cn</span><span style="color:#E1E4E8">(</span><span style="color:#79B8FF">HERO_MARK</span><span style="color:#E1E4E8">, </span><span style="color:#9ECBFF">"overflow-hidden rounded-full ring-1 ring-black/10"</span><span style="color:#E1E4E8">)}></span></span>
+<span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#85E89D">img</span><span style="color:#B392F0"> src</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{src} </span><span style="color:#B392F0">alt</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{alt} </span><span style="color:#B392F0">className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"size-full object-cover"</span><span style="color:#B392F0"> decoding</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"async"</span><span style="color:#E1E4E8"> /></span></span>
+<span class="line"><span style="color:#E1E4E8">    &#x3C;/</span><span style="color:#85E89D">span</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">  );</span></span>
+<span class="line"><span style="color:#E1E4E8">}</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#F97583">function</span><span style="color:#B392F0"> HeroStory</span><span style="color:#E1E4E8">() {</span></span>
+<span class="line"><span style="color:#F97583">  const</span><span style="color:#79B8FF"> type</span><span style="color:#F97583"> =</span></span>
+<span class="line"><span style="color:#9ECBFF">    "text-[clamp(1.25rem,2vw,1.75rem)] font-medium leading-[1.55] tracking-[-0.02em]"</span><span style="color:#E1E4E8">;</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#F97583">  return</span><span style="color:#E1E4E8"> (</span></span>
+<span class="line"><span style="color:#E1E4E8">    &#x3C;</span><span style="color:#85E89D">div</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"max-w-[min(100%,36rem)] space-y-6"</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#85E89D">p</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{type}></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">span</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">HERO_TONE</span><span style="color:#E1E4E8">.mute}>Hi, I'm &#x3C;/</span><span style="color:#85E89D">span</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">span</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">HERO_TONE</span><span style="color:#E1E4E8">.ink}>{</span><span style="color:#79B8FF">PHOTOGRAPHER</span><span style="color:#E1E4E8">.name}&#x3C;/</span><span style="color:#85E89D">span</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#79B8FF">ProfileGlyph</span><span style="color:#B392F0"> src</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">PHOTOGRAPHER</span><span style="color:#E1E4E8">.avatar} </span><span style="color:#B392F0">alt</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">PHOTOGRAPHER</span><span style="color:#E1E4E8">.studio} /></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">span</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">HERO_TONE</span><span style="color:#E1E4E8">.mute}>. I shoot &#x3C;/</span><span style="color:#85E89D">span</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#79B8FF">HeroMark</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"text-black"</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">          &#x3C;</span><span style="color:#79B8FF">SwitchCameraIcon</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"size-full [&#x26;_svg]:size-full"</span><span style="color:#E1E4E8"> /></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;/</span><span style="color:#79B8FF">HeroMark</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">span</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">HERO_TONE</span><span style="color:#E1E4E8">.mute}> &#x3C;/</span><span style="color:#85E89D">span</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">span</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">HERO_TONE</span><span style="color:#E1E4E8">.ink}>weddings and events&#x3C;/</span><span style="color:#85E89D">span</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">span</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">HERO_TONE</span><span style="color:#E1E4E8">.mute}> in &#x3C;/</span><span style="color:#85E89D">span</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#79B8FF">HeroMark</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"text-black/55"</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">          &#x3C;</span><span style="color:#79B8FF">MapPinIcon</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"size-full [&#x26;_svg]:size-full"</span><span style="color:#E1E4E8"> /></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;/</span><span style="color:#79B8FF">HeroMark</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">span</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">HERO_TONE</span><span style="color:#E1E4E8">.mute}> &#x3C;/</span><span style="color:#85E89D">span</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">span</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">HERO_TONE</span><span style="color:#E1E4E8">.ink}>{</span><span style="color:#79B8FF">PHOTOGRAPHER</span><span style="color:#E1E4E8">.location}&#x3C;/</span><span style="color:#85E89D">span</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">span</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">HERO_TONE</span><span style="color:#E1E4E8">.mute}></span></span>
+<span class="line"><span style="color:#E1E4E8">          {</span><span style="color:#9ECBFF">" "</span><span style="color:#E1E4E8">}</span></span>
+<span class="line"><span style="color:#E1E4E8">          — good light, real moments, and photos that don't feel forced.</span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;/</span><span style="color:#85E89D">span</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">      &#x3C;/</span><span style="color:#85E89D">p</span><span style="color:#E1E4E8">></span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#85E89D">p</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{type}></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">span</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">HERO_TONE</span><span style="color:#E1E4E8">.accent}>Booking Q3.&#x3C;/</span><span style="color:#85E89D">span</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">span</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">HERO_TONE</span><span style="color:#E1E4E8">.mute}> &#x3C;/</span><span style="color:#85E89D">span</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">a</span></span>
+<span class="line"><span style="color:#B392F0">          href</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">PHOTOGRAPHER</span><span style="color:#E1E4E8">.email}</span></span>
+<span class="line"><span style="color:#B392F0">          className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#B392F0">cn</span><span style="color:#E1E4E8">(</span><span style="color:#79B8FF">HERO_TONE</span><span style="color:#E1E4E8">.ink, </span><span style="color:#9ECBFF">"underline-offset-[4px] hover:underline"</span><span style="color:#E1E4E8">)}</span></span>
+<span class="line"><span style="color:#E1E4E8">        ></span></span>
+<span class="line"><span style="color:#E1E4E8">          Send me your date.</span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;/</span><span style="color:#85E89D">a</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">      &#x3C;/</span><span style="color:#85E89D">p</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">    &#x3C;/</span><span style="color:#85E89D">div</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">  );</span></span>
+<span class="line"><span style="color:#E1E4E8">}</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#F97583">function</span><span style="color:#B392F0"> ViewfinderFrame</span><span style="color:#E1E4E8">() {</span></span>
+<span class="line"><span style="color:#F97583">  const</span><span style="color:#79B8FF"> corner</span><span style="color:#F97583"> =</span><span style="color:#9ECBFF"> "absolute size-4 border-white/80"</span><span style="color:#E1E4E8">;</span></span>
+<span class="line"><span style="color:#F97583">  return</span><span style="color:#E1E4E8"> (</span></span>
+<span class="line"><span style="color:#E1E4E8">    &#x3C;</span><span style="color:#85E89D">div</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"pointer-events-none absolute inset-3 sm:inset-4"</span><span style="color:#B392F0"> aria-hidden</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#85E89D">span</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#B392F0">cn</span><span style="color:#E1E4E8">(corner, </span><span style="color:#9ECBFF">"left-0 top-0 border-l-2 border-t-2"</span><span style="color:#E1E4E8">)} /></span></span>
+<span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#85E89D">span</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#B392F0">cn</span><span style="color:#E1E4E8">(corner, </span><span style="color:#9ECBFF">"right-0 top-0 border-r-2 border-t-2"</span><span style="color:#E1E4E8">)} /></span></span>
+<span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#85E89D">span</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#B392F0">cn</span><span style="color:#E1E4E8">(corner, </span><span style="color:#9ECBFF">"bottom-0 left-0 border-b-2 border-l-2"</span><span style="color:#E1E4E8">)} /></span></span>
+<span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#85E89D">span</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#B392F0">cn</span><span style="color:#E1E4E8">(corner, </span><span style="color:#9ECBFF">"bottom-0 right-0 border-b-2 border-r-2"</span><span style="color:#E1E4E8">)} /></span></span>
+<span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#85E89D">div</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 opacity-[0.16]"</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">span</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"absolute left-1/2 top-1/2 h-px w-5 -translate-x-1/2 -translate-y-1/2 bg-white"</span><span style="color:#E1E4E8"> /></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">span</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"absolute left-1/2 top-1/2 h-5 w-px -translate-x-1/2 -translate-y-1/2 bg-white"</span><span style="color:#E1E4E8"> /></span></span>
+<span class="line"><span style="color:#E1E4E8">      &#x3C;/</span><span style="color:#85E89D">div</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">    &#x3C;/</span><span style="color:#85E89D">div</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">  );</span></span>
+<span class="line"><span style="color:#E1E4E8">}</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#F97583">function</span><span style="color:#B392F0"> PrintCaption</span><span style="color:#E1E4E8">() {</span></span>
+<span class="line"><span style="color:#F97583">  const</span><span style="color:#E1E4E8"> { </span><span style="color:#79B8FF">activeItem</span><span style="color:#E1E4E8"> } </span><span style="color:#F97583">=</span><span style="color:#B392F0"> useCardStack</span><span style="color:#E1E4E8">();</span></span>
+<span class="line"><span style="color:#F97583">  const</span><span style="color:#79B8FF"> index</span><span style="color:#F97583"> =</span><span style="color:#E1E4E8"> activeItem </span><span style="color:#F97583">?</span><span style="color:#79B8FF"> PORTFOLIO</span><span style="color:#E1E4E8">.</span><span style="color:#B392F0">findIndex</span><span style="color:#E1E4E8">((</span><span style="color:#FFAB70">item</span><span style="color:#E1E4E8">) </span><span style="color:#F97583">=></span><span style="color:#E1E4E8"> item.id </span><span style="color:#F97583">===</span><span style="color:#E1E4E8"> activeItem.id) </span><span style="color:#F97583">+</span><span style="color:#79B8FF"> 1</span><span style="color:#F97583"> :</span><span style="color:#79B8FF"> 1</span><span style="color:#E1E4E8">;</span></span>
+<span class="line"><span style="color:#F97583">  const</span><span style="color:#79B8FF"> settings</span><span style="color:#F97583"> =</span><span style="color:#E1E4E8"> activeItem </span><span style="color:#F97583">?</span><span style="color:#79B8FF"> SHOT_SETTINGS</span><span style="color:#E1E4E8">[activeItem.id] </span><span style="color:#F97583">:</span><span style="color:#79B8FF"> SHOT_SETTINGS</span><span style="color:#E1E4E8">.vows;</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#F97583">  if</span><span style="color:#E1E4E8"> (</span><span style="color:#F97583">!</span><span style="color:#E1E4E8">activeItem </span><span style="color:#F97583">||</span><span style="color:#F97583"> !</span><span style="color:#E1E4E8">settings) {</span></span>
+<span class="line"><span style="color:#F97583">    return</span><span style="color:#79B8FF"> null</span><span style="color:#E1E4E8">;</span></span>
+<span class="line"><span style="color:#E1E4E8">  }</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#F97583">  return</span><span style="color:#E1E4E8"> (</span></span>
+<span class="line"><span style="color:#E1E4E8">    &#x3C;</span><span style="color:#85E89D">figcaption</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"relative z-10 shrink-0 border-b border-black/80 bg-transparent pb-3"</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#85E89D">div</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"flex items-baseline justify-between gap-4"</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">p</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"text-[11px] font-medium uppercase tracking-[0.1em] text-black"</span><span style="color:#E1E4E8">>{activeItem.title}&#x3C;/</span><span style="color:#85E89D">p</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">p</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"shrink-0 text-[11px] font-medium tabular-nums tracking-[0.1em] text-black/45"</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">          {</span><span style="color:#B392F0">String</span><span style="color:#E1E4E8">(index).</span><span style="color:#B392F0">padStart</span><span style="color:#E1E4E8">(</span><span style="color:#79B8FF">2</span><span style="color:#E1E4E8">, </span><span style="color:#9ECBFF">"0"</span><span style="color:#E1E4E8">)}</span></span>
+<span class="line"><span style="color:#E1E4E8">          &#x3C;</span><span style="color:#85E89D">span</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"text-black/20"</span><span style="color:#E1E4E8">>/&#x3C;/</span><span style="color:#85E89D">span</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">          {</span><span style="color:#B392F0">String</span><span style="color:#E1E4E8">(</span><span style="color:#79B8FF">PORTFOLIO</span><span style="color:#E1E4E8">.</span><span style="color:#79B8FF">length</span><span style="color:#E1E4E8">).</span><span style="color:#B392F0">padStart</span><span style="color:#E1E4E8">(</span><span style="color:#79B8FF">2</span><span style="color:#E1E4E8">, </span><span style="color:#9ECBFF">"0"</span><span style="color:#E1E4E8">)}</span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;/</span><span style="color:#85E89D">p</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">      &#x3C;/</span><span style="color:#85E89D">div</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#85E89D">p</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"mt-2 text-[11px] font-medium uppercase tracking-[0.1em] text-black/45"</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">        ƒ/{settings.aperture}</span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">span</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"px-1.5 text-black/20"</span><span style="color:#E1E4E8">>·&#x3C;/</span><span style="color:#85E89D">span</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">        {settings.shutter}</span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">span</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"px-1.5 text-black/20"</span><span style="color:#E1E4E8">>·&#x3C;/</span><span style="color:#85E89D">span</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">        {settings.stock}</span></span>
+<span class="line"><span style="color:#E1E4E8">      &#x3C;/</span><span style="color:#85E89D">p</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">    &#x3C;/</span><span style="color:#85E89D">figcaption</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">  );</span></span>
+<span class="line"><span style="color:#E1E4E8">}</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#F97583">const</span><span style="color:#79B8FF"> BASELINE</span><span style="color:#F97583"> =</span><span style="color:#79B8FF"> 8</span><span style="color:#E1E4E8">;</span></span>
+<span class="line"><span style="color:#F97583">const</span><span style="color:#79B8FF"> LAYOUT</span><span style="color:#F97583"> =</span><span style="color:#E1E4E8"> {</span></span>
+<span class="line"><span style="color:#E1E4E8">  shell: </span><span style="color:#9ECBFF">"px-6 sm:px-10 lg:px-14"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">  blockY: </span><span style="color:#9ECBFF">"py-8 lg:py-10"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">  grid: </span><span style="color:#9ECBFF">"gap-x-8 gap-y-8 lg:gap-x-10 lg:gap-y-10"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">} </span><span style="color:#F97583">as</span><span style="color:#F97583"> const</span><span style="color:#E1E4E8">;</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#F97583">function</span><span style="color:#B392F0"> ProofStack</span><span style="color:#E1E4E8">({</span></span>
+<span class="line"><span style="color:#FFAB70">  stackRef</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#FFAB70">  captionRef</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">}</span><span style="color:#F97583">:</span><span style="color:#E1E4E8"> {</span></span>
+<span class="line"><span style="color:#FFAB70">  stackRef</span><span style="color:#F97583">:</span><span style="color:#B392F0"> RefObject</span><span style="color:#E1E4E8">&#x3C;</span><span style="color:#B392F0">HTMLElement</span><span style="color:#F97583"> |</span><span style="color:#79B8FF"> null</span><span style="color:#E1E4E8">>;</span></span>
+<span class="line"><span style="color:#FFAB70">  captionRef</span><span style="color:#F97583">:</span><span style="color:#B392F0"> RefObject</span><span style="color:#E1E4E8">&#x3C;</span><span style="color:#B392F0">HTMLDivElement</span><span style="color:#F97583"> |</span><span style="color:#79B8FF"> null</span><span style="color:#E1E4E8">>;</span></span>
+<span class="line"><span style="color:#E1E4E8">}) {</span></span>
+<span class="line"><span style="color:#F97583">  return</span><span style="color:#E1E4E8"> (</span></span>
+<span class="line"><span style="color:#E1E4E8">    &#x3C;</span><span style="color:#85E89D">figure</span></span>
+<span class="line"><span style="color:#B392F0">      ref</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{stackRef}</span></span>
+<span class="line"><span style="color:#B392F0">      className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"ml-auto grid h-full min-h-0 w-full min-w-0 max-w-full grid-rows-[auto_minmax(0,1fr)] gap-y-3 sm:gap-y-4"</span></span>
+<span class="line"><span style="color:#E1E4E8">    ></span></span>
+<span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#85E89D">div</span><span style="color:#B392F0"> ref</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{captionRef} </span><span style="color:#B392F0">className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"relative z-30 w-full shrink-0 bg-transparent"</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#79B8FF">PrintCaption</span><span style="color:#E1E4E8"> /></span></span>
+<span class="line"><span style="color:#E1E4E8">      &#x3C;/</span><span style="color:#85E89D">div</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#85E89D">div</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"@container/stack relative flex min-h-0 flex-1 items-end justify-end pt-[max(2.5rem,11%)]"</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#79B8FF">CardStack.Frame</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"relative aspect-[4/5] h-auto w-[min(100cqw,calc(100cqh*4/5))] max-h-full min-h-0 shrink-0 overflow-visible"</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">          &#x3C;</span><span style="color:#79B8FF">CardStack.LiveRegion</span><span style="color:#E1E4E8"> /></span></span>
+<span class="line"><span style="color:#E1E4E8">          &#x3C;</span><span style="color:#79B8FF">CardStack.Trigger</span><span style="color:#B392F0"> aria-label</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"Show next photo"</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"block size-full text-left"</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">            &#x3C;</span><span style="color:#79B8FF">CardStack.Viewport</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"relative size-full overflow-visible !min-h-0 !pt-0"</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">            &#x3C;</span><span style="color:#79B8FF">CardStack.List</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">              {(</span><span style="color:#FFAB70">item</span><span style="color:#E1E4E8">, </span><span style="color:#FFAB70">index</span><span style="color:#E1E4E8">, </span><span style="color:#FFAB70">layer</span><span style="color:#E1E4E8">) </span><span style="color:#F97583">=></span><span style="color:#E1E4E8"> (</span></span>
+<span class="line"><span style="color:#E1E4E8">                &#x3C;</span><span style="color:#79B8FF">CardStack.Card</span></span>
+<span class="line"><span style="color:#B392F0">                  key</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{item.id}</span></span>
+<span class="line"><span style="color:#B392F0">                  layer</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{layer}</span></span>
+<span class="line"><span style="color:#B392F0">                  stackIndex</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{index}</span></span>
+<span class="line"><span style="color:#B392F0">                  className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"size-full gap-0 overflow-visible rounded-none bg-transparent p-0 shadow-none ring-0 [background-image:none]"</span></span>
+<span class="line"><span style="color:#E1E4E8">                ></span></span>
+<span class="line"><span style="color:#E1E4E8">                  &#x3C;</span><span style="color:#85E89D">figure</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"flex size-full flex-col border-0 bg-transparent p-0"</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">                    &#x3C;</span><span style="color:#85E89D">div</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"relative min-h-0 w-full flex-1 overflow-hidden bg-black/5"</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">                      &#x3C;</span><span style="color:#85E89D">img</span></span>
+<span class="line"><span style="color:#B392F0">                        src</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{item.image}</span></span>
+<span class="line"><span style="color:#B392F0">                        alt</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#9ECBFF">\`\${</span><span style="color:#79B8FF">PHOTOGRAPHER</span><span style="color:#9ECBFF">.</span><span style="color:#E1E4E8">studio</span><span style="color:#9ECBFF">} — \${</span><span style="color:#E1E4E8">item</span><span style="color:#9ECBFF">.</span><span style="color:#E1E4E8">title</span><span style="color:#9ECBFF">}\`</span><span style="color:#E1E4E8">}</span></span>
+<span class="line"><span style="color:#B392F0">                        width</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">PRINT_WIDTH</span><span style="color:#E1E4E8">}</span></span>
+<span class="line"><span style="color:#B392F0">                        height</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">PRINT_HEIGHT</span><span style="color:#E1E4E8">}</span></span>
+<span class="line"><span style="color:#B392F0">                        decoding</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"async"</span></span>
+<span class="line"><span style="color:#B392F0">                        draggable</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">false</span><span style="color:#E1E4E8">}</span></span>
+<span class="line"><span style="color:#B392F0">                        className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"absolute inset-0 size-full object-cover object-center"</span></span>
+<span class="line"><span style="color:#E1E4E8">                      /></span></span>
+<span class="line"><span style="color:#E1E4E8">                      {index </span><span style="color:#F97583">===</span><span style="color:#79B8FF"> 0</span><span style="color:#F97583"> ?</span><span style="color:#E1E4E8"> &#x3C;</span><span style="color:#79B8FF">ViewfinderFrame</span><span style="color:#E1E4E8"> /> </span><span style="color:#F97583">:</span><span style="color:#79B8FF"> null</span><span style="color:#E1E4E8">}</span></span>
+<span class="line"><span style="color:#E1E4E8">                    &#x3C;/</span><span style="color:#85E89D">div</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">                  &#x3C;/</span><span style="color:#85E89D">figure</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">                &#x3C;/</span><span style="color:#79B8FF">CardStack.Card</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">              )}</span></span>
+<span class="line"><span style="color:#E1E4E8">            &#x3C;/</span><span style="color:#79B8FF">CardStack.List</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">          &#x3C;/</span><span style="color:#79B8FF">CardStack.Viewport</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;/</span><span style="color:#79B8FF">CardStack.Trigger</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">      &#x3C;/</span><span style="color:#79B8FF">CardStack.Frame</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">      &#x3C;/</span><span style="color:#85E89D">div</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">    &#x3C;/</span><span style="color:#85E89D">figure</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">  );</span></span>
+<span class="line"><span style="color:#E1E4E8">}</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#F97583">function</span><span style="color:#B392F0"> PortfolioLayout</span><span style="color:#E1E4E8">({</span></span>
+<span class="line"><span style="color:#FFAB70">  stackRef</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#FFAB70">  heroRef</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#FFAB70">  captionRef</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">}</span><span style="color:#F97583">:</span><span style="color:#E1E4E8"> {</span></span>
+<span class="line"><span style="color:#FFAB70">  stackRef</span><span style="color:#F97583">:</span><span style="color:#B392F0"> RefObject</span><span style="color:#E1E4E8">&#x3C;</span><span style="color:#B392F0">HTMLElement</span><span style="color:#F97583"> |</span><span style="color:#79B8FF"> null</span><span style="color:#E1E4E8">>;</span></span>
+<span class="line"><span style="color:#FFAB70">  heroRef</span><span style="color:#F97583">:</span><span style="color:#B392F0"> RefObject</span><span style="color:#E1E4E8">&#x3C;</span><span style="color:#B392F0">HTMLDivElement</span><span style="color:#F97583"> |</span><span style="color:#79B8FF"> null</span><span style="color:#E1E4E8">>;</span></span>
+<span class="line"><span style="color:#FFAB70">  captionRef</span><span style="color:#F97583">:</span><span style="color:#B392F0"> RefObject</span><span style="color:#E1E4E8">&#x3C;</span><span style="color:#B392F0">HTMLDivElement</span><span style="color:#F97583"> |</span><span style="color:#79B8FF"> null</span><span style="color:#E1E4E8">>;</span></span>
+<span class="line"><span style="color:#E1E4E8">}) {</span></span>
+<span class="line"><span style="color:#F97583">  return</span><span style="color:#E1E4E8"> (</span></span>
+<span class="line"><span style="color:#E1E4E8">    &#x3C;</span><span style="color:#85E89D">div</span></span>
+<span class="line"><span style="color:#B392F0">      className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#B392F0">cn</span><span style="color:#E1E4E8">(</span></span>
+<span class="line"><span style="color:#9ECBFF">        "grid h-[calc(100svh-var(--demo-chrome-reserve,5rem))] min-h-0 grid-cols-1 grid-rows-[auto_minmax(18rem,1fr)]"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#9ECBFF">        "md:grid-cols-[minmax(0,2fr)_minmax(0,3fr)] md:grid-rows-1"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#79B8FF">        LAYOUT</span><span style="color:#E1E4E8">.grid,</span></span>
+<span class="line"><span style="color:#79B8FF">        LAYOUT</span><span style="color:#E1E4E8">.blockY,</span></span>
+<span class="line"><span style="color:#E1E4E8">      )}</span></span>
+<span class="line"><span style="color:#B392F0">      style</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{{ </span><span style="color:#9ECBFF">"--layout-baseline"</span><span style="color:#E1E4E8">: </span><span style="color:#9ECBFF">\`\${</span><span style="color:#79B8FF">BASELINE</span><span style="color:#9ECBFF">}px\`</span><span style="color:#E1E4E8"> } </span><span style="color:#F97583">as</span><span style="color:#B392F0"> CSSProperties</span><span style="color:#E1E4E8">}</span></span>
+<span class="line"><span style="color:#E1E4E8">    ></span></span>
+<span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#85E89D">div</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"flex min-h-0 flex-col justify-end md:col-start-1 md:row-start-1 md:pt-[clamp(3rem,11vh,8rem)]"</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#85E89D">div</span><span style="color:#B392F0"> ref</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{heroRef} </span><span style="color:#B392F0">className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"relative z-20 w-fit max-w-full bg-transparent"</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">          &#x3C;</span><span style="color:#79B8FF">HeroStory</span><span style="color:#E1E4E8"> /></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;/</span><span style="color:#85E89D">div</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">      &#x3C;/</span><span style="color:#85E89D">div</span><span style="color:#E1E4E8">></span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#85E89D">div</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"relative z-20 flex min-h-0 min-w-0 flex-col overflow-visible md:col-start-2 md:row-start-1 md:h-full md:pl-6 md:pt-[clamp(3rem,11vh,8rem)] lg:pl-10"</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#79B8FF">ProofStack</span><span style="color:#B392F0"> stackRef</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{stackRef} </span><span style="color:#B392F0">captionRef</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{captionRef} /></span></span>
+<span class="line"><span style="color:#E1E4E8">      &#x3C;/</span><span style="color:#85E89D">div</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">    &#x3C;/</span><span style="color:#85E89D">div</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">  );</span></span>
+<span class="line"><span style="color:#E1E4E8">}</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#F97583">export</span><span style="color:#F97583"> default</span><span style="color:#F97583"> function</span><span style="color:#B392F0"> PhotographerPortfolio</span><span style="color:#E1E4E8">() {</span></span>
+<span class="line"><span style="color:#F97583">  const</span><span style="color:#79B8FF"> stackRef</span><span style="color:#F97583"> =</span><span style="color:#B392F0"> useRef</span><span style="color:#E1E4E8">&#x3C;</span><span style="color:#B392F0">HTMLElement</span><span style="color:#E1E4E8">>(</span><span style="color:#79B8FF">null</span><span style="color:#E1E4E8">);</span></span>
+<span class="line"><span style="color:#F97583">  const</span><span style="color:#79B8FF"> heroRef</span><span style="color:#F97583"> =</span><span style="color:#B392F0"> useRef</span><span style="color:#E1E4E8">&#x3C;</span><span style="color:#B392F0">HTMLDivElement</span><span style="color:#E1E4E8">>(</span><span style="color:#79B8FF">null</span><span style="color:#E1E4E8">);</span></span>
+<span class="line"><span style="color:#F97583">  const</span><span style="color:#79B8FF"> captionRef</span><span style="color:#F97583"> =</span><span style="color:#B392F0"> useRef</span><span style="color:#E1E4E8">&#x3C;</span><span style="color:#B392F0">HTMLDivElement</span><span style="color:#E1E4E8">>(</span><span style="color:#79B8FF">null</span><span style="color:#E1E4E8">);</span></span>
+<span class="line"><span style="color:#F97583">  const</span><span style="color:#E1E4E8"> [</span><span style="color:#79B8FF">preloaderDone</span><span style="color:#E1E4E8">, </span><span style="color:#79B8FF">setPreloaderDone</span><span style="color:#E1E4E8">] </span><span style="color:#F97583">=</span><span style="color:#B392F0"> useState</span><span style="color:#E1E4E8">(</span><span style="color:#79B8FF">false</span><span style="color:#E1E4E8">);</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#F97583">  return</span><span style="color:#E1E4E8"> (</span></span>
+<span class="line"><span style="color:#E1E4E8">    &#x3C;></span></span>
+<span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#85E89D">section</span></span>
+<span class="line"><span style="color:#B392F0">        className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"relative isolate min-h-[calc(100svh-var(--demo-chrome-reserve,5rem))] overflow-hidden"</span></span>
+<span class="line"><span style="color:#B392F0">        style</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{{ backgroundColor: </span><span style="color:#79B8FF">CANVAS</span><span style="color:#E1E4E8">, color: </span><span style="color:#79B8FF">INK</span><span style="color:#E1E4E8">, fontFamily: </span><span style="color:#79B8FF">FONT</span><span style="color:#E1E4E8"> }}</span></span>
+<span class="line"><span style="color:#E1E4E8">      ></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#79B8FF">TrailingImage</span></span>
+<span class="line"><span style="color:#B392F0">          edgeToEdge</span></span>
+<span class="line"><span style="color:#B392F0">          layerOnly</span></span>
+<span class="line"><span style="color:#B392F0">          contained</span></span>
+<span class="line"><span style="color:#B392F0">          className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"z-10 isolate"</span></span>
+<span class="line"><span style="color:#B392F0">          images</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">TRAIL_IMAGES</span><span style="color:#E1E4E8">}</span></span>
+<span class="line"><span style="color:#B392F0">          threshold</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">88</span><span style="color:#E1E4E8">}</span></span>
+<span class="line"><span style="color:#B392F0">          maxTrailZIndex</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">12</span><span style="color:#E1E4E8">}</span></span>
+<span class="line"><span style="color:#B392F0">          excludeRefs</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{[heroRef, captionRef]}</span></span>
+<span class="line"><span style="color:#E1E4E8">        /></span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#79B8FF">CardStack</span></span>
+<span class="line"><span style="color:#B392F0">          items</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">PORTFOLIO</span><span style="color:#E1E4E8">}</span></span>
+<span class="line"><span style="color:#B392F0">          depth</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">3</span><span style="color:#E1E4E8">}</span></span>
+<span class="line"><span style="color:#B392F0">          autoplay</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{preloaderDone}</span></span>
+<span class="line"><span style="color:#B392F0">          autoplayInterval</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">4500</span><span style="color:#E1E4E8">}</span></span>
+<span class="line"><span style="color:#E1E4E8">        ></span></span>
+<span class="line"><span style="color:#E1E4E8">          &#x3C;</span><span style="color:#85E89D">div</span></span>
+<span class="line"><span style="color:#B392F0">            className</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#B392F0">cn</span><span style="color:#E1E4E8">(</span></span>
+<span class="line"><span style="color:#9ECBFF">              "relative z-20 isolate mx-auto min-h-[calc(100svh-var(--demo-chrome-reserve,5rem))] w-full max-w-[92rem] pb-[var(--demo-chrome-reserve,5rem)]"</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#79B8FF">              LAYOUT</span><span style="color:#E1E4E8">.shell,</span></span>
+<span class="line"><span style="color:#E1E4E8">            )}</span></span>
+<span class="line"><span style="color:#E1E4E8">          ></span></span>
+<span class="line"><span style="color:#E1E4E8">            &#x3C;</span><span style="color:#79B8FF">PortfolioLayout</span><span style="color:#B392F0"> stackRef</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{stackRef} </span><span style="color:#B392F0">heroRef</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{heroRef} </span><span style="color:#B392F0">captionRef</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{captionRef} /></span></span>
+<span class="line"><span style="color:#E1E4E8">          &#x3C;/</span><span style="color:#85E89D">div</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;/</span><span style="color:#79B8FF">CardStack</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">      &#x3C;/</span><span style="color:#85E89D">section</span><span style="color:#E1E4E8">></span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#79B8FF">SplitReveal</span></span>
+<span class="line"><span style="color:#B392F0">        images</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">PRELOAD_IMAGES</span><span style="color:#E1E4E8">}</span></span>
+<span class="line"><span style="color:#B392F0">        backgroundColor</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">CANVAS</span><span style="color:#E1E4E8">}</span></span>
+<span class="line"><span style="color:#B392F0">        foregroundColor</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">INK</span><span style="color:#E1E4E8">}</span></span>
+<span class="line"><span style="color:#B392F0">        zIndex</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">120</span><span style="color:#E1E4E8">}</span></span>
+<span class="line"><span style="color:#B392F0">        lockScroll</span></span>
+<span class="line"><span style="color:#B392F0">        onComplete</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{() </span><span style="color:#F97583">=></span><span style="color:#B392F0"> setPreloaderDone</span><span style="color:#E1E4E8">(</span><span style="color:#79B8FF">true</span><span style="color:#E1E4E8">)}</span></span>
+<span class="line"><span style="color:#B392F0">        renderProgress</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{({ </span><span style="color:#FFAB70">loaded</span><span style="color:#E1E4E8">, </span><span style="color:#FFAB70">total</span><span style="color:#E1E4E8">, </span><span style="color:#FFAB70">progress</span><span style="color:#E1E4E8"> }) </span><span style="color:#F97583">=></span><span style="color:#E1E4E8"> (</span></span>
+<span class="line"><span style="color:#E1E4E8">          &#x3C;></span></span>
+<span class="line"><span style="color:#E1E4E8">            &#x3C;</span><span style="color:#79B8FF">SplitReveal.ProgressTrack</span><span style="color:#B392F0"> progress</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{progress} </span><span style="color:#B392F0">foregroundColor</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">INK</span><span style="color:#E1E4E8">} /></span></span>
+<span class="line"><span style="color:#E1E4E8">            &#x3C;</span><span style="color:#85E89D">p</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"mt-3 text-center text-[11px] font-medium uppercase tracking-[0.12em] text-black/45"</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">              Loading frames</span></span>
+<span class="line"><span style="color:#E1E4E8">              &#x3C;</span><span style="color:#85E89D">span</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"px-1.5 text-black/20"</span><span style="color:#E1E4E8">>·&#x3C;/</span><span style="color:#85E89D">span</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">              {</span><span style="color:#B392F0">String</span><span style="color:#E1E4E8">(loaded).</span><span style="color:#B392F0">padStart</span><span style="color:#E1E4E8">(</span><span style="color:#79B8FF">2</span><span style="color:#E1E4E8">, </span><span style="color:#9ECBFF">"0"</span><span style="color:#E1E4E8">)}</span></span>
+<span class="line"><span style="color:#E1E4E8">              &#x3C;</span><span style="color:#85E89D">span</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"text-black/20"</span><span style="color:#E1E4E8">>/&#x3C;/</span><span style="color:#85E89D">span</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">              {</span><span style="color:#B392F0">String</span><span style="color:#E1E4E8">(total).</span><span style="color:#B392F0">padStart</span><span style="color:#E1E4E8">(</span><span style="color:#79B8FF">2</span><span style="color:#E1E4E8">, </span><span style="color:#9ECBFF">"0"</span><span style="color:#E1E4E8">)}</span></span>
+<span class="line"><span style="color:#E1E4E8">            &#x3C;/</span><span style="color:#85E89D">p</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">          &#x3C;/></span></span>
+<span class="line"><span style="color:#E1E4E8">        )}</span></span>
+<span class="line"><span style="color:#E1E4E8">      /></span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#79B8FF">PhotographerPortfolioNotes</span><span style="color:#E1E4E8"> /></span></span>
+<span class="line"><span style="color:#E1E4E8">    &#x3C;/></span></span>
+<span class="line"><span style="color:#E1E4E8">  );</span></span>
+<span class="line"><span style="color:#E1E4E8">}</span></span>
+<span class="line"></span></code></pre>`,
+    },
+  ],
 };

--- a/app/demo/library/hero/photographer-portfolio-notes.tsx
+++ b/app/demo/library/hero/photographer-portfolio-notes.tsx
@@ -1,0 +1,135 @@
+import { DemoNotes } from "@/app/demo/demo-notes";
+import { DemoSourcePanel } from "@/app/demo/demo-source-panel";
+import { DEMO_SOURCES } from "@/app/demo/generated/demo-sources";
+
+const DEMO_KEY = "hero/photographer-portfolio";
+
+const TRAIL_EXCLUDE_SNIPPET = `<TrailingImage
+  edgeToEdge
+  layerOnly
+  contained
+  images={TRAIL_IMAGES}
+  threshold={88}
+  maxTrailZIndex={12}
+  excludeRefs={[heroRef, captionRef]}
+/>`;
+
+const PRELOADER_SNIPPET = `<section>{/* your page */}</section>
+
+<SplitReveal
+  images={PRELOAD_IMAGES}
+  lockScroll
+  onComplete={() => setPreloaderDone(true)}
+  renderProgress={({ loaded, total, progress }) => (
+    <>
+      <SplitReveal.ProgressTrack progress={progress} foregroundColor="#000" />
+      <p>Loading frames · {loaded}/{total}</p>
+    </>
+  )}
+/>`;
+
+export function PhotographerPortfolioNotes() {
+  const sources = DEMO_SOURCES[DEMO_KEY] ?? [];
+
+  return (
+    <DemoNotes.Root>
+      <DemoNotes.Header
+        id="demo-notes-title"
+        eyebrow="Recipe"
+        title="Photographer portfolio"
+        description="White page, hero copy on the left, print stack on the right. SplitReveal sits on top as a sibling — no wrapping required."
+      />
+
+      <DemoNotes.Section id="concept" index={1} title="Concept">
+        <DemoNotes.Prose>
+          <p>
+            Maya&apos;s portfolio page with almost nothing else on it. White background, black type,
+            a short intro in the bottom-left corner, and a tall 4:5 stack on the right. Move the
+            mouse and wedding frames from Lummi trail behind the layout.
+          </p>
+          <p>
+            Before any of that shows, <code>SplitReveal</code> preloads every image and covers the
+            viewport. Progress ticks up on the center seam; when the batch is done, the top and
+            bottom halves slide apart. The page was already mounted underneath — you just
+            couldn&apos;t see it yet.
+          </p>
+          <p>The active stack frame gets viewfinder brackets. Everything else is just the photo.</p>
+        </DemoNotes.Prose>
+      </DemoNotes.Section>
+
+      <DemoNotes.Section id="components" index={2} title="Components used">
+        <DemoNotes.Prose>
+          <p>
+            <code>SplitReveal</code> is a fixed overlay you drop next to your layout — pass{" "}
+            <code>images</code>, optionally <code>renderProgress</code>, and it handles preload,
+            scroll lock, and the split exit. No <code>.Content</code> wrapper.
+          </p>
+          <p>
+            <code>CardStack</code> cycles the portfolio forward; autoplay waits until the preloader
+            finishes. <code>PrintCaption</code> reads the active frame and fakes exposure metadata.
+            Hero camera and map pin icons come from Lucide Animated and only animate on hover.
+          </p>
+          <p>
+            <code>TrailingImage</code> runs at <code>z-10</code>. Hero and caption refs are on the
+            exclude list so trails never land on readable text.
+          </p>
+        </DemoNotes.Prose>
+        <DemoNotes.ComponentLinks demoKey={DEMO_KEY} />
+      </DemoNotes.Section>
+
+      <DemoNotes.Section id="build" index={3} title="How it's built">
+        <DemoNotes.Prose>
+          <p>
+            URLs live in <code>LUMMI_ASSETS</code> — six stack frames, twelve trail frames, one
+            avatar — all cropped through a shared <code>lummi()</code> helper.{" "}
+            <code>PRELOAD_IMAGES</code> dedupes the lot before handing it to SplitReveal.
+          </p>
+          <p>
+            <code>PortfolioLayout</code> is a 2:3 grid on desktop. Hero pins to the bottom of the
+            left column; the stack column keeps the caption above the cards with a little peek
+            padding so the promoted frame can breathe.
+          </p>
+          <p>
+            Trail blocking is DOM-based. Only the hero and caption wrappers are excluded — not the
+            whole stack — so photos can still drift over the prints.
+          </p>
+        </DemoNotes.Prose>
+        <DemoNotes.Code caption="SplitReveal as a sibling overlay">
+          {PRELOADER_SNIPPET}
+        </DemoNotes.Code>
+        <DemoNotes.Code caption="Trail layer — exclude text wrappers">
+          {TRAIL_EXCLUDE_SNIPPET}
+        </DemoNotes.Code>
+      </DemoNotes.Section>
+
+      <DemoNotes.Section id="credits" index={4} title="Credits">
+        <DemoNotes.Prose>
+          <p>
+            <strong>Photos</strong> — from <a href="https://www.lummi.ai">Lummi</a> (wedding and
+            event searches). IDs are in <code>LUMMI_ASSETS</code>. Fine for demos; swap in your own
+            work for anything client-facing.
+          </p>
+          <p>
+            <strong>Icons</strong> — <a href="https://lucide-animated.com/icons/map-pin">Map Pin</a>{" "}
+            and <a href="https://lucide-animated.com/icons/switch-camera">Switch Camera</a> from
+            Lucide Animated (MIT).
+          </p>
+          <p>
+            <strong>Type</strong> —{" "}
+            <a href="https://fontsource.org/fonts/instrument-sans">Instrument Sans Variable</a> via
+            Fontsource.
+          </p>
+        </DemoNotes.Prose>
+      </DemoNotes.Section>
+
+      <DemoNotes.Section id="source" index={5} title="Full source">
+        <DemoNotes.Prose>
+          <p>Pulled from the demo file at build time.</p>
+        </DemoNotes.Prose>
+        <DemoNotes.Bleed>
+          <DemoSourcePanel files={sources} />
+        </DemoNotes.Bleed>
+      </DemoNotes.Section>
+    </DemoNotes.Root>
+  );
+}

--- a/app/demo/library/hero/photographer-portfolio-notes.tsx
+++ b/app/demo/library/hero/photographer-portfolio-notes.tsx
@@ -53,42 +53,45 @@ export function PhotographerPortfolioNotes() {
         id="demo-notes-title"
         eyebrow="Recipe"
         title="Photographer portfolio"
-        description="White page, hero copy on the left, print stack on the right. SplitReveal sits on top as a sibling — no wrapping required."
+        description="Minimal wedding portfolio: intro bottom-left, 4:5 print stack on the right, mouse trails underneath. SplitReveal preloads first."
       />
 
       <DemoNotes.Section id="concept" index={1} title="Concept">
         <DemoNotes.Prose>
           <p>
-            Maya&apos;s portfolio page with almost nothing else on it. White background, black type,
-            a short intro in the bottom-left corner, and a tall 4:5 stack on the right — full width
-            on mobile, right-aligned on desktop. Move the mouse and wedding frames from Lummi trail
-            behind the layout.
+            Fake site for Maya, a wedding photographer. White page, black type, not much else — name
+            and contact in the bottom-left, a tall stack of prints on the right. On phone the stack
+            goes full width; on desktop it sits on the right edge. Wedding stills from Lummi follow
+            the cursor behind everything.
           </p>
           <p>
-            Before any of that shows, <code>SplitReveal</code> preloads every image and covers the
-            viewport. Progress ticks up on the center seam; when the batch is done, the top and
-            bottom halves slide apart. The page was already mounted underneath — you just
-            couldn&apos;t see it yet.
+            The first thing you see is not the page. <code>SplitReveal</code> covers the screen,
+            loads every image, and ticks progress on the center seam. When the batch finishes, the
+            halves slide apart. The layout was already there — just hidden.
           </p>
-          <p>The active stack frame gets viewfinder brackets. Everything else is just the photo.</p>
+          <p>
+            Whichever print is on top gets corner brackets, like a viewfinder. The rest are plain
+            photos.
+          </p>
         </DemoNotes.Prose>
       </DemoNotes.Section>
 
       <DemoNotes.Section id="components" index={2} title="Components used">
         <DemoNotes.Prose>
           <p>
-            <code>SplitReveal</code> is a fixed overlay you drop next to your layout — pass{" "}
-            <code>images</code>, optionally <code>renderProgress</code>, and it handles preload,
-            scroll lock, and the split exit. No <code>.Content</code> wrapper.
+            <code>SplitReveal</code> sits next to the page as a fixed overlay — pass{" "}
+            <code>images</code>, wire <code>onComplete</code>, done. We skipped the{" "}
+            <code>.Content</code> wrapper on purpose; the real layout mounts normally underneath.
           </p>
           <p>
-            <code>CardStack</code> cycles the portfolio forward; autoplay waits until the preloader
-            finishes. <code>PrintCaption</code> reads the active frame and fakes exposure metadata.
-            Hero camera and map pin icons come from Lucide Animated and only animate on hover.
+            <code>CardStack</code> advances the portfolio. Autoplay only starts after the preloader
+            clears. <code>PrintCaption</code> mirrors the top frame with fake shutter metadata.
+            Camera and map pin icons are Lucide Animated — they only move on hover so the hero stays
+            quiet.
           </p>
           <p>
-            <code>TrailingImage</code> runs at <code>z-10</code>. Hero and caption refs are on the
-            exclude list so trails never land on readable text.
+            <code>TrailingImage</code> at <code>z-10</code>. Hero and caption refs sit on the
+            exclude list so trails skip readable text but can still drift over the prints.
           </p>
         </DemoNotes.Prose>
         <DemoNotes.ComponentLinks demoKey={DEMO_KEY} />
@@ -97,25 +100,29 @@ export function PhotographerPortfolioNotes() {
       <DemoNotes.Section id="build" index={3} title="How it's built">
         <DemoNotes.Prose>
           <p>
-            URLs live in <code>LUMMI_ASSETS</code> — six stack frames, twelve trail frames, one
-            avatar — all cropped through a shared <code>lummi()</code> helper.{" "}
-            <code>PRELOAD_IMAGES</code> dedupes the lot before handing it to SplitReveal.
+            All image URLs live in <code>LUMMI_ASSETS</code> — six stack frames, twelve for trails,
+            one avatar — cropped through a shared <code>lummi()</code> helper.{" "}
+            <code>PRELOAD_IMAGES</code> dedupes before SplitReveal sees them.
           </p>
           <p>
-            <code>PortfolioLayout</code> is a flex column on mobile and a 2:3 row on desktop. Hero
-            and print column both pin to the bottom with <code>justify-end</code> — extra space
-            stays above the copy, not between the caption and the stack.
+            Layout is a column on mobile, 2:3 row on desktop. Hero and print column both use{" "}
+            <code>justify-end</code> so extra height goes above the copy, not between the caption
+            and the stack. That gap looked wrong in early passes.
           </p>
           <p>
-            Print sizing is CSS-only. Mobile uses <code>w-full</code> and <code>aspect-[4/5]</code>.
-            Desktop puts a size container on the print column and caps width with{" "}
-            <code>min(100cqw, calc((100cqh - 4.5rem) * 8 / 11))</code> so a 4:5 frame plus a 10%
-            peek strip (<code>aspect-[8/1]</code>) fits the viewport without{" "}
-            <code>ResizeObserver</code>.
+            Print width was the annoying part. We tried JS measurement first; on desktop the caption
+            and stack kept drifting out of sync. Switched to a size container on the print column
+            and capped width with <code>min(100cqw, calc((100cqh - 4.5rem) * 8 / 11))</code> — 4:5
+            frame plus a 10% peek strip (<code>aspect-[8/1]</code>) that fits the viewport height.
+            No <code>ResizeObserver</code>.
           </p>
           <p>
-            Trail blocking is DOM-based. Only the hero and caption wrappers are excluded — not the
-            whole stack — so photos can still drift over the prints.
+            Caption had a white fill at one point. It fought the page background and made the
+            metadata feel like a sticker — dropped it; caption and page share the same canvas now.
+          </p>
+          <p>
+            For trails we first excluded the whole stack. Looked too clean — nothing ever crossed
+            the prints. Narrowed it to the hero and caption wrappers only.
           </p>
         </DemoNotes.Prose>
         <DemoNotes.Code caption="Responsive print column — container query sizing">
@@ -132,26 +139,28 @@ export function PhotographerPortfolioNotes() {
       <DemoNotes.Section id="credits" index={4} title="Credits">
         <DemoNotes.Prose>
           <p>
-            <strong>Photos</strong> — from <a href="https://www.lummi.ai">Lummi</a> (wedding and
-            event searches). IDs are in <code>LUMMI_ASSETS</code>. Fine for demos; swap in your own
-            work for anything client-facing.
+            Photos from <a href="https://www.lummi.ai">Lummi</a> — wedding and event searches. IDs
+            are in <code>LUMMI_ASSETS</code>. Fine for demos; use your own shots for anything real.
           </p>
           <p>
-            <strong>Icons</strong> — <a href="https://lucide-animated.com/icons/map-pin">Map Pin</a>{" "}
-            and <a href="https://lucide-animated.com/icons/switch-camera">Switch Camera</a> from
-            Lucide Animated (MIT).
+            Icons: <a href="https://lucide-animated.com/icons/map-pin">Map Pin</a> and{" "}
+            <a href="https://lucide-animated.com/icons/switch-camera">Switch Camera</a> (Lucide
+            Animated, MIT).
           </p>
           <p>
-            <strong>Type</strong> —{" "}
-            <a href="https://fontsource.org/fonts/instrument-sans">Instrument Sans Variable</a> via
-            Fontsource.
+            Type:{" "}
+            <a href="https://fontsource.org/fonts/instrument-sans">Instrument Sans Variable</a>{" "}
+            (Fontsource).
           </p>
         </DemoNotes.Prose>
       </DemoNotes.Section>
 
       <DemoNotes.Section id="source" index={5} title="Full source">
         <DemoNotes.Prose>
-          <p>Pulled from the demo file at build time.</p>
+          <p>
+            Pulled from the demo file at build time. Copy what you need below; component links are
+            above.
+          </p>
         </DemoNotes.Prose>
         <DemoNotes.Bleed>
           <DemoSourcePanel files={sources} />

--- a/app/demo/library/hero/photographer-portfolio-notes.tsx
+++ b/app/demo/library/hero/photographer-portfolio-notes.tsx
@@ -14,6 +14,22 @@ const TRAIL_EXCLUDE_SNIPPET = `<TrailingImage
   excludeRefs={[heroRef, captionRef]}
 />`;
 
+const LAYOUT_SNIPPET = `{/* mobile: column stack · desktop: 2:3 row, both pinned to bottom */}
+<div className="flex flex-col gap-8 md:h-full md:flex-1 md:flex-row md:gap-6">
+  <div className="md:flex md:flex-[2] md:flex-col md:justify-end">{/* hero */}</div>
+
+  <div className="md:flex md:flex-[3] md:flex-col md:justify-end md:@container/print md:[container-type:size]">
+    <figure className="flex w-full flex-col">
+      <figcaption>{/* active frame metadata */}</figcaption>
+
+      <div className="flex w-full flex-col md:ml-auto md:w-[min(100cqw,calc((100cqh-4.5rem)*8/11))]">
+        <div aria-hidden className="aspect-[8/1] w-full" />
+        <div className="relative aspect-[4/5] w-full">{/* CardStack */}</div>
+      </div>
+    </figure>
+  </div>
+</div>`;
+
 const PRELOADER_SNIPPET = `<section>{/* your page */}</section>
 
 <SplitReveal
@@ -44,8 +60,9 @@ export function PhotographerPortfolioNotes() {
         <DemoNotes.Prose>
           <p>
             Maya&apos;s portfolio page with almost nothing else on it. White background, black type,
-            a short intro in the bottom-left corner, and a tall 4:5 stack on the right. Move the
-            mouse and wedding frames from Lummi trail behind the layout.
+            a short intro in the bottom-left corner, and a tall 4:5 stack on the right — full width
+            on mobile, right-aligned on desktop. Move the mouse and wedding frames from Lummi trail
+            behind the layout.
           </p>
           <p>
             Before any of that shows, <code>SplitReveal</code> preloads every image and covers the
@@ -85,15 +102,25 @@ export function PhotographerPortfolioNotes() {
             <code>PRELOAD_IMAGES</code> dedupes the lot before handing it to SplitReveal.
           </p>
           <p>
-            <code>PortfolioLayout</code> is a 2:3 grid on desktop. Hero pins to the bottom of the
-            left column; the stack column keeps the caption above the cards with a little peek
-            padding so the promoted frame can breathe.
+            <code>PortfolioLayout</code> is a flex column on mobile and a 2:3 row on desktop. Hero
+            and print column both pin to the bottom with <code>justify-end</code> — extra space
+            stays above the copy, not between the caption and the stack.
+          </p>
+          <p>
+            Print sizing is CSS-only. Mobile uses <code>w-full</code> and <code>aspect-[4/5]</code>.
+            Desktop puts a size container on the print column and caps width with{" "}
+            <code>min(100cqw, calc((100cqh - 4.5rem) * 8 / 11))</code> so a 4:5 frame plus a 10%
+            peek strip (<code>aspect-[8/1]</code>) fits the viewport without{" "}
+            <code>ResizeObserver</code>.
           </p>
           <p>
             Trail blocking is DOM-based. Only the hero and caption wrappers are excluded — not the
             whole stack — so photos can still drift over the prints.
           </p>
         </DemoNotes.Prose>
+        <DemoNotes.Code caption="Responsive print column — container query sizing">
+          {LAYOUT_SNIPPET}
+        </DemoNotes.Code>
         <DemoNotes.Code caption="SplitReveal as a sibling overlay">
           {PRELOADER_SNIPPET}
         </DemoNotes.Code>

--- a/app/demo/library/hero/photographer-portfolio.tsx
+++ b/app/demo/library/hero/photographer-portfolio.tsx
@@ -63,7 +63,9 @@ const PHOTOGRAPHER = {
 
 const TRAIL_IMAGES = LUMMI_ASSETS.trail.map((id) => lummi(id));
 
-const SHOT_SETTINGS: Record<string, { aperture: string; shutter: string; stock: string }> = {
+type PortfolioId = keyof typeof LUMMI_ASSETS.portfolio;
+
+const SHOT_SETTINGS: Record<PortfolioId, { aperture: string; shutter: string; stock: string }> = {
   vows: { aperture: "2", shutter: "1/500", stock: "Portra 400" },
   ceremony: { aperture: "2.8", shutter: "1/250", stock: "Portra 160" },
   reception: { aperture: "2", shutter: "1/125", stock: "Portra 800" },
@@ -83,7 +85,6 @@ const PORTFOLIO: CardStackItem[] = [
     image: lummi(LUMMI_ASSETS.portfolio.vows),
     title: "Vows",
     tagline: "Cliffside ceremony",
-    counts: { like: 0, comment: 0 },
     maskId: CARD_STACK_MASK_IDS[0],
   },
   {
@@ -91,7 +92,6 @@ const PORTFOLIO: CardStackItem[] = [
     image: lummi(LUMMI_ASSETS.portfolio.ceremony),
     title: "Ceremony",
     tagline: "Church exit",
-    counts: { like: 0, comment: 0 },
     maskId: CARD_STACK_MASK_IDS[0],
   },
   {
@@ -99,7 +99,6 @@ const PORTFOLIO: CardStackItem[] = [
     image: lummi(LUMMI_ASSETS.portfolio.reception),
     title: "Reception",
     tagline: "Evening dance",
-    counts: { like: 0, comment: 0 },
     maskId: CARD_STACK_MASK_IDS[0],
   },
   {
@@ -107,7 +106,6 @@ const PORTFOLIO: CardStackItem[] = [
     image: lummi(LUMMI_ASSETS.portfolio.candid),
     title: "Candid",
     tagline: "Real laughter",
-    counts: { like: 0, comment: 0 },
     maskId: CARD_STACK_MASK_IDS[0],
   },
   {
@@ -115,7 +113,6 @@ const PORTFOLIO: CardStackItem[] = [
     image: lummi(LUMMI_ASSETS.portfolio.florals),
     title: "Florals",
     tagline: "Bouquet detail",
-    counts: { like: 0, comment: 0 },
     maskId: CARD_STACK_MASK_IDS[0],
   },
   {
@@ -123,7 +120,6 @@ const PORTFOLIO: CardStackItem[] = [
     image: lummi(LUMMI_ASSETS.portfolio.festival),
     title: "Event",
     tagline: "Summer festival",
-    counts: { like: 0, comment: 0 },
     maskId: CARD_STACK_MASK_IDS[0],
   },
 ];
@@ -206,8 +202,12 @@ function ViewfinderFrame() {
 
 function PrintCaption() {
   const { activeItem } = useCardStack();
-  const index = activeItem ? PORTFOLIO.findIndex((item) => item.id === activeItem.id) + 1 : 1;
-  const settings = activeItem ? SHOT_SETTINGS[activeItem.id] : SHOT_SETTINGS.vows;
+  const rawIndex = activeItem ? PORTFOLIO.findIndex((item) => item.id === activeItem.id) : -1;
+  const index = rawIndex === -1 ? 1 : rawIndex + 1;
+  const settings =
+    activeItem && activeItem.id in SHOT_SETTINGS
+      ? SHOT_SETTINGS[activeItem.id as PortfolioId]
+      : SHOT_SETTINGS.vows;
 
   if (!activeItem || !settings) {
     return null;

--- a/app/demo/library/hero/photographer-portfolio.tsx
+++ b/app/demo/library/hero/photographer-portfolio.tsx
@@ -1,14 +1,7 @@
 "use client";
 
 import "@fontsource-variable/instrument-sans";
-import {
-  type CSSProperties,
-  type ReactNode,
-  type RefObject,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from "react";
+import { type CSSProperties, type ReactNode, type RefObject, useRef, useState } from "react";
 
 import CardStack, {
   CARD_STACK_MASK_IDS,
@@ -19,7 +12,6 @@ import TrailingImage from "@/animata/image/trailing-image";
 import SplitReveal from "@/animata/preloader/split-reveal";
 import { MapPinIcon } from "@/components/ui/map-pin";
 import { SwitchCameraIcon } from "@/components/ui/switch-camera";
-import { useMediaQuery } from "@/hooks/use-media-query";
 import { cn } from "@/lib/utils";
 
 import { PhotographerPortfolioNotes } from "./photographer-portfolio-notes";
@@ -249,113 +241,54 @@ function PrintCaption() {
 
 const SHELL =
   "px-6 pt-6 pb-[calc(var(--demo-chrome-reserve,5rem)+1.5rem)] sm:px-10 sm:pt-10 sm:pb-[calc(var(--demo-chrome-reserve,5rem)+2.5rem)] lg:px-14 lg:pt-14 lg:pb-[calc(var(--demo-chrome-reserve,5rem)+3.5rem)]";
-const PRINT_ASPECT = 5 / 4;
-/** Deepest stack layer y is -7.5% of card height — reserve a little extra for motion */
-const STACK_PEEK_RATIO = 0.1;
 
-type PrintSize = { width: number; height: number; peek: number };
+/** Stack peek is 10% of print height — at 4:5 that is an 8:1 strip */
+const STACK_PEEK = "aspect-[8/1]";
 
-function computePrintSize(
-  columnWidth: number,
-  budgetHeight: number,
-  captionHeight: number,
-): PrintSize {
-  const usable = Math.max(0, budgetHeight - captionHeight);
-  const maxPrintHeight = usable / (1 + STACK_PEEK_RATIO);
-  const height = Math.min(columnWidth * PRINT_ASPECT, maxPrintHeight);
-  const width = height / PRINT_ASPECT;
-
-  return {
-    width,
-    height,
-    peek: height * STACK_PEEK_RATIO,
-  };
-}
-
-function getPrintBudget(layoutEl: HTMLElement, stacked: boolean, columnWidth: number): number {
-  if (stacked) {
-    return columnWidth * PRINT_ASPECT;
-  }
-
-  const layoutRect = layoutEl.getBoundingClientRect();
-  const shell = layoutEl.parentElement;
-  if (!shell) {
-    return layoutEl.clientHeight;
-  }
-
-  const shellRect = shell.getBoundingClientRect();
-  const padBottom = Number.parseFloat(getComputedStyle(shell).paddingBottom);
-  const visibleBottom = shellRect.bottom - padBottom;
-  const visibleHeight = Math.max(0, visibleBottom - layoutRect.top);
-
-  return Math.min(layoutEl.clientHeight, visibleHeight);
-}
-
-function usePrintSize(
-  layoutRef: RefObject<HTMLElement | null>,
-  columnRef: RefObject<HTMLElement | null>,
-  captionRef: RefObject<HTMLElement | null>,
-) {
-  const [printSize, setPrintSize] = useState<PrintSize>({ width: 0, height: 0, peek: 0 });
-
-  useLayoutEffect(() => {
-    const layout = layoutRef.current;
-    const column = columnRef.current;
-    if (!layout || !column) return;
-
-    const measure = () => {
-      const columnWidth = column.clientWidth;
-      if (columnWidth <= 0) return;
-
-      const captionHeight = captionRef.current?.offsetHeight ?? 0;
-      const stacked = window.matchMedia("(max-width: 767px)").matches;
-
-      if (stacked) {
-        const height = columnWidth * PRINT_ASPECT;
-        setPrintSize({
-          width: columnWidth,
-          height,
-          peek: height * STACK_PEEK_RATIO,
-        });
-        return;
-      }
-
-      const budgetHeight = getPrintBudget(layout, false, columnWidth);
-      setPrintSize(computePrintSize(columnWidth, budgetHeight, captionHeight));
-    };
-
-    measure();
-
-    const observer = new ResizeObserver(measure);
-    observer.observe(layout);
-    observer.observe(column);
-    if (captionRef.current) observer.observe(captionRef.current);
-
-    return () => observer.disconnect();
-  }, [captionRef, columnRef, layoutRef]);
-
-  return printSize;
+function PrintStack() {
+  return (
+    <CardStack.Frame className="absolute inset-0 overflow-visible">
+      <CardStack.LiveRegion />
+      <CardStack.Trigger aria-label="Show next photo" className="absolute inset-0 block text-left">
+        <CardStack.Viewport className="size-full overflow-visible !min-h-0 !pt-0">
+          <CardStack.List>
+            {(item, index, layer) => (
+              <CardStack.Card
+                key={item.id}
+                layer={layer}
+                stackIndex={index}
+                className="!inset-x-0 !top-0 !h-fit !w-full gap-0 overflow-visible rounded-none !bg-transparent p-0 shadow-none ring-0"
+              >
+                <figure className="relative aspect-[4/5] size-full overflow-hidden bg-black/5">
+                  <img
+                    src={item.image}
+                    alt={`${PHOTOGRAPHER.studio} — ${item.title}`}
+                    width={PRINT_WIDTH}
+                    height={PRINT_HEIGHT}
+                    decoding="async"
+                    draggable={false}
+                    className="size-full object-cover object-center"
+                  />
+                  {index === 0 ? <ViewfinderFrame /> : null}
+                </figure>
+              </CardStack.Card>
+            )}
+          </CardStack.List>
+        </CardStack.Viewport>
+      </CardStack.Trigger>
+    </CardStack.Frame>
+  );
 }
 
 function PrintProof({
   stackRef,
   captionRef,
-  printSize,
-  stacked,
 }: {
   stackRef: RefObject<HTMLElement | null>;
   captionRef: RefObject<HTMLDivElement | null>;
-  printSize: PrintSize;
-  stacked: boolean;
 }) {
-  const ready = printSize.width > 0 && printSize.height > 0;
-
   return (
-    <figure
-      ref={stackRef}
-      className={cn("flex w-full min-w-0 shrink-0 flex-col", !stacked && "md:ml-auto")}
-      style={!stacked && ready ? { width: printSize.width } : undefined}
-    >
+    <figure ref={stackRef} className="flex w-full min-w-0 flex-col">
       <div
         ref={captionRef}
         className="relative z-30 w-full shrink-0"
@@ -365,98 +298,48 @@ function PrintProof({
       </div>
 
       <div
-        aria-hidden="true"
-        className="w-full shrink-0"
-        style={{ aspectRatio: `${4 / (STACK_PEEK_RATIO * 5)}` }}
-      />
-
-      <div
         className={cn(
-          "relative w-full shrink-0 overflow-visible",
-          stacked ? "aspect-[4/5]" : "md:ml-auto",
+          "flex w-full flex-col",
+          "md:ml-auto md:w-[min(100cqw,calc((100cqh-4.5rem)*8/11))]",
         )}
-        style={!stacked && ready ? { width: printSize.width, height: printSize.height } : undefined}
       >
-        <CardStack.Frame className="absolute inset-0 overflow-visible">
-          <CardStack.LiveRegion />
-          <CardStack.Trigger
-            aria-label="Show next photo"
-            className="absolute inset-0 block text-left"
-          >
-            <CardStack.Viewport className="size-full overflow-visible !min-h-0 !pt-0">
-              <CardStack.List>
-                {(item, index, layer) => (
-                  <CardStack.Card
-                    key={item.id}
-                    layer={layer}
-                    stackIndex={index}
-                    className="!inset-x-0 !top-0 !h-fit !w-full gap-0 overflow-visible rounded-none !bg-transparent p-0 shadow-none ring-0"
-                  >
-                    <figure className="relative aspect-[4/5] size-full overflow-hidden bg-black/5">
-                      <img
-                        src={item.image}
-                        alt={`${PHOTOGRAPHER.studio} — ${item.title}`}
-                        width={PRINT_WIDTH}
-                        height={PRINT_HEIGHT}
-                        decoding="async"
-                        draggable={false}
-                        className="size-full object-cover object-center"
-                      />
-                      {index === 0 ? <ViewfinderFrame /> : null}
-                    </figure>
-                  </CardStack.Card>
-                )}
-              </CardStack.List>
-            </CardStack.Viewport>
-          </CardStack.Trigger>
-        </CardStack.Frame>
+        <div aria-hidden="true" className={cn("w-full shrink-0", STACK_PEEK)} />
+        <div className="relative aspect-[4/5] w-full shrink-0 overflow-visible">
+          <PrintStack />
+        </div>
       </div>
     </figure>
   );
 }
 
 function PortfolioLayout({
-  layoutRef,
   stackRef,
   heroRef,
   captionRef,
 }: {
-  layoutRef: RefObject<HTMLDivElement | null>;
   stackRef: RefObject<HTMLElement | null>;
   heroRef: RefObject<HTMLDivElement | null>;
   captionRef: RefObject<HTMLDivElement | null>;
 }) {
-  const columnRef = useRef<HTMLDivElement>(null);
-  const stacked = useMediaQuery("(max-width: 767px)");
-  const printSize = usePrintSize(layoutRef, columnRef, captionRef);
-
   return (
     <div
-      ref={layoutRef}
-      className={cn(
-        "flex flex-col gap-8",
-        "md:min-h-0 md:flex-1 md:flex-row md:items-end md:justify-start md:gap-6 md:h-full",
-      )}
+      className={cn("flex flex-col gap-8", "md:h-full md:min-h-0 md:flex-1 md:flex-row md:gap-6")}
     >
-      <div ref={heroRef} className="relative z-20 min-w-0 md:flex-[2] md:basis-0">
+      <div
+        ref={heroRef}
+        className="relative z-20 min-w-0 md:flex md:flex-[2] md:basis-0 md:flex-col md:justify-end"
+      >
         <HeroStory />
       </div>
 
-      <div ref={columnRef} className="w-full min-w-0 md:col-start-2 md:flex-[3] md:basis-0">
-        <PrintProof
-          stackRef={stackRef}
-          captionRef={captionRef}
-          printSize={printSize}
-          stacked={stacked}
-        />
+      <div className="w-full min-w-0 md:flex md:min-h-0 md:flex-[3] md:basis-0 md:flex-col md:justify-end md:@container/print md:[container-type:size]">
+        <PrintProof stackRef={stackRef} captionRef={captionRef} />
       </div>
     </div>
   );
 }
 
 export default function PhotographerPortfolio() {
-  const shellRef = useRef<HTMLDivElement>(null);
-  const layoutRef = useRef<HTMLDivElement>(null);
   const stackRef = useRef<HTMLElement>(null);
   const heroRef = useRef<HTMLDivElement>(null);
   const captionRef = useRef<HTMLDivElement>(null);
@@ -481,18 +364,12 @@ export default function PhotographerPortfolio() {
 
         <CardStack items={PORTFOLIO} depth={3} autoplay={preloaderDone} autoplayInterval={4500}>
           <div
-            ref={shellRef}
             className={cn(
               "relative z-20 isolate mx-auto flex w-full max-w-[92rem] flex-col md:h-full md:min-h-0 md:flex-1",
               SHELL,
             )}
           >
-            <PortfolioLayout
-              layoutRef={layoutRef}
-              stackRef={stackRef}
-              heroRef={heroRef}
-              captionRef={captionRef}
-            />
+            <PortfolioLayout stackRef={stackRef} heroRef={heroRef} captionRef={captionRef} />
           </div>
         </CardStack>
       </section>

--- a/app/demo/library/hero/photographer-portfolio.tsx
+++ b/app/demo/library/hero/photographer-portfolio.tsx
@@ -214,10 +214,7 @@ function PrintCaption() {
   }
 
   return (
-    <figcaption
-      className="relative z-10 shrink-0 border-b border-black/80 pb-3"
-      style={{ backgroundColor: CANVAS }}
-    >
+    <figcaption className="relative z-10 shrink-0 border-b border-black/80 pb-3">
       <div className="flex items-baseline justify-between gap-4">
         <p className="text-[11px] font-medium uppercase tracking-[0.1em] text-black">
           {activeItem.title}
@@ -295,11 +292,7 @@ function PrintProof({
           "md:w-[min(100cqw,calc((100cqh-4.5rem)*8/11))]",
         )}
       >
-        <div
-          ref={captionRef}
-          className="relative z-30 w-full shrink-0"
-          style={{ backgroundColor: CANVAS }}
-        >
+        <div ref={captionRef} className="relative z-30 w-full shrink-0">
           <PrintCaption />
         </div>
 

--- a/app/demo/library/hero/photographer-portfolio.tsx
+++ b/app/demo/library/hero/photographer-portfolio.tsx
@@ -1,0 +1,395 @@
+"use client";
+
+import "@fontsource-variable/instrument-sans";
+import { type CSSProperties, type ReactNode, type RefObject, useRef, useState } from "react";
+
+import CardStack, {
+  CARD_STACK_MASK_IDS,
+  type CardStackItem,
+  useCardStack,
+} from "@/animata/card/card-stack";
+import TrailingImage from "@/animata/image/trailing-image";
+import SplitReveal from "@/animata/preloader/split-reveal";
+import { MapPinIcon } from "@/components/ui/map-pin";
+import { SwitchCameraIcon } from "@/components/ui/switch-camera";
+import { cn } from "@/lib/utils";
+
+import { PhotographerPortfolioNotes } from "./photographer-portfolio-notes";
+
+const FONT = '"Instrument Sans Variable", ui-sans-serif, system-ui, sans-serif';
+
+const CANVAS = "#fff";
+const INK = "#000";
+const PRINT_WIDTH = 900;
+const PRINT_HEIGHT = 1125;
+
+const lummi = (assetId: string) =>
+  `https://assets.lummi.ai/assets/${assetId}?auto=format&fit=crop&w=${PRINT_WIDTH}&h=${PRINT_HEIGHT}&q=85`;
+
+/** Wedding + event frames from https://lummi.ai — see demo notes for credits */
+const LUMMI_ASSETS = {
+  avatar: "QmXp6StB1i36XHbbmppop5AwtQgnyom8bYTZqPkLVNGJnk",
+  portfolio: {
+    vows: "QmabCfDwG7NUco1UhMnAE7NiHSK63MNKmPxAA2mc8Xrh8j",
+    ceremony: "QmS6CSjJ3hc82mvhNtYGWmcAZ1coJUdEkrAVmJ6PPEH2Q3",
+    reception: "QmaCT6boTGzVxo9ii5JYcnAuakoVhso3esFDA9Y58Nm7Le",
+    candid: "QmY8f1t5PS7b6fVhd6R7s1AFQMVERRKmgE8gNataeweAS4",
+    florals: "QmYerGQMAkWiRYDyYMwVfZQSKy8FGy2Js4G83vf1vyBGdR",
+    festival: "QmZnV56e2xNN5kqUWRVMupeiUExehkWKqo5X5ewgMpA19C",
+  },
+  trail: [
+    "QmVufjyFaAWjZYr4kdM8JLxr68EDky5V9YnwkhRbeD3jVb",
+    "QmTfDd4u2rHboSjREqrmM2AX8uamVhgURW5iKAJmTpe3Rz",
+    "QmcVMDiPtnnxCKgLCppm4iHQNp8L2zX8NF1xzV1Ch7nBtk",
+    "QmSXefvUey7N617ro5dG1mjRXFm9iUN5uUmwBTS63DEApS",
+    "QmVgzYXYEaShMjw87vVZZv1J7PjhaNKy92XY2uTrB59o9R",
+    "QmcioeKGZKuCeauwteg4DEu2edo6qe3HeK99Y9FywsYk8i",
+    "QmUB7fgmDhst3VZKU5R5uUkfvbcXvZ3FDKFvkNk5TkRvqD",
+    "QmeL2wx9Sdw4dGPawgxUBenthP9jt8ff8Ux4uog45NL95j",
+    "QmTXHjCens6Bg4Q7J4LjzU9fyKVec3t1ziqT32ShpXa93r",
+    "QmV1pUNAsa1orHnyBWFWki6qZvatRQpgbQnDCVdV1EzRGd",
+    "QmZAgYih2jUqmKJz4wUoTARdijpv7bveUFYrjvacV66KXp",
+    "QmQMun9ag4MrBC8man7bQC9xNupf4oCufwvCj2VpU7rXDi",
+  ],
+} as const;
+
+const PHOTOGRAPHER = {
+  studio: "Maya Chen",
+  name: "Maya",
+  location: "Brooklyn",
+  email: "mailto:hello@mayachen.studio",
+  avatar: lummi(LUMMI_ASSETS.avatar),
+};
+
+const TRAIL_IMAGES = LUMMI_ASSETS.trail.map((id) => lummi(id));
+
+const SHOT_SETTINGS: Record<string, { aperture: string; shutter: string; stock: string }> = {
+  vows: { aperture: "2", shutter: "1/500", stock: "Portra 400" },
+  ceremony: { aperture: "2.8", shutter: "1/250", stock: "Portra 160" },
+  reception: { aperture: "2", shutter: "1/125", stock: "Portra 800" },
+  candid: { aperture: "1.8", shutter: "1/320", stock: "Tri-X 400" },
+  florals: { aperture: "4", shutter: "1/200", stock: "Ektar 100" },
+  festival: { aperture: "2.8", shutter: "1/160", stock: "Portra 800" },
+};
+
+const HERO_TONE = {
+  mute: "text-black/40",
+  ink: "text-black",
+  accent: "text-[#c2410c]",
+} as const;
+
+const PORTFOLIO: CardStackItem[] = [
+  {
+    id: "vows",
+    image: lummi(LUMMI_ASSETS.portfolio.vows),
+    title: "Vows",
+    tagline: "Cliffside ceremony",
+    counts: { like: 0, comment: 0 },
+    maskId: CARD_STACK_MASK_IDS[0],
+  },
+  {
+    id: "ceremony",
+    image: lummi(LUMMI_ASSETS.portfolio.ceremony),
+    title: "Ceremony",
+    tagline: "Church exit",
+    counts: { like: 0, comment: 0 },
+    maskId: CARD_STACK_MASK_IDS[0],
+  },
+  {
+    id: "reception",
+    image: lummi(LUMMI_ASSETS.portfolio.reception),
+    title: "Reception",
+    tagline: "Evening dance",
+    counts: { like: 0, comment: 0 },
+    maskId: CARD_STACK_MASK_IDS[0],
+  },
+  {
+    id: "candid",
+    image: lummi(LUMMI_ASSETS.portfolio.candid),
+    title: "Candid",
+    tagline: "Real laughter",
+    counts: { like: 0, comment: 0 },
+    maskId: CARD_STACK_MASK_IDS[0],
+  },
+  {
+    id: "florals",
+    image: lummi(LUMMI_ASSETS.portfolio.florals),
+    title: "Florals",
+    tagline: "Bouquet detail",
+    counts: { like: 0, comment: 0 },
+    maskId: CARD_STACK_MASK_IDS[0],
+  },
+  {
+    id: "festival",
+    image: lummi(LUMMI_ASSETS.portfolio.festival),
+    title: "Event",
+    tagline: "Summer festival",
+    counts: { like: 0, comment: 0 },
+    maskId: CARD_STACK_MASK_IDS[0],
+  },
+];
+
+const PRELOAD_IMAGES = [
+  ...new Set([PHOTOGRAPHER.avatar, ...PORTFOLIO.map((item) => item.image), ...TRAIL_IMAGES]),
+];
+
+const HERO_MARK =
+  "mx-1 inline-flex size-[clamp(1.75rem,1.286em,2.25rem)] shrink-0 items-center justify-center align-middle";
+
+function HeroMark({ children, className }: { children: ReactNode; className?: string }) {
+  return (
+    <span className={cn(HERO_MARK, className)} aria-hidden>
+      {children}
+    </span>
+  );
+}
+
+function ProfileGlyph({ src, alt }: { src: string; alt: string }) {
+  return (
+    <span className={cn(HERO_MARK, "overflow-hidden rounded-full ring-1 ring-black/10")}>
+      <img src={src} alt={alt} className="size-full object-cover" decoding="async" />
+    </span>
+  );
+}
+
+function HeroStory() {
+  const type = "text-[clamp(1.25rem,2vw,1.75rem)] font-medium leading-[1.55] tracking-[-0.02em]";
+
+  return (
+    <div className="max-w-[min(100%,36rem)] space-y-6">
+      <p className={type}>
+        <span className={HERO_TONE.mute}>Hi, I'm </span>
+        <span className={HERO_TONE.ink}>{PHOTOGRAPHER.name}</span>
+        <ProfileGlyph src={PHOTOGRAPHER.avatar} alt={PHOTOGRAPHER.studio} />
+        <span className={HERO_TONE.mute}>. I shoot </span>
+        <HeroMark className="text-black">
+          <SwitchCameraIcon className="size-full [&_svg]:size-full" />
+        </HeroMark>
+        <span className={HERO_TONE.mute}> </span>
+        <span className={HERO_TONE.ink}>weddings and events</span>
+        <span className={HERO_TONE.mute}> in </span>
+        <HeroMark className="text-black/55">
+          <MapPinIcon className="size-full [&_svg]:size-full" />
+        </HeroMark>
+        <span className={HERO_TONE.mute}> </span>
+        <span className={HERO_TONE.ink}>{PHOTOGRAPHER.location}</span>
+        <span className={HERO_TONE.mute}>
+          {" "}
+          — good light, real moments, and photos that don't feel forced.
+        </span>
+      </p>
+
+      <p className={type}>
+        <span className={HERO_TONE.accent}>Booking Q3.</span>
+        <span className={HERO_TONE.mute}> </span>
+        <a
+          href={PHOTOGRAPHER.email}
+          className={cn(HERO_TONE.ink, "underline-offset-[4px] hover:underline")}
+        >
+          Send me your date.
+        </a>
+      </p>
+    </div>
+  );
+}
+
+function ViewfinderFrame() {
+  const corner = "absolute size-4 border-white/80";
+  return (
+    <div className="pointer-events-none absolute inset-3 sm:inset-4" aria-hidden>
+      <span className={cn(corner, "left-0 top-0 border-l-2 border-t-2")} />
+      <span className={cn(corner, "right-0 top-0 border-r-2 border-t-2")} />
+      <span className={cn(corner, "bottom-0 left-0 border-b-2 border-l-2")} />
+      <span className={cn(corner, "bottom-0 right-0 border-b-2 border-r-2")} />
+      <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 opacity-[0.16]">
+        <span className="absolute left-1/2 top-1/2 h-px w-5 -translate-x-1/2 -translate-y-1/2 bg-white" />
+        <span className="absolute left-1/2 top-1/2 h-5 w-px -translate-x-1/2 -translate-y-1/2 bg-white" />
+      </div>
+    </div>
+  );
+}
+
+function PrintCaption() {
+  const { activeItem } = useCardStack();
+  const index = activeItem ? PORTFOLIO.findIndex((item) => item.id === activeItem.id) + 1 : 1;
+  const settings = activeItem ? SHOT_SETTINGS[activeItem.id] : SHOT_SETTINGS.vows;
+
+  if (!activeItem || !settings) {
+    return null;
+  }
+
+  return (
+    <figcaption className="relative z-10 shrink-0 border-b border-black/80 bg-transparent pb-3">
+      <div className="flex items-baseline justify-between gap-4">
+        <p className="text-[11px] font-medium uppercase tracking-[0.1em] text-black">
+          {activeItem.title}
+        </p>
+        <p className="shrink-0 text-[11px] font-medium tabular-nums tracking-[0.1em] text-black/45">
+          {String(index).padStart(2, "0")}
+          <span className="text-black/20">/</span>
+          {String(PORTFOLIO.length).padStart(2, "0")}
+        </p>
+      </div>
+      <p className="mt-2 text-[11px] font-medium uppercase tracking-[0.1em] text-black/45">
+        ƒ/{settings.aperture}
+        <span className="px-1.5 text-black/20">·</span>
+        {settings.shutter}
+        <span className="px-1.5 text-black/20">·</span>
+        {settings.stock}
+      </p>
+    </figcaption>
+  );
+}
+
+const BASELINE = 8;
+const LAYOUT = {
+  shell: "px-6 sm:px-10 lg:px-14",
+  blockY: "py-8 lg:py-10",
+  grid: "gap-x-8 gap-y-8 lg:gap-x-10 lg:gap-y-10",
+} as const;
+
+function ProofStack({
+  stackRef,
+  captionRef,
+}: {
+  stackRef: RefObject<HTMLElement | null>;
+  captionRef: RefObject<HTMLDivElement | null>;
+}) {
+  return (
+    <figure
+      ref={stackRef}
+      className="ml-auto grid h-full min-h-0 w-full min-w-0 max-w-full grid-rows-[auto_minmax(0,1fr)] gap-y-3 sm:gap-y-4"
+    >
+      <div ref={captionRef} className="relative z-30 w-full shrink-0 bg-transparent">
+        <PrintCaption />
+      </div>
+      <div className="@container/stack relative flex min-h-0 flex-1 items-end justify-end pt-[max(2.5rem,11%)]">
+        <CardStack.Frame className="relative aspect-[4/5] h-auto w-[min(100cqw,calc(100cqh*4/5))] max-h-full min-h-0 shrink-0 overflow-visible">
+          <CardStack.LiveRegion />
+          <CardStack.Trigger aria-label="Show next photo" className="block size-full text-left">
+            <CardStack.Viewport className="relative size-full overflow-visible !min-h-0 !pt-0">
+              <CardStack.List>
+                {(item, index, layer) => (
+                  <CardStack.Card
+                    key={item.id}
+                    layer={layer}
+                    stackIndex={index}
+                    className="size-full gap-0 overflow-visible rounded-none bg-transparent p-0 shadow-none ring-0 [background-image:none]"
+                  >
+                    <figure className="flex size-full flex-col border-0 bg-transparent p-0">
+                      <div className="relative min-h-0 w-full flex-1 overflow-hidden bg-black/5">
+                        <img
+                          src={item.image}
+                          alt={`${PHOTOGRAPHER.studio} — ${item.title}`}
+                          width={PRINT_WIDTH}
+                          height={PRINT_HEIGHT}
+                          decoding="async"
+                          draggable={false}
+                          className="absolute inset-0 size-full object-cover object-center"
+                        />
+                        {index === 0 ? <ViewfinderFrame /> : null}
+                      </div>
+                    </figure>
+                  </CardStack.Card>
+                )}
+              </CardStack.List>
+            </CardStack.Viewport>
+          </CardStack.Trigger>
+        </CardStack.Frame>
+      </div>
+    </figure>
+  );
+}
+
+function PortfolioLayout({
+  stackRef,
+  heroRef,
+  captionRef,
+}: {
+  stackRef: RefObject<HTMLElement | null>;
+  heroRef: RefObject<HTMLDivElement | null>;
+  captionRef: RefObject<HTMLDivElement | null>;
+}) {
+  return (
+    <div
+      className={cn(
+        "grid h-[calc(100svh-var(--demo-chrome-reserve,5rem))] min-h-0 grid-cols-1 grid-rows-[auto_minmax(18rem,1fr)]",
+        "md:grid-cols-[minmax(0,2fr)_minmax(0,3fr)] md:grid-rows-1",
+        LAYOUT.grid,
+        LAYOUT.blockY,
+      )}
+      style={{ "--layout-baseline": `${BASELINE}px` } as CSSProperties}
+    >
+      <div className="flex min-h-0 flex-col justify-end md:col-start-1 md:row-start-1 md:pt-[clamp(3rem,11vh,8rem)]">
+        <div ref={heroRef} className="relative z-20 w-fit max-w-full bg-transparent">
+          <HeroStory />
+        </div>
+      </div>
+
+      <div className="relative z-20 flex min-h-0 min-w-0 flex-col overflow-visible md:col-start-2 md:row-start-1 md:h-full md:pl-6 md:pt-[clamp(3rem,11vh,8rem)] lg:pl-10">
+        <ProofStack stackRef={stackRef} captionRef={captionRef} />
+      </div>
+    </div>
+  );
+}
+
+export default function PhotographerPortfolio() {
+  const stackRef = useRef<HTMLElement>(null);
+  const heroRef = useRef<HTMLDivElement>(null);
+  const captionRef = useRef<HTMLDivElement>(null);
+  const [preloaderDone, setPreloaderDone] = useState(false);
+
+  return (
+    <>
+      <section
+        className="relative isolate min-h-[calc(100svh-var(--demo-chrome-reserve,5rem))] overflow-hidden"
+        style={{ backgroundColor: CANVAS, color: INK, fontFamily: FONT }}
+      >
+        <TrailingImage
+          edgeToEdge
+          layerOnly
+          contained
+          className="z-10 isolate"
+          images={TRAIL_IMAGES}
+          threshold={88}
+          maxTrailZIndex={12}
+          excludeRefs={[heroRef, captionRef]}
+        />
+
+        <CardStack items={PORTFOLIO} depth={3} autoplay={preloaderDone} autoplayInterval={4500}>
+          <div
+            className={cn(
+              "relative z-20 isolate mx-auto min-h-[calc(100svh-var(--demo-chrome-reserve,5rem))] w-full max-w-[92rem] pb-[var(--demo-chrome-reserve,5rem)]",
+              LAYOUT.shell,
+            )}
+          >
+            <PortfolioLayout stackRef={stackRef} heroRef={heroRef} captionRef={captionRef} />
+          </div>
+        </CardStack>
+      </section>
+
+      <SplitReveal
+        images={PRELOAD_IMAGES}
+        backgroundColor={CANVAS}
+        foregroundColor={INK}
+        zIndex={120}
+        lockScroll
+        onComplete={() => setPreloaderDone(true)}
+        renderProgress={({ loaded, total, progress }) => (
+          <>
+            <SplitReveal.ProgressTrack progress={progress} foregroundColor={INK} />
+            <p className="mt-3 text-center text-[11px] font-medium uppercase tracking-[0.12em] text-black/45">
+              Loading frames
+              <span className="px-1.5 text-black/20">·</span>
+              {String(loaded).padStart(2, "0")}
+              <span className="text-black/20">/</span>
+              {String(total).padStart(2, "0")}
+            </p>
+          </>
+        )}
+      />
+
+      <PhotographerPortfolioNotes />
+    </>
+  );
+}

--- a/app/demo/library/hero/photographer-portfolio.tsx
+++ b/app/demo/library/hero/photographer-portfolio.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import "@fontsource-variable/instrument-sans";
-import { type CSSProperties, type ReactNode, type RefObject, useRef, useState } from "react";
+import {
+  type CSSProperties,
+  type ReactNode,
+  type RefObject,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 
 import CardStack, {
   CARD_STACK_MASK_IDS,
@@ -12,6 +19,7 @@ import TrailingImage from "@/animata/image/trailing-image";
 import SplitReveal from "@/animata/preloader/split-reveal";
 import { MapPinIcon } from "@/components/ui/map-pin";
 import { SwitchCameraIcon } from "@/components/ui/switch-camera";
+import { useMediaQuery } from "@/hooks/use-media-query";
 import { cn } from "@/lib/utils";
 
 import { PhotographerPortfolioNotes } from "./photographer-portfolio-notes";
@@ -75,7 +83,6 @@ const SHOT_SETTINGS: Record<string, { aperture: string; shutter: string; stock: 
 const HERO_TONE = {
   mute: "text-black/40",
   ink: "text-black",
-  accent: "text-[#c2410c]",
 } as const;
 
 const PORTFOLIO: CardStackItem[] = [
@@ -138,9 +145,9 @@ const HERO_MARK =
 
 function HeroMark({ children, className }: { children: ReactNode; className?: string }) {
   return (
-    <span className={cn(HERO_MARK, className)} aria-hidden>
+    <div className={cn(HERO_MARK, className)} aria-hidden>
       {children}
-    </span>
+    </div>
   );
 }
 
@@ -156,8 +163,8 @@ function HeroStory() {
   const type = "text-[clamp(1.25rem,2vw,1.75rem)] font-medium leading-[1.55] tracking-[-0.02em]";
 
   return (
-    <div className="max-w-[min(100%,36rem)] space-y-6">
-      <p className={type}>
+    <div className="flex flex-col gap-[1.15em]">
+      <div className={type}>
         <span className={HERO_TONE.mute}>Hi, I'm </span>
         <span className={HERO_TONE.ink}>{PHOTOGRAPHER.name}</span>
         <ProfileGlyph src={PHOTOGRAPHER.avatar} alt={PHOTOGRAPHER.studio} />
@@ -173,15 +180,11 @@ function HeroStory() {
         </HeroMark>
         <span className={HERO_TONE.mute}> </span>
         <span className={HERO_TONE.ink}>{PHOTOGRAPHER.location}</span>
-        <span className={HERO_TONE.mute}>
-          {" "}
-          — good light, real moments, and photos that don't feel forced.
-        </span>
-      </p>
+        <span className={HERO_TONE.mute}> and capture photos you hang on the wall.</span>
+      </div>
 
-      <p className={type}>
-        <span className={HERO_TONE.accent}>Booking Q3.</span>
-        <span className={HERO_TONE.mute}> </span>
+      <p className={type} style={{ textBoxTrim: "trim-both" } as CSSProperties}>
+        <span className={HERO_TONE.mute}>Booking Q3. </span>
         <a
           href={PHOTOGRAPHER.email}
           className={cn(HERO_TONE.ink, "underline-offset-[4px] hover:underline")}
@@ -219,7 +222,10 @@ function PrintCaption() {
   }
 
   return (
-    <figcaption className="relative z-10 shrink-0 border-b border-black/80 bg-transparent pb-3">
+    <figcaption
+      className="relative z-10 shrink-0 border-b border-black/80 pb-3"
+      style={{ backgroundColor: CANVAS }}
+    >
       <div className="flex items-baseline justify-between gap-4">
         <p className="text-[11px] font-medium uppercase tracking-[0.1em] text-black">
           {activeItem.title}
@@ -241,54 +247,162 @@ function PrintCaption() {
   );
 }
 
-const BASELINE = 8;
-const LAYOUT = {
-  shell: "px-6 sm:px-10 lg:px-14",
-  blockY: "py-8 lg:py-10",
-  grid: "gap-x-8 gap-y-8 lg:gap-x-10 lg:gap-y-10",
-} as const;
+const SHELL =
+  "px-6 pt-6 pb-[calc(var(--demo-chrome-reserve,5rem)+1.5rem)] sm:px-10 sm:pt-10 sm:pb-[calc(var(--demo-chrome-reserve,5rem)+2.5rem)] lg:px-14 lg:pt-14 lg:pb-[calc(var(--demo-chrome-reserve,5rem)+3.5rem)]";
+const PRINT_ASPECT = 5 / 4;
+/** Deepest stack layer y is -7.5% of card height — reserve a little extra for motion */
+const STACK_PEEK_RATIO = 0.1;
 
-function ProofStack({
+type PrintSize = { width: number; height: number; peek: number };
+
+function computePrintSize(
+  columnWidth: number,
+  budgetHeight: number,
+  captionHeight: number,
+): PrintSize {
+  const usable = Math.max(0, budgetHeight - captionHeight);
+  const maxPrintHeight = usable / (1 + STACK_PEEK_RATIO);
+  const height = Math.min(columnWidth * PRINT_ASPECT, maxPrintHeight);
+  const width = height / PRINT_ASPECT;
+
+  return {
+    width,
+    height,
+    peek: height * STACK_PEEK_RATIO,
+  };
+}
+
+function getPrintBudget(layoutEl: HTMLElement, stacked: boolean, columnWidth: number): number {
+  if (stacked) {
+    return columnWidth * PRINT_ASPECT;
+  }
+
+  const layoutRect = layoutEl.getBoundingClientRect();
+  const shell = layoutEl.parentElement;
+  if (!shell) {
+    return layoutEl.clientHeight;
+  }
+
+  const shellRect = shell.getBoundingClientRect();
+  const padBottom = Number.parseFloat(getComputedStyle(shell).paddingBottom);
+  const visibleBottom = shellRect.bottom - padBottom;
+  const visibleHeight = Math.max(0, visibleBottom - layoutRect.top);
+
+  return Math.min(layoutEl.clientHeight, visibleHeight);
+}
+
+function usePrintSize(
+  layoutRef: RefObject<HTMLElement | null>,
+  columnRef: RefObject<HTMLElement | null>,
+  captionRef: RefObject<HTMLElement | null>,
+) {
+  const [printSize, setPrintSize] = useState<PrintSize>({ width: 0, height: 0, peek: 0 });
+
+  useLayoutEffect(() => {
+    const layout = layoutRef.current;
+    const column = columnRef.current;
+    if (!layout || !column) return;
+
+    const measure = () => {
+      const columnWidth = column.clientWidth;
+      if (columnWidth <= 0) return;
+
+      const captionHeight = captionRef.current?.offsetHeight ?? 0;
+      const stacked = window.matchMedia("(max-width: 767px)").matches;
+
+      if (stacked) {
+        const height = columnWidth * PRINT_ASPECT;
+        setPrintSize({
+          width: columnWidth,
+          height,
+          peek: height * STACK_PEEK_RATIO,
+        });
+        return;
+      }
+
+      const budgetHeight = getPrintBudget(layout, false, columnWidth);
+      setPrintSize(computePrintSize(columnWidth, budgetHeight, captionHeight));
+    };
+
+    measure();
+
+    const observer = new ResizeObserver(measure);
+    observer.observe(layout);
+    observer.observe(column);
+    if (captionRef.current) observer.observe(captionRef.current);
+
+    return () => observer.disconnect();
+  }, [captionRef, columnRef, layoutRef]);
+
+  return printSize;
+}
+
+function PrintProof({
   stackRef,
   captionRef,
+  printSize,
+  stacked,
 }: {
   stackRef: RefObject<HTMLElement | null>;
   captionRef: RefObject<HTMLDivElement | null>;
+  printSize: PrintSize;
+  stacked: boolean;
 }) {
+  const ready = printSize.width > 0 && printSize.height > 0;
+
   return (
     <figure
       ref={stackRef}
-      className="ml-auto grid h-full min-h-0 w-full min-w-0 max-w-full grid-rows-[auto_minmax(0,1fr)] gap-y-3 sm:gap-y-4"
+      className={cn("flex w-full min-w-0 shrink-0 flex-col", !stacked && "md:ml-auto")}
+      style={!stacked && ready ? { width: printSize.width } : undefined}
     >
-      <div ref={captionRef} className="relative z-30 w-full shrink-0 bg-transparent">
+      <div
+        ref={captionRef}
+        className="relative z-30 w-full shrink-0"
+        style={{ backgroundColor: CANVAS }}
+      >
         <PrintCaption />
       </div>
-      <div className="@container/stack relative flex min-h-0 flex-1 items-end justify-end pt-[max(2.5rem,11%)]">
-        <CardStack.Frame className="relative aspect-[4/5] h-auto w-[min(100cqw,calc(100cqh*4/5))] max-h-full min-h-0 shrink-0 overflow-visible">
+
+      <div
+        aria-hidden="true"
+        className="w-full shrink-0"
+        style={{ aspectRatio: `${4 / (STACK_PEEK_RATIO * 5)}` }}
+      />
+
+      <div
+        className={cn(
+          "relative w-full shrink-0 overflow-visible",
+          stacked ? "aspect-[4/5]" : "md:ml-auto",
+        )}
+        style={!stacked && ready ? { width: printSize.width, height: printSize.height } : undefined}
+      >
+        <CardStack.Frame className="absolute inset-0 overflow-visible">
           <CardStack.LiveRegion />
-          <CardStack.Trigger aria-label="Show next photo" className="block size-full text-left">
-            <CardStack.Viewport className="relative size-full overflow-visible !min-h-0 !pt-0">
+          <CardStack.Trigger
+            aria-label="Show next photo"
+            className="absolute inset-0 block text-left"
+          >
+            <CardStack.Viewport className="size-full overflow-visible !min-h-0 !pt-0">
               <CardStack.List>
                 {(item, index, layer) => (
                   <CardStack.Card
                     key={item.id}
                     layer={layer}
                     stackIndex={index}
-                    className="size-full gap-0 overflow-visible rounded-none bg-transparent p-0 shadow-none ring-0 [background-image:none]"
+                    className="!inset-x-0 !top-0 !h-fit !w-full gap-0 overflow-visible rounded-none !bg-transparent p-0 shadow-none ring-0"
                   >
-                    <figure className="flex size-full flex-col border-0 bg-transparent p-0">
-                      <div className="relative min-h-0 w-full flex-1 overflow-hidden bg-black/5">
-                        <img
-                          src={item.image}
-                          alt={`${PHOTOGRAPHER.studio} — ${item.title}`}
-                          width={PRINT_WIDTH}
-                          height={PRINT_HEIGHT}
-                          decoding="async"
-                          draggable={false}
-                          className="absolute inset-0 size-full object-cover object-center"
-                        />
-                        {index === 0 ? <ViewfinderFrame /> : null}
-                      </div>
+                    <figure className="relative aspect-[4/5] size-full overflow-hidden bg-black/5">
+                      <img
+                        src={item.image}
+                        alt={`${PHOTOGRAPHER.studio} — ${item.title}`}
+                        width={PRINT_WIDTH}
+                        height={PRINT_HEIGHT}
+                        decoding="async"
+                        draggable={false}
+                        className="size-full object-cover object-center"
+                      />
+                      {index === 0 ? <ViewfinderFrame /> : null}
                     </figure>
                   </CardStack.Card>
                 )}
@@ -302,38 +416,47 @@ function ProofStack({
 }
 
 function PortfolioLayout({
+  layoutRef,
   stackRef,
   heroRef,
   captionRef,
 }: {
+  layoutRef: RefObject<HTMLDivElement | null>;
   stackRef: RefObject<HTMLElement | null>;
   heroRef: RefObject<HTMLDivElement | null>;
   captionRef: RefObject<HTMLDivElement | null>;
 }) {
+  const columnRef = useRef<HTMLDivElement>(null);
+  const stacked = useMediaQuery("(max-width: 767px)");
+  const printSize = usePrintSize(layoutRef, columnRef, captionRef);
+
   return (
     <div
+      ref={layoutRef}
       className={cn(
-        "grid h-[calc(100svh-var(--demo-chrome-reserve,5rem))] min-h-0 grid-cols-1 grid-rows-[auto_minmax(18rem,1fr)]",
-        "md:grid-cols-[minmax(0,2fr)_minmax(0,3fr)] md:grid-rows-1",
-        LAYOUT.grid,
-        LAYOUT.blockY,
+        "flex flex-col gap-8",
+        "md:min-h-0 md:flex-1 md:flex-row md:items-end md:justify-start md:gap-6 md:h-full",
       )}
-      style={{ "--layout-baseline": `${BASELINE}px` } as CSSProperties}
     >
-      <div className="flex min-h-0 flex-col justify-end md:col-start-1 md:row-start-1 md:pt-[clamp(3rem,11vh,8rem)]">
-        <div ref={heroRef} className="relative z-20 w-fit max-w-full bg-transparent">
-          <HeroStory />
-        </div>
+      <div ref={heroRef} className="relative z-20 min-w-0 md:flex-[2] md:basis-0">
+        <HeroStory />
       </div>
 
-      <div className="relative z-20 flex min-h-0 min-w-0 flex-col overflow-visible md:col-start-2 md:row-start-1 md:h-full md:pl-6 md:pt-[clamp(3rem,11vh,8rem)] lg:pl-10">
-        <ProofStack stackRef={stackRef} captionRef={captionRef} />
+      <div ref={columnRef} className="w-full min-w-0 md:col-start-2 md:flex-[3] md:basis-0">
+        <PrintProof
+          stackRef={stackRef}
+          captionRef={captionRef}
+          printSize={printSize}
+          stacked={stacked}
+        />
       </div>
     </div>
   );
 }
 
 export default function PhotographerPortfolio() {
+  const shellRef = useRef<HTMLDivElement>(null);
+  const layoutRef = useRef<HTMLDivElement>(null);
   const stackRef = useRef<HTMLElement>(null);
   const heroRef = useRef<HTMLDivElement>(null);
   const captionRef = useRef<HTMLDivElement>(null);
@@ -342,7 +465,7 @@ export default function PhotographerPortfolio() {
   return (
     <>
       <section
-        className="relative isolate min-h-[calc(100svh-var(--demo-chrome-reserve,5rem))] overflow-hidden"
+        className="relative isolate min-h-svh overflow-x-hidden overflow-y-auto md:h-svh md:overflow-hidden"
         style={{ backgroundColor: CANVAS, color: INK, fontFamily: FONT }}
       >
         <TrailingImage
@@ -358,12 +481,18 @@ export default function PhotographerPortfolio() {
 
         <CardStack items={PORTFOLIO} depth={3} autoplay={preloaderDone} autoplayInterval={4500}>
           <div
+            ref={shellRef}
             className={cn(
-              "relative z-20 isolate mx-auto min-h-[calc(100svh-var(--demo-chrome-reserve,5rem))] w-full max-w-[92rem] pb-[var(--demo-chrome-reserve,5rem)]",
-              LAYOUT.shell,
+              "relative z-20 isolate mx-auto flex w-full max-w-[92rem] flex-col md:h-full md:min-h-0 md:flex-1",
+              SHELL,
             )}
           >
-            <PortfolioLayout stackRef={stackRef} heroRef={heroRef} captionRef={captionRef} />
+            <PortfolioLayout
+              layoutRef={layoutRef}
+              stackRef={stackRef}
+              heroRef={heroRef}
+              captionRef={captionRef}
+            />
           </div>
         </CardStack>
       </section>

--- a/app/demo/library/hero/photographer-portfolio.tsx
+++ b/app/demo/library/hero/photographer-portfolio.tsx
@@ -57,7 +57,7 @@ const PHOTOGRAPHER = {
   studio: "Maya Chen",
   name: "Maya",
   location: "Brooklyn",
-  email: "mailto:hello@mayachen.studio",
+  email: "mailto:hello@codse.com",
   avatar: lummi(LUMMI_ASSETS.avatar),
 };
 
@@ -288,21 +288,21 @@ function PrintProof({
   captionRef: RefObject<HTMLDivElement | null>;
 }) {
   return (
-    <figure ref={stackRef} className="flex w-full min-w-0 flex-col">
-      <div
-        ref={captionRef}
-        className="relative z-30 w-full shrink-0"
-        style={{ backgroundColor: CANVAS }}
-      >
-        <PrintCaption />
-      </div>
-
+    <figure ref={stackRef} className="flex w-full min-w-0 flex-col md:items-end">
       <div
         className={cn(
-          "flex w-full flex-col",
-          "md:ml-auto md:w-[min(100cqw,calc((100cqh-4.5rem)*8/11))]",
+          "flex w-full min-w-0 flex-col",
+          "md:w-[min(100cqw,calc((100cqh-4.5rem)*8/11))]",
         )}
       >
+        <div
+          ref={captionRef}
+          className="relative z-30 w-full shrink-0"
+          style={{ backgroundColor: CANVAS }}
+        >
+          <PrintCaption />
+        </div>
+
         <div aria-hidden="true" className={cn("w-full shrink-0", STACK_PEEK)} />
         <div className="relative aspect-[4/5] w-full shrink-0 overflow-visible">
           <PrintStack />
@@ -325,11 +325,10 @@ function PortfolioLayout({
     <div
       className={cn("flex flex-col gap-8", "md:h-full md:min-h-0 md:flex-1 md:flex-row md:gap-6")}
     >
-      <div
-        ref={heroRef}
-        className="relative z-20 min-w-0 md:flex md:flex-[2] md:basis-0 md:flex-col md:justify-end"
-      >
-        <HeroStory />
+      <div className="relative z-20 min-w-0 md:flex md:flex-[2] md:basis-0 md:flex-col md:justify-end">
+        <div ref={heroRef}>
+          <HeroStory />
+        </div>
       </div>
 
       <div className="w-full min-w-0 md:flex md:min-h-0 md:flex-[3] md:basis-0 md:flex-col md:justify-end md:@container/print md:[container-type:size]">

--- a/app/demo/library/shared/card-stack-people.ts
+++ b/app/demo/library/shared/card-stack-people.ts
@@ -1,0 +1,181 @@
+import { CARD_STACK_MASK_IDS, type CardStackItem } from "@/animata/card/card-stack";
+
+export const DEMO_PEOPLE: CardStackItem[] = [
+  {
+    id: "maya",
+    image:
+      "https://assets.lummi.ai/assets/QmPyqQgSM8sDVrcQxRwUA6fTDaeXkLMvpf6Z3Kx4aCg3pU?auto=format&w=500",
+    title: "Maya Chen",
+    tagline: "Portrait photographer · Brooklyn",
+    counts: { like: 142, comment: 23 },
+    maskId: CARD_STACK_MASK_IDS[0],
+  },
+  {
+    id: "jordan",
+    image:
+      "https://assets.lummi.ai/assets/QmVDPTUj31YYC4ycLmn3r1FhuSZDHBdK4d3Pk4gdbyB5MZ?auto=format&w=500",
+    title: "Jordan Okonkwo",
+    tagline: "Editorial · Lagos",
+    counts: { like: 98, comment: 17 },
+    maskId: CARD_STACK_MASK_IDS[1],
+  },
+  {
+    id: "elena",
+    image:
+      "https://assets.lummi.ai/assets/QmXp6StB1i36XHbbmppop5AwtQgnyom8bYTZqPkLVNGJnk?auto=format&w=500",
+    title: "Elena Ruiz",
+    tagline: "Food stylist · Mexico City",
+    counts: { like: 176, comment: 41 },
+    maskId: CARD_STACK_MASK_IDS[2],
+  },
+  {
+    id: "sam",
+    image:
+      "https://assets.lummi.ai/assets/QmWmYYozQAtxLohY8Hy1yopo4ds25KokJfNdtqybXnR5cw?auto=format&w=500",
+    title: "Sam Ortiz",
+    tagline: "Documentary · Austin",
+    counts: { like: 64, comment: 12 },
+    maskId: CARD_STACK_MASK_IDS[3],
+  },
+  {
+    id: "priya",
+    image:
+      "https://assets.lummi.ai/assets/QmdybQRQqnqUKugP2e9hTaQi9GUciQkBADkrMVJ6GERsS2?auto=format&w=500",
+    title: "Priya Nair",
+    tagline: "Fashion · Mumbai",
+    counts: { like: 211, comment: 33 },
+    maskId: CARD_STACK_MASK_IDS[0],
+  },
+  {
+    id: "leo",
+    image:
+      "https://assets.lummi.ai/assets/QmaEVTC9eFZtSLTJmMVNpd2t9ctw1BXPzQKV4rhja62Y5z?auto=format&w=500",
+    title: "Leo Bergström",
+    tagline: "Architecture · Stockholm",
+    counts: { like: 87, comment: 9 },
+    maskId: CARD_STACK_MASK_IDS[1],
+  },
+];
+
+export const CREATOR_META: Record<
+  string,
+  { city: string; rate: string; specialty: string; available: string }
+> = {
+  maya: {
+    city: "Brooklyn, NY",
+    rate: "$320 / hr",
+    specialty: "Natural light portraits",
+    available: "Thu – Sat",
+  },
+  jordan: {
+    city: "Lagos, NG",
+    rate: "$280 / hr",
+    specialty: "Editorial campaigns",
+    available: "Mon – Wed",
+  },
+  elena: {
+    city: "Mexico City",
+    rate: "$240 / hr",
+    specialty: "Recipe & table scenes",
+    available: "Fri – Sun",
+  },
+  sam: {
+    city: "Austin, TX",
+    rate: "$300 / hr",
+    specialty: "Long-form documentary",
+    available: "By request",
+  },
+  priya: {
+    city: "Mumbai",
+    rate: "$360 / hr",
+    specialty: "Runway & lookbooks",
+    available: "Tue – Thu",
+  },
+  leo: {
+    city: "Stockholm",
+    rate: "$290 / hr",
+    specialty: "Spatial & interior",
+    available: "Mon – Fri",
+  },
+};
+
+export const CANDIDATE_META: Record<string, { role: string; stage: string; skills: string[] }> = {
+  maya: {
+    role: "Senior product designer",
+    stage: "Phone screen",
+    skills: ["Figma", "Design systems", "Prototyping"],
+  },
+  jordan: {
+    role: "Staff frontend engineer",
+    stage: "Portfolio review",
+    skills: ["React", "Motion", "Accessibility"],
+  },
+  elena: {
+    role: "Brand designer",
+    stage: "Take-home",
+    skills: ["Typography", "Art direction", "Print"],
+  },
+  sam: {
+    role: "Design engineer",
+    stage: "Technical interview",
+    skills: ["TypeScript", "CSS", "Storybook"],
+  },
+  priya: {
+    role: "Visual designer",
+    stage: "Culture fit",
+    skills: ["Illustration", "Motion", "3D"],
+  },
+  leo: {
+    role: "UX researcher",
+    stage: "Panel",
+    skills: ["Interviews", "Synthesis", "Workshops"],
+  },
+};
+
+export const LOOKBOOK_ITEMS: CardStackItem[] = [
+  {
+    id: "shell",
+    image: "https://images.unsplash.com/photo-1556821840-3a63f95609a7?auto=format&w=800&q=80",
+    title: "Shell track",
+    tagline: "Drop 04 · outerwear",
+    counts: { like: 148, comment: 42 },
+    maskId: CARD_STACK_MASK_IDS[2],
+  },
+  {
+    id: "oxide",
+    image: "https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?auto=format&w=800&q=80",
+    title: "Oxide tee",
+    tagline: "Drop 04 · knits",
+    counts: { like: 68, comment: 38 },
+    maskId: CARD_STACK_MASK_IDS[3],
+  },
+  {
+    id: "cargo",
+    image: "https://images.unsplash.com/photo-1624378515194-6fc7111942f2?auto=format&w=800&q=80",
+    title: "Cargo wide",
+    tagline: "Drop 04 · bottoms",
+    counts: { like: 124, comment: 34 },
+    maskId: CARD_STACK_MASK_IDS[0],
+  },
+  {
+    id: "mesh",
+    image: "https://images.unsplash.com/photo-1591047139829-d91aecb6caea?auto=format&w=800&q=80",
+    title: "Mesh layer",
+    tagline: "Drop 04 · layers",
+    counts: { like: 92, comment: 36 },
+    maskId: CARD_STACK_MASK_IDS[1],
+  },
+  {
+    id: "cap",
+    image: "https://images.unsplash.com/photo-1588850561407-ed78c036e952?auto=format&w=800&q=80",
+    title: "Wax cap",
+    tagline: "Drop 04 · accessories",
+    counts: { like: 44, comment: 32 },
+    maskId: CARD_STACK_MASK_IDS[3],
+  },
+];
+
+export const GUEST_ITEMS: CardStackItem[] = DEMO_PEOPLE.map((person) => ({
+  ...person,
+  tagline: person.tagline.split(" · ")[0] ?? person.tagline,
+}));

--- a/app/demo/library/shared/profile-stack-card.tsx
+++ b/app/demo/library/shared/profile-stack-card.tsx
@@ -30,6 +30,7 @@ export function ProfileStackCard({
       stackIndex={index}
       className={cn(
         "bg-linear-to-br from-[#f5efe6] via-[#faf8f5] to-white ring-white/20",
+        "dark:from-pink-950 dark:via-card dark:to-card dark:ring-border/60",
         cardClassName,
       )}
     >
@@ -42,11 +43,11 @@ export function ProfileStackCard({
 
       {showMetrics ? (
         <CardStack.Footer>
-          <CardStack.Metric icon={Heart} label="Likes" value={item.counts.like} />
+          <CardStack.Metric icon={Heart} label="Likes" value={item.counts?.like ?? 0} />
           <CardStack.Metric
             icon={MessageCircle}
             label="Comments"
-            value={item.counts.comment}
+            value={item.counts?.comment ?? 0}
             className="ms-1"
           />
           <ArrowRight aria-hidden className="ml-auto size-6 shrink-0 text-black/40" />

--- a/app/demo/library/shared/profile-stack-card.tsx
+++ b/app/demo/library/shared/profile-stack-card.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { ArrowRight, Heart, MessageCircle } from "lucide-react";
+
+import CardStack, {
+  type CardStackItem,
+  type CardStackLayerMotion,
+} from "@/animata/card/card-stack";
+import { cn } from "@/lib/utils";
+
+interface ProfileStackCardProps {
+  item: CardStackItem;
+  index: number;
+  layer: CardStackLayerMotion;
+  cardClassName?: string;
+  showMetrics?: boolean;
+}
+
+export function ProfileStackCard({
+  item,
+  index,
+  layer,
+  cardClassName,
+  showMetrics = true,
+}: ProfileStackCardProps) {
+  return (
+    <CardStack.Card
+      key={item.id}
+      layer={layer}
+      stackIndex={index}
+      className={cn(
+        "bg-linear-to-br from-[#f5efe6] via-[#faf8f5] to-white ring-white/20",
+        cardClassName,
+      )}
+    >
+      <CardStack.Header>
+        <CardStack.Avatar src={item.image} />
+        <CardStack.Meta title={item.title} tagline={item.tagline} />
+      </CardStack.Header>
+
+      <CardStack.Media src={item.image} alt={`Portrait of ${item.title}`} maskId={item.maskId} />
+
+      {showMetrics ? (
+        <CardStack.Footer>
+          <CardStack.Metric icon={Heart} label="Likes" value={item.counts.like} />
+          <CardStack.Metric
+            icon={MessageCircle}
+            label="Comments"
+            value={item.counts.comment}
+            className="ms-1"
+          />
+          <ArrowRight aria-hidden className="ml-auto size-6 shrink-0 text-black/40" />
+        </CardStack.Footer>
+      ) : null}
+    </CardStack.Card>
+  );
+}

--- a/components/shapes/card-stack-mask-defs.tsx
+++ b/components/shapes/card-stack-mask-defs.tsx
@@ -5,7 +5,7 @@ export function CardStackMaskDefs(props: SVGProps<SVGSVGElement>) {
     <svg aria-hidden width={0} height={0} xmlns="http://www.w3.org/2000/svg" {...props}>
       <defs>
         <mask
-          id="cs_mask_1_ellipse-1"
+          id="cardstack_mask_ellipse-1"
           width="200"
           height="200"
           x="0"
@@ -21,7 +21,7 @@ export function CardStackMaskDefs(props: SVGProps<SVGSVGElement>) {
         </mask>
 
         <mask
-          id="cs_mask_1_flower-14"
+          id="cardstack_mask_flower-14"
           width="200"
           height="194"
           x="0"
@@ -36,7 +36,7 @@ export function CardStackMaskDefs(props: SVGProps<SVGSVGElement>) {
         </mask>
 
         <mask
-          id="cs_mask_1_flower-1"
+          id="cardstack_mask_flower-1"
           width="200"
           height="186"
           x="0"
@@ -51,7 +51,7 @@ export function CardStackMaskDefs(props: SVGProps<SVGSVGElement>) {
         </mask>
 
         <mask
-          id="cs_mask_1_misc-5"
+          id="cardstack_mask_misc-5"
           width="200"
           height="185"
           x="0"

--- a/components/shapes/card-stack-mask-defs.tsx
+++ b/components/shapes/card-stack-mask-defs.tsx
@@ -1,0 +1,70 @@
+import type { SVGProps } from "react";
+
+export function CardStackMaskDefs(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg aria-hidden width={0} height={0} xmlns="http://www.w3.org/2000/svg" {...props}>
+      <defs>
+        <mask
+          id="cs_mask_1_ellipse-1"
+          width="200"
+          height="200"
+          x="0"
+          y="0"
+          maskUnits="userSpaceOnUse"
+          style={{ maskType: "alpha" }}
+        >
+          <path
+            d="M0 100C0 44.772 44.772 0 100 0s100 44.772 100 100-44.772 100-100 100S0 155.228 0 100z"
+            fill="#fff"
+            fillRule="evenodd"
+          />
+        </mask>
+
+        <mask
+          id="cs_mask_1_flower-14"
+          width="200"
+          height="194"
+          x="0"
+          y="3"
+          maskUnits="userSpaceOnUse"
+          style={{ maskType: "alpha" }}
+        >
+          <path
+            d="M60.87 29.427c14.184-35.236 64.076-35.236 78.26 0a25.028 25.028 0 0021.519 15.608c37.828 2.56 53.333 49.971 24.205 74.248a24.967 24.967 0 00-8.222 25.283c9.275 36.775-31.175 65.993-63.313 45.867a25.138 25.138 0 00-26.638 0c-32.138 20.126-72.587-9.092-63.313-45.867a24.967 24.967 0 00-8.221-25.283C-13.983 95.006 1.522 47.594 39.35 45.035A25.028 25.028 0 0060.87 29.427z"
+            fill="#fff"
+          />
+        </mask>
+
+        <mask
+          id="cs_mask_1_flower-1"
+          width="200"
+          height="186"
+          x="0"
+          y="7"
+          maskUnits="userSpaceOnUse"
+          style={{ maskType: "alpha" }}
+        >
+          <path
+            d="M150.005 128.863c66.681 38.481-49.997 105.828-49.997 28.861 0 76.967-116.658 9.62-49.997-28.861-66.681 38.481-66.681-96.207 0-57.727-66.681-38.48 49.997-105.827 49.997-28.86 0-76.967 116.657-9.62 49.997 28.86 66.66-38.48 66.66 96.208 0 57.727z"
+            fill="#fff"
+          />
+        </mask>
+
+        <mask
+          id="cs_mask_1_misc-5"
+          width="200"
+          height="185"
+          x="0"
+          y="8"
+          maskUnits="userSpaceOnUse"
+          style={{ maskType: "alpha" }}
+        >
+          <path
+            d="M145 8c30.376 0 55 25 55 60 0 70-75 110-100 125C75 178 0 138 0 68 0 33 25 8 55 8c18.6 0 35 10 45 20 10-10 26.4-20 45-20z"
+            fill="#fff"
+          />
+        </mask>
+      </defs>
+    </svg>
+  );
+}

--- a/components/shapes/ellipse-1.tsx
+++ b/components/shapes/ellipse-1.tsx
@@ -1,0 +1,71 @@
+import type { SVGProps } from "react";
+
+export function Ellipse1(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      className="coolshapes ellipse-1"
+      height="400"
+      width="400"
+      fill="none"
+      viewBox="0 0 200 200"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <g clipPath="url(#cs_clip_1_ellipse-1)">
+        <mask
+          height="200"
+          id="cs_mask_1_ellipse-1"
+          style={{ maskType: "alpha" }}
+          width="200"
+          x="0"
+          y="0"
+          maskUnits="userSpaceOnUse"
+        >
+          <path
+            d="M0 100C0 44.772 44.772 0 100 0s100 44.772 100 100-44.772 100-100 100S0 155.228 0 100z"
+            fill="#fff"
+            fillRule="evenodd"
+          />
+        </mask>
+        <g mask="url(#cs_mask_1_ellipse-1)">
+          <path d="M200 0H0v200h200V0z" fill="#fff" />
+          <path d="M200 0H0v200h200V0z" fill="url(#paint0_linear_748_4808)" />
+          <g filter="url(#filter0_f_748_4808)">
+            <path d="M130 0H69v113h61V0z" fill="#FF58E4" />
+            <path d="M196 91H82v102h114V91z" fill="#0CE548" fillOpacity="0.35" />
+            <path d="M113 80H28v120h85V80z" fill="#FFE500" fillOpacity="0.74" />
+          </g>
+        </g>
+      </g>
+      <defs>
+        <filter
+          height="310"
+          id="filter0_f_748_4808"
+          width="278"
+          x="-27"
+          y="-55"
+          filterUnits="userSpaceOnUse"
+          colorInterpolationFilters="sRGB"
+        >
+          <feFlood result="BackgroundImageFix" floodOpacity="0" />
+          <feBlend result="shape" in="SourceGraphic" in2="BackgroundImageFix" />
+          <feGaussianBlur result="effect1_foregroundBlur_748_4808" stdDeviation="27.5" />
+        </filter>
+        <linearGradient
+          id="paint0_linear_748_4808"
+          gradientUnits="userSpaceOnUse"
+          x1="186.5"
+          x2="37"
+          y1="37"
+          y2="186.5"
+        >
+          <stop stopColor="#0E6FFF" stopOpacity="0.51" />
+          <stop offset="1" stopColor="#00F0FF" stopOpacity="0.59" />
+        </linearGradient>
+        <clipPath id="cs_clip_1_ellipse-1">
+          <path d="M0 0H200V200H0z" fill="#fff" />
+        </clipPath>
+      </defs>
+    </svg>
+  );
+}

--- a/components/shapes/flower-1.tsx
+++ b/components/shapes/flower-1.tsx
@@ -1,0 +1,70 @@
+import type { SVGProps } from "react";
+
+export function Flower1(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      className="coolshapes flower-1"
+      height="400"
+      width="400"
+      fill="none"
+      viewBox="0 0 200 200"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <g clipPath="url(#cs_clip_1_flower-1)">
+        <mask
+          height="186"
+          id="cs_mask_1_flower-1"
+          style={{ maskType: "alpha" }}
+          width="200"
+          x="0"
+          y="7"
+          maskUnits="userSpaceOnUse"
+        >
+          <path
+            d="M150.005 128.863c66.681 38.481-49.997 105.828-49.997 28.861 0 76.967-116.658 9.62-49.997-28.861-66.681 38.481-66.681-96.207 0-57.727-66.681-38.48 49.997-105.827 49.997-28.86 0-76.967 116.657-9.62 49.997 28.86 66.66-38.48 66.66 96.208 0 57.727z"
+            fill="#fff"
+          />
+        </mask>
+        <g mask="url(#cs_mask_1_flower-1)">
+          <path d="M200 0H0v200h200V0z" fill="#fff" />
+          <path d="M200 0H0v200h200V0z" fill="url(#paint0_linear_748_4711)" />
+          <g filter="url(#filter0_f_748_4711)">
+            <path d="M130 0H69v113h61V0z" fill="#FF58E4" />
+            <path d="M196 91H82v102h114V91z" fill="#0CE548" fillOpacity="0.35" />
+            <path d="M113 80H28v120h85V80z" fill="#FFE500" fillOpacity="0.74" />
+          </g>
+        </g>
+      </g>
+      <defs>
+        <filter
+          height="310"
+          id="filter0_f_748_4711"
+          width="278"
+          x="-27"
+          y="-55"
+          filterUnits="userSpaceOnUse"
+          colorInterpolationFilters="sRGB"
+        >
+          <feFlood result="BackgroundImageFix" floodOpacity="0" />
+          <feBlend result="shape" in="SourceGraphic" in2="BackgroundImageFix" />
+          <feGaussianBlur result="effect1_foregroundBlur_748_4711" stdDeviation="27.5" />
+        </filter>
+        <linearGradient
+          id="paint0_linear_748_4711"
+          gradientUnits="userSpaceOnUse"
+          x1="186.5"
+          x2="37"
+          y1="37"
+          y2="186.5"
+        >
+          <stop stopColor="#0E6FFF" stopOpacity="0.51" />
+          <stop offset="1" stopColor="#00F0FF" stopOpacity="0.59" />
+        </linearGradient>
+        <clipPath id="cs_clip_1_flower-1">
+          <path d="M0 0H200V200H0z" fill="#fff" />
+        </clipPath>
+      </defs>
+    </svg>
+  );
+}

--- a/components/shapes/flower-14.tsx
+++ b/components/shapes/flower-14.tsx
@@ -1,0 +1,59 @@
+import type { SVGProps } from "react";
+
+export function Flower14(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      className="coolshapes flower-14"
+      height="400"
+      width="400"
+      fill="none"
+      viewBox="0 0 200 200"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <g clipPath="url(#cs_clip_1_flower-14)">
+        <mask
+          height="194"
+          id="cs_mask_1_flower-14"
+          style={{ maskType: "alpha" }}
+          width="200"
+          x="0"
+          y="3"
+          maskUnits="userSpaceOnUse"
+        >
+          <path
+            d="M60.87 29.427c14.184-35.236 64.076-35.236 78.26 0a25.028 25.028 0 0021.519 15.608c37.828 2.56 53.333 49.971 24.205 74.248a24.967 24.967 0 00-8.222 25.283c9.275 36.775-31.175 65.993-63.313 45.867a25.138 25.138 0 00-26.638 0c-32.138 20.126-72.587-9.092-63.313-45.867a24.967 24.967 0 00-8.221-25.283C-13.983 95.006 1.522 47.594 39.35 45.035A25.028 25.028 0 0060.87 29.427z"
+            fill="#fff"
+          />
+        </mask>
+        <g mask="url(#cs_mask_1_flower-14)">
+          <path d="M200 0H0v200h200V0z" fill="#fff" />
+          <path d="M200 0H0v200h200V0z" fill="#FFF500" fillOpacity="0.44" />
+          <g filter="url(#filter0_f_748_4584)">
+            <ellipse cx="106" cy="22.5" fill="#FF00D6" rx="88" ry="49.5" />
+            <ellipse cx="55.5" cy="160" fill="#07FFE1" rx="64.5" ry="45" />
+            <path d="M218 126H100v120h118V126z" fill="#FFC700" />
+          </g>
+        </g>
+      </g>
+      <defs>
+        <filter
+          height="433"
+          id="filter0_f_748_4584"
+          width="387"
+          x="-89"
+          y="-107"
+          filterUnits="userSpaceOnUse"
+          colorInterpolationFilters="sRGB"
+        >
+          <feFlood result="BackgroundImageFix" floodOpacity="0" />
+          <feBlend result="shape" in="SourceGraphic" in2="BackgroundImageFix" />
+          <feGaussianBlur result="effect1_foregroundBlur_748_4584" stdDeviation="40" />
+        </filter>
+        <clipPath id="cs_clip_1_flower-14">
+          <path d="M0 0H200V200H0z" fill="#fff" />
+        </clipPath>
+      </defs>
+    </svg>
+  );
+}

--- a/components/shapes/flower-5.tsx
+++ b/components/shapes/flower-5.tsx
@@ -1,0 +1,59 @@
+import type { SVGProps } from "react";
+
+export function Flower5(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      className="coolshapes flower-5"
+      height="400"
+      width="400"
+      fill="none"
+      viewBox="0 0 200 200"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <g clipPath="url(#cs_clip_1_flower-5)">
+        <mask
+          height="200"
+          id="cs_mask_1_flower-5"
+          style={{ maskType: "alpha" }}
+          width="200"
+          x="0"
+          y="0"
+          maskUnits="userSpaceOnUse"
+        >
+          <path
+            d="M140.395 59.605C175.502 64.644 200 77.28 200 100c0 22.72-24.498 35.356-59.605 40.395C135.356 175.502 122.72 200 100 200c-22.72 0-35.356-24.498-40.395-59.605C24.498 135.356 0 122.72 0 100c0-22.72 24.498-35.356 59.605-40.395C64.644 24.498 77.28 0 100 0c22.72 0 35.356 24.498 40.395 59.605z"
+            fill="#fff"
+          />
+        </mask>
+        <g mask="url(#cs_mask_1_flower-5)">
+          <path d="M200 0H0v200h200V0z" fill="#fff" />
+          <path d="M200 0H0v200h200V0z" fill="#FF6C02" fillOpacity="0.19" />
+          <g filter="url(#filter0_f_748_4670)">
+            <path d="M194 128H41v118h153V128z" fill="#FFC700" />
+            <path d="M106 13H21v87h85V13z" fill="#FFE500" />
+            <path d="M95 56H-23v87H95V56z" fill="#00C5DF" />
+          </g>
+        </g>
+      </g>
+      <defs>
+        <filter
+          height="358"
+          id="filter0_f_748_4670"
+          width="342"
+          x="-85.5"
+          y="-49.5"
+          filterUnits="userSpaceOnUse"
+          colorInterpolationFilters="sRGB"
+        >
+          <feFlood result="BackgroundImageFix" floodOpacity="0" />
+          <feBlend result="shape" in="SourceGraphic" in2="BackgroundImageFix" />
+          <feGaussianBlur result="effect1_foregroundBlur_748_4670" stdDeviation="31.25" />
+        </filter>
+        <clipPath id="cs_clip_1_flower-5">
+          <path d="M0 0H200V200H0z" fill="#fff" />
+        </clipPath>
+      </defs>
+    </svg>
+  );
+}

--- a/components/shapes/flower-5.tsx
+++ b/components/shapes/flower-5.tsx
@@ -1,6 +1,13 @@
-import type { SVGProps } from "react";
+"use client";
+
+import { type SVGProps, useId } from "react";
 
 export function Flower5(props: SVGProps<SVGSVGElement>) {
+  const uid = useId().replace(/:/g, "");
+  const clipId = `${uid}-clip`;
+  const maskId = `${uid}-mask`;
+  const filterId = `${uid}-filter`;
+
   return (
     <svg
       className="coolshapes flower-5"
@@ -11,10 +18,10 @@ export function Flower5(props: SVGProps<SVGSVGElement>) {
       xmlns="http://www.w3.org/2000/svg"
       {...props}
     >
-      <g clipPath="url(#cs_clip_1_flower-5)">
+      <g clipPath={`url(#${clipId})`}>
         <mask
           height="200"
-          id="cs_mask_1_flower-5"
+          id={maskId}
           style={{ maskType: "alpha" }}
           width="200"
           x="0"
@@ -26,10 +33,10 @@ export function Flower5(props: SVGProps<SVGSVGElement>) {
             fill="#fff"
           />
         </mask>
-        <g mask="url(#cs_mask_1_flower-5)">
+        <g mask={`url(#${maskId})`}>
           <path d="M200 0H0v200h200V0z" fill="#fff" />
           <path d="M200 0H0v200h200V0z" fill="#FF6C02" fillOpacity="0.19" />
-          <g filter="url(#filter0_f_748_4670)">
+          <g filter={`url(#${filterId})`}>
             <path d="M194 128H41v118h153V128z" fill="#FFC700" />
             <path d="M106 13H21v87h85V13z" fill="#FFE500" />
             <path d="M95 56H-23v87H95V56z" fill="#00C5DF" />
@@ -39,7 +46,7 @@ export function Flower5(props: SVGProps<SVGSVGElement>) {
       <defs>
         <filter
           height="358"
-          id="filter0_f_748_4670"
+          id={filterId}
           width="342"
           x="-85.5"
           y="-49.5"
@@ -50,7 +57,7 @@ export function Flower5(props: SVGProps<SVGSVGElement>) {
           <feBlend result="shape" in="SourceGraphic" in2="BackgroundImageFix" />
           <feGaussianBlur result="effect1_foregroundBlur_748_4670" stdDeviation="31.25" />
         </filter>
-        <clipPath id="cs_clip_1_flower-5">
+        <clipPath id={clipId}>
           <path d="M0 0H200V200H0z" fill="#fff" />
         </clipPath>
       </defs>

--- a/components/shapes/index.ts
+++ b/components/shapes/index.ts
@@ -1,0 +1,6 @@
+export { CardStackMaskDefs } from "./card-stack-mask-defs";
+export { Ellipse1 } from "./ellipse-1";
+export { Flower1 } from "./flower-1";
+export { Flower5 } from "./flower-5";
+export { Flower14 } from "./flower-14";
+export { Misc5 } from "./misc-5";

--- a/components/shapes/misc-5.tsx
+++ b/components/shapes/misc-5.tsx
@@ -1,6 +1,14 @@
-import type { SVGProps } from "react";
+"use client";
+
+import { type SVGProps, useId } from "react";
 
 export function Misc5(props: SVGProps<SVGSVGElement>) {
+  const uid = useId().replace(/:/g, "");
+  const clipId = `${uid}-clip`;
+  const maskId = `${uid}-mask`;
+  const paint0Id = `${uid}-paint0`;
+  const paint1Id = `${uid}-paint1`;
+
   return (
     <svg
       className="coolshapes misc-5"
@@ -11,10 +19,10 @@ export function Misc5(props: SVGProps<SVGSVGElement>) {
       xmlns="http://www.w3.org/2000/svg"
       {...props}
     >
-      <g clipPath="url(#cs_clip_1_misc-5)">
+      <g clipPath={`url(#${clipId})`}>
         <mask
           height="185"
-          id="cs_mask_1_misc-5"
+          id={maskId}
           style={{ maskType: "alpha" }}
           width="200"
           x="0"
@@ -26,15 +34,15 @@ export function Misc5(props: SVGProps<SVGSVGElement>) {
             fill="#fff"
           />
         </mask>
-        <g mask="url(#cs_mask_1_misc-5)">
+        <g mask={`url(#${maskId})`}>
           <path d="M200 0H0v200h200V0z" fill="#fff" />
-          <path d="M200 0H0v200h200V0z" fill="url(#paint0_radial_748_5033)" />
-          <path d="M200 0H0v200h200V0z" fill="url(#paint1_radial_748_5033)" />
+          <path d="M200 0H0v200h200V0z" fill={`url(#${paint0Id})`} />
+          <path d="M200 0H0v200h200V0z" fill={`url(#${paint1Id})`} />
         </g>
       </g>
       <defs>
         <radialGradient
-          id="paint0_radial_748_5033"
+          id={paint0Id}
           cx="0"
           cy="0"
           gradientTransform="rotate(116.694 71.023 87.946) scale(199.234)"
@@ -45,7 +53,7 @@ export function Misc5(props: SVGProps<SVGSVGElement>) {
           <stop offset="1" stopColor="#FF00D6" stopOpacity="0" />
         </radialGradient>
         <radialGradient
-          id="paint1_radial_748_5033"
+          id={paint1Id}
           cx="0"
           cy="0"
           gradientTransform="rotate(48.452 -12.085 35.502) scale(223.143)"
@@ -56,7 +64,7 @@ export function Misc5(props: SVGProps<SVGSVGElement>) {
           <stop offset="0.461" stopColor="#FF7171" stopOpacity="0.84" />
           <stop offset="1" stopColor="#FFF500" stopOpacity="0" />
         </radialGradient>
-        <clipPath id="cs_clip_1_misc-5">
+        <clipPath id={clipId}>
           <path d="M0 0H200V200H0z" fill="#fff" />
         </clipPath>
       </defs>

--- a/components/shapes/misc-5.tsx
+++ b/components/shapes/misc-5.tsx
@@ -1,0 +1,65 @@
+import type { SVGProps } from "react";
+
+export function Misc5(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      className="coolshapes misc-5"
+      height="400"
+      width="400"
+      fill="none"
+      viewBox="0 0 200 200"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <g clipPath="url(#cs_clip_1_misc-5)">
+        <mask
+          height="185"
+          id="cs_mask_1_misc-5"
+          style={{ maskType: "alpha" }}
+          width="200"
+          x="0"
+          y="8"
+          maskUnits="userSpaceOnUse"
+        >
+          <path
+            d="M145 8c30.376 0 55 25 55 60 0 70-75 110-100 125C75 178 0 138 0 68 0 33 25 8 55 8c18.6 0 35 10 45 20 10-10 26.4-20 45-20z"
+            fill="#fff"
+          />
+        </mask>
+        <g mask="url(#cs_mask_1_misc-5)">
+          <path d="M200 0H0v200h200V0z" fill="#fff" />
+          <path d="M200 0H0v200h200V0z" fill="url(#paint0_radial_748_5033)" />
+          <path d="M200 0H0v200h200V0z" fill="url(#paint1_radial_748_5033)" />
+        </g>
+      </g>
+      <defs>
+        <radialGradient
+          id="paint0_radial_748_5033"
+          cx="0"
+          cy="0"
+          gradientTransform="rotate(116.694 71.023 87.946) scale(199.234)"
+          gradientUnits="userSpaceOnUse"
+          r="1"
+        >
+          <stop stopColor="#FFF500" />
+          <stop offset="1" stopColor="#FF00D6" stopOpacity="0" />
+        </radialGradient>
+        <radialGradient
+          id="paint1_radial_748_5033"
+          cx="0"
+          cy="0"
+          gradientTransform="rotate(48.452 -12.085 35.502) scale(223.143)"
+          gradientUnits="userSpaceOnUse"
+          r="1"
+        >
+          <stop stopColor="#FF00D6" />
+          <stop offset="0.461" stopColor="#FF7171" stopOpacity="0.84" />
+          <stop offset="1" stopColor="#FFF500" stopOpacity="0" />
+        </radialGradient>
+        <clipPath id="cs_clip_1_misc-5">
+          <path d="M0 0H200V200H0z" fill="#fff" />
+        </clipPath>
+      </defs>
+    </svg>
+  );
+}

--- a/components/ui/map-pin.tsx
+++ b/components/ui/map-pin.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import type { Variants } from "motion/react";
+import { motion, useAnimation } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface MapPinIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface MapPinIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const SVG_VARIANTS: Variants = {
+  normal: {
+    y: 0,
+  },
+  animate: {
+    y: [0, -5, -3],
+    transition: {
+      duration: 0.5,
+      times: [0, 0.6, 1],
+    },
+  },
+};
+
+const CIRCLE_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    pathOffset: [0.5, 0],
+    transition: {
+      delay: 0.3,
+      duration: 0.5,
+      opacity: { duration: 0.1, delay: 0.3 },
+    },
+  },
+};
+
+const MapPinIcon = forwardRef<MapPinIconHandle, MapPinIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseEnter?.(e);
+        } else {
+          controls.start("animate");
+        }
+      },
+      [controls, onMouseEnter]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseLeave?.(e);
+        } else {
+          controls.start("normal");
+        }
+      },
+      [controls, onMouseLeave]
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          animate={controls}
+          fill="none"
+          height={size}
+          initial="normal"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          variants={SVG_VARIANTS}
+          viewBox="0 0 24 24"
+          width={size}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0" />
+          <motion.circle
+            animate={controls}
+            cx="12"
+            cy="10"
+            initial="normal"
+            r="3"
+            variants={CIRCLE_VARIANTS}
+          />
+        </motion.svg>
+      </div>
+    );
+  }
+);
+
+MapPinIcon.displayName = "MapPinIcon";
+
+export { MapPinIcon };

--- a/components/ui/map-pin.tsx
+++ b/components/ui/map-pin.tsx
@@ -61,24 +61,22 @@ const MapPinIcon = forwardRef<MapPinIconHandle, MapPinIconProps>(
 
     const handleMouseEnter = useCallback(
       (e: React.MouseEvent<HTMLDivElement>) => {
-        if (isControlledRef.current) {
-          onMouseEnter?.(e);
-        } else {
+        onMouseEnter?.(e);
+        if (!isControlledRef.current) {
           controls.start("animate");
         }
       },
-      [controls, onMouseEnter]
+      [controls, onMouseEnter],
     );
 
     const handleMouseLeave = useCallback(
       (e: React.MouseEvent<HTMLDivElement>) => {
-        if (isControlledRef.current) {
-          onMouseLeave?.(e);
-        } else {
+        onMouseLeave?.(e);
+        if (!isControlledRef.current) {
           controls.start("normal");
         }
       },
-      [controls, onMouseLeave]
+      [controls, onMouseLeave],
     );
 
     return (

--- a/components/ui/switch-camera.tsx
+++ b/components/ui/switch-camera.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { motion, useAnimation, type Variants } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface SwitchCameraIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface SwitchCameraIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const PATH_VARIANTS: Variants = {
+  normal: { pathLength: 1 },
+  animate: {
+    pathLength: [0, 1],
+    transition: { duration: 0.4, ease: "linear" },
+  },
+};
+
+const SwitchCameraIcon = forwardRef<SwitchCameraIconHandle, SwitchCameraIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (event: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseEnter?.(event);
+          return;
+        }
+        controls.start("animate");
+      },
+      [controls, onMouseEnter],
+    );
+
+    const handleMouseLeave = useCallback(
+      (event: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseLeave?.(event);
+          return;
+        }
+        controls.start("normal");
+      },
+      [controls, onMouseLeave],
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          animate={controls}
+          fill="none"
+          height={size}
+          initial="normal"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          viewBox="0 0 24 24"
+          width={size}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <motion.path
+            animate={controls}
+            d="M11 19H4a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2h5"
+            initial="normal"
+            variants={PATH_VARIANTS}
+          />
+          <motion.path
+            animate={controls}
+            d="M13 5h7a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2h-5"
+            initial="normal"
+            variants={PATH_VARIANTS}
+          />
+          <circle cx="12" cy="12" r="3" />
+          <motion.path
+            animate={controls}
+            d="m18 22-3-3 3-3"
+            initial="normal"
+            variants={PATH_VARIANTS}
+          />
+          <motion.path
+            animate={controls}
+            d="m6 2 3 3-3 3"
+            initial="normal"
+            variants={PATH_VARIANTS}
+          />
+        </motion.svg>
+      </div>
+    );
+  },
+);
+
+SwitchCameraIcon.displayName = "SwitchCameraIcon";
+
+export { SwitchCameraIcon };

--- a/components/ui/switch-camera.tsx
+++ b/components/ui/switch-camera.tsx
@@ -38,22 +38,20 @@ const SwitchCameraIcon = forwardRef<SwitchCameraIconHandle, SwitchCameraIconProp
 
     const handleMouseEnter = useCallback(
       (event: React.MouseEvent<HTMLDivElement>) => {
-        if (isControlledRef.current) {
-          onMouseEnter?.(event);
-          return;
+        onMouseEnter?.(event);
+        if (!isControlledRef.current) {
+          controls.start("animate");
         }
-        controls.start("animate");
       },
       [controls, onMouseEnter],
     );
 
     const handleMouseLeave = useCallback(
       (event: React.MouseEvent<HTMLDivElement>) => {
-        if (isControlledRef.current) {
-          onMouseLeave?.(event);
-          return;
+        onMouseLeave?.(event);
+        if (!isControlledRef.current) {
+          controls.start("normal");
         }
-        controls.start("normal");
       },
       [controls, onMouseLeave],
     );

--- a/content/docs/card/card-stack.mdx
+++ b/content/docs/card/card-stack.mdx
@@ -1,13 +1,19 @@
 ---
 title: Card Stack
-description: A composable, infinitely cycling card stack with SVG photo masks and synchronized shuffle motion.
+description: Click-through card stack with SVG photo masks. The deck loops; cards shuffle in one motion.
 labels: ["requires interaction", "click"]
-author: animata
+author: hari
 ---
 
 <ComponentPreview name="card-card-stack--primary" />
 
 ## Installation
+
+### CLI
+
+<RegistryInstall category="card" name="card-stack" />
+
+The registry item installs `card-stack.tsx` and `components/shapes/card-stack-mask-defs.tsx`.
 
 ### Manual
 
@@ -20,7 +26,7 @@ npm install motion lucide-react
 
 <Step>Create the mask definitions</Step>
 
-Card photos use CSS `mask-image` with SVG `<mask>` ids. Mount a hidden 0×0 SVG once per stack (via `CardStack.Masks`) so those ids resolve in the document.
+Photos use CSS `mask-image` pointing at SVG `<mask>` ids. Render a hidden 0×0 SVG once per stack (`CardStack.Masks`) so those ids exist in the document.
 
 ```bash
 mkdir -p components/shapes && touch components/shapes/card-stack-mask-defs.tsx
@@ -44,7 +50,7 @@ mkdir -p components/animata/card && touch components/animata/card/card-stack.tsx
 
 ## Usage
 
-Compose the stack with primitives. Pass an `items` array with stable `id`s, set `depth` (1–3 visible cards), and render each card inside `CardStack.List`.
+Build the stack from `CardStack.*` parts. Pass `items` with stable `id`s, set `depth` (1–3 visible cards), and render each card in `CardStack.List`.
 
 ```tsx
 import { Heart, MessageCircle } from "lucide-react";
@@ -96,26 +102,26 @@ const items: CardStackItem[] = [
 </CardStack>
 ```
 
-`CardStack.Trigger` is a `<button>` — clicking anywhere on the stack advances to the next card. Use `onItemsChange` on the root to observe the rotated array. Export `useCardStack()` inside custom children if you need `activeItem`, `advance`, or layer presets.
+`CardStack.Trigger` is a `<button>`. Click anywhere on the stack to advance. Hook `onItemsChange` on the root if you want the rotated array. Inside custom children, `useCardStack()` exposes `activeItem`, `advance`, and layer presets.
 
-Pick a mask per card with `CARD_STACK_MASK_IDS` (`ellipse-1`, `flower-14`, `flower-1`, `misc-5`). `CardStack.Media` accepts `aspect` (`square`, `4/5`, `3/4`, `16/10`, or `fill`).
+Each card gets a mask from `CARD_STACK_MASK_IDS`: `ellipse-1`, `flower-14`, `flower-1`, or `misc-5`. `CardStack.Media` takes `aspect`: `square`, `4/5`, `3/4`, `16/10`, or `fill`.
 
 ## How it works
 
-**Infinite rotation.** The root keeps the full `items` array and shows only the first `depth` entries. On advance, the front item moves to the back of the array — the same cards cycle forever without unmounting the whole stack.
+The root holds the full `items` array but only renders the first `depth` entries. On advance, the front item moves to the back. Same cards, infinite loop, no full remount.
 
-**Synchronized shuffle.** `CardStack.List` wraps cards in `AnimatePresence` with `mode="sync"`. When you click, the front card exits (`y: 420`, `scale: 0.96`) while cards behind interpolate to the next layer’s transform at the same time. That reads as one continuous shuffle, not exit-then-enter.
+`CardStack.List` uses `AnimatePresence` with `mode="sync"`. Click and the front card exits (`y: 420`, `scale: 0.96`) while the cards behind move up into the next layer at the same time. One shuffle, not exit-then-enter.
 
-**Layer depth via `zIndex`.** Motion drives stacking, not Tailwind `z-*` classes: front rests at `zIndex: 20`, middle at `5`, back at `0`. On exit the front card bumps to `zIndex: 30` so it slides out over the rising stack.
+Stacking order comes from Motion `zIndex`, not Tailwind `z-*`: front at 20, middle at 5, back at 0. On exit the front card jumps to 30 so it slides out over the stack rising underneath.
 
-**Click handling.** Only one shuffle runs at a time. Clicks during an animation are ignored — no queue of pending dismisses that keeps playing after you stop clicking.
+Only one shuffle runs at a time. Extra clicks during the animation are dropped. Nothing queues up and keeps playing after you stop clicking.
 
-**Peek-in.** The rearmost slot animates from a smaller, offset pose when a card first enters the visible stack. Cards promoted from middle slots use `initial={false}` so they tween from their current pose instead of re-entering.
+The back slot peeks in from a smaller offset when a card first becomes visible. Cards moving up from the middle use `initial={false}` so they tween from where they already are instead of popping in again.
 
-**Masks.** `CardStack.Masks` renders `CardStackMaskDefs` — a hidden SVG whose `<mask>` elements are referenced by `mask-image: url(#cs_mask_1_…)` on the photo. Keep one defs instance in the tree; duplicate ids break masking.
+`CardStack.Masks` renders `CardStackMaskDefs`, a hidden SVG. Photos reference its `<mask>` ids via `mask-image: url(#cs_mask_1_…)`. One defs instance per page; duplicate ids break masking.
 
-**Accessibility.** `CardStack.LiveRegion` announces the active card. Each card is a `motion.article` with `aria-roledescription`. Metrics expose visible counts with `sr-only` labels. Respects `prefers-reduced-motion`: rotation is instant and motion durations drop to zero.
+`CardStack.LiveRegion` announces the active card. Cards are `motion.article` with `aria-roledescription`. Metrics keep visible counts but label them in `sr-only` text. With `prefers-reduced-motion`, rotation is instant and durations go to zero.
 
 ## Credits
 
-Built by [Animata](https://animata.design)
+Built by [hari](https://github.com/hari)

--- a/content/docs/card/card-stack.mdx
+++ b/content/docs/card/card-stack.mdx
@@ -110,7 +110,7 @@ Each card gets a mask from `CARD_STACK_MASK_IDS`: `ellipse-1`, `flower-14`, `flo
 
 The root holds the full `items` array but only renders the first `depth` entries. On advance, the front item moves to the back. Same cards, infinite loop, no full remount.
 
-`CardStack.List` uses `AnimatePresence` with `mode="sync"`. Click and the front card exits (`y: 420`, `scale: 0.96`) while the cards behind move up into the next layer at the same time. One shuffle, not exit-then-enter.
+`CardStack.List` uses `AnimatePresence` with `mode="sync"`. Click and the front card exits (`y: "125%"`, `scale: 0.96`) while the cards behind move up into the next layer at the same time. One shuffle, not exit-then-enter.
 
 Stacking order comes from Motion `zIndex`, not Tailwind `z-*`: front at 20, middle at 5, back at 0. On exit the front card jumps to 30 so it slides out over the stack rising underneath.
 

--- a/content/docs/card/card-stack.mdx
+++ b/content/docs/card/card-stack.mdx
@@ -1,0 +1,121 @@
+---
+title: Card Stack
+description: A composable, infinitely cycling card stack with SVG photo masks and synchronized shuffle motion.
+labels: ["requires interaction", "click"]
+author: animata
+---
+
+<ComponentPreview name="card-card-stack--primary" />
+
+## Installation
+
+### Manual
+
+<Steps>
+<Step>Install dependencies</Step>
+
+```bash
+npm install motion lucide-react
+```
+
+<Step>Create the mask definitions</Step>
+
+Card photos use CSS `mask-image` with SVG `<mask>` ids. Mount a hidden 0×0 SVG once per stack (via `CardStack.Masks`) so those ids resolve in the document.
+
+```bash
+mkdir -p components/shapes && touch components/shapes/card-stack-mask-defs.tsx
+```
+
+```jsx file=<rootDir>/components/shapes/card-stack-mask-defs.tsx
+
+```
+
+<Step>Create the component</Step>
+
+```bash
+mkdir -p components/animata/card && touch components/animata/card/card-stack.tsx
+```
+
+```jsx file=<rootDir>/animata/card/card-stack.tsx
+
+```
+
+</Steps>
+
+## Usage
+
+Compose the stack with primitives. Pass an `items` array with stable `id`s, set `depth` (1–3 visible cards), and render each card inside `CardStack.List`.
+
+```tsx
+import { Heart, MessageCircle } from "lucide-react";
+import CardStack, { CARD_STACK_MASK_IDS, type CardStackItem } from "@/animata/card/card-stack";
+
+const items: CardStackItem[] = [
+  {
+    id: "hari",
+    image: "/hari.jpg",
+    title: "Hari Lamichhane",
+    tagline: "Software Engineer",
+    counts: { like: 142, comment: 23 },
+    maskId: CARD_STACK_MASK_IDS[0],
+  },
+  // …more items
+];
+
+<CardStack items={items} depth={3}>
+  <CardStack.Frame className="relative mx-auto w-full max-w-sm overflow-hidden">
+    <CardStack.Masks />
+    <CardStack.LiveRegion />
+
+    <CardStack.Trigger>
+      <CardStack.Viewport>
+        <CardStack.List>
+          {(item, index, layer) => (
+            <CardStack.Card key={item.id} layer={layer} stackIndex={index}>
+              <CardStack.Header>
+                <CardStack.Avatar src={item.image} />
+                <CardStack.Meta title={item.title} tagline={item.tagline} />
+              </CardStack.Header>
+
+              <CardStack.Media
+                src={item.image}
+                alt={`Portrait of ${item.title}`}
+                maskId={item.maskId}
+              />
+
+              <CardStack.Footer>
+                <CardStack.Metric icon={Heart} label="Likes" value={item.counts.like} />
+                <CardStack.Metric icon={MessageCircle} label="Comments" value={item.counts.comment} />
+              </CardStack.Footer>
+            </CardStack.Card>
+          )}
+        </CardStack.List>
+      </CardStack.Viewport>
+    </CardStack.Trigger>
+  </CardStack.Frame>
+</CardStack>
+```
+
+`CardStack.Trigger` is a `<button>` — clicking anywhere on the stack advances to the next card. Use `onItemsChange` on the root to observe the rotated array. Export `useCardStack()` inside custom children if you need `activeItem`, `advance`, or layer presets.
+
+Pick a mask per card with `CARD_STACK_MASK_IDS` (`ellipse-1`, `flower-14`, `flower-1`, `misc-5`). `CardStack.Media` accepts `aspect` (`square`, `4/5`, `3/4`, `16/10`, or `fill`).
+
+## How it works
+
+**Infinite rotation.** The root keeps the full `items` array and shows only the first `depth` entries. On advance, the front item moves to the back of the array — the same cards cycle forever without unmounting the whole stack.
+
+**Synchronized shuffle.** `CardStack.List` wraps cards in `AnimatePresence` with `mode="sync"`. When you click, the front card exits (`y: 420`, `scale: 0.96`) while cards behind interpolate to the next layer’s transform at the same time. That reads as one continuous shuffle, not exit-then-enter.
+
+**Layer depth via `zIndex`.** Motion drives stacking, not Tailwind `z-*` classes: front rests at `zIndex: 20`, middle at `5`, back at `0`. On exit the front card bumps to `zIndex: 30` so it slides out over the rising stack.
+
+**Click handling.** Only one shuffle runs at a time. Clicks during an animation are ignored — no queue of pending dismisses that keeps playing after you stop clicking.
+
+**Peek-in.** The rearmost slot animates from a smaller, offset pose when a card first enters the visible stack. Cards promoted from middle slots use `initial={false}` so they tween from their current pose instead of re-entering.
+
+**Masks.** `CardStack.Masks` renders `CardStackMaskDefs` — a hidden SVG whose `<mask>` elements are referenced by `mask-image: url(#cs_mask_1_…)` on the photo. Keep one defs instance in the tree; duplicate ids break masking.
+
+**Accessibility.** `CardStack.LiveRegion` announces the active card. Each card is a `motion.article` with `aria-roledescription`. Metrics expose visible counts with `sr-only` labels. Respects `prefers-reduced-motion`: rotation is instant and motion durations drop to zero.
+
+## Credits
+
+Built by [Animata](https://animata.design)

--- a/content/docs/card/card-stack.mdx
+++ b/content/docs/card/card-stack.mdx
@@ -90,8 +90,8 @@ const items: CardStackItem[] = [
               />
 
               <CardStack.Footer>
-                <CardStack.Metric icon={Heart} label="Likes" value={item.counts.like} />
-                <CardStack.Metric icon={MessageCircle} label="Comments" value={item.counts.comment} />
+                <CardStack.Metric icon={Heart} label="Likes" value={item.counts?.like ?? 0} />
+                <CardStack.Metric icon={MessageCircle} label="Comments" value={item.counts?.comment ?? 0} />
               </CardStack.Footer>
             </CardStack.Card>
           )}

--- a/content/docs/card/card-stack.mdx
+++ b/content/docs/card/card-stack.mdx
@@ -118,7 +118,7 @@ Only one shuffle runs at a time. Extra clicks during the animation are dropped. 
 
 The back slot peeks in from a smaller offset when a card first becomes visible. Cards moving up from the middle use `initial={false}` so they tween from where they already are instead of popping in again.
 
-`CardStack.Masks` renders `CardStackMaskDefs`, a hidden SVG. Photos reference its `<mask>` ids via `mask-image: url(#cs_mask_1_…)`. One defs instance per page; duplicate ids break masking.
+`CardStack.Masks` renders `CardStackMaskDefs`, a hidden SVG. Photos reference its `<mask>` ids via `mask-image: url(#cardstack_mask_…)`. One defs instance per page; duplicate ids break masking.
 
 `CardStack.LiveRegion` announces the active card. Cards are `motion.article` with `aria-roledescription`. Metrics keep visible counts but label them in `sr-only` text. With `prefers-reduced-motion`, rotation is instant and durations go to zero.
 

--- a/content/docs/changelog/2026-05.mdx
+++ b/content/docs/changelog/2026-05.mdx
@@ -27,7 +27,7 @@ Four new components, live demos at `/demo`, significant updates to Fluid and Shi
   </ChangeLogEntry>
   <ChangeLogEntry href="/docs/preloader/split-reveal">
     <h3>Split Reveal</h3>
-    <p>Fixed overlay preloader that loads images, locks scroll, and splits from the center seam when done.</p>
+    <p>Fixed overlay preloader that loads images, locks scroll, fades the progress UI, then splits from the center seam.</p>
   </ChangeLogEntry>
 </ChangeLogComponents>
 

--- a/content/docs/changelog/2026-05.mdx
+++ b/content/docs/changelog/2026-05.mdx
@@ -25,6 +25,10 @@ Four new components, live demos at `/demo`, significant updates to Fluid and Shi
     <h3>Card Stack</h3>
     <p>Composable card stack that cycles infinitely with SVG photo masks and a synchronized shuffle animation.</p>
   </ChangeLogEntry>
+  <ChangeLogEntry href="/docs/preloader/split-reveal">
+    <h3>Split Reveal</h3>
+    <p>Fixed overlay preloader that loads images, locks scroll, and splits from the center seam when done.</p>
+  </ChangeLogEntry>
 </ChangeLogComponents>
 
 ## Live demos
@@ -43,6 +47,10 @@ Full-page compositions at `/demo/{group}/{item}` with chrome that fades in on po
   <ChangeLogEntry href="/demo/browse/cinema-row">
     <h3>Stream · premiere browse</h3>
     <p>Premiere headline, scroll-snap poster row, and dual opposing Marquee columns.</p>
+  </ChangeLogEntry>
+  <ChangeLogEntry href="/demo/hero/photographer-portfolio">
+    <h3>Photographer portfolio</h3>
+    <p>Wedding photographer hero with Card Stack, Trailing Image trail, and Split Reveal preload.</p>
   </ChangeLogEntry>
 </ChangeLogComponents>
 

--- a/content/docs/changelog/2026-05.mdx
+++ b/content/docs/changelog/2026-05.mdx
@@ -1,10 +1,10 @@
 ---
 title: May 2026
-description: Boids Ecosystem, Sibling Focus Nav, Gooey Tabs, live demos at /demo, and Tailwind CSS 4.3.
+description: Boids Ecosystem, Sibling Focus Nav, Gooey Tabs, Card Stack, live demos at /demo, and Tailwind CSS 4.3.
 date: 2026-05-21
 ---
 
-Three new components, live demos at `/demo`, significant updates to Fluid and Shift tabs and Speed Dial, and a toolchain pass (pnpm, Tailwind 4.3, shadcn/ui resync).
+Four new components, live demos at `/demo`, significant updates to Fluid and Shift tabs and Speed Dial, and a toolchain pass (pnpm, Tailwind 4.3, shadcn/ui resync).
 
 ## New components
 
@@ -20,6 +20,10 @@ Three new components, live demos at `/demo`, significant updates to Fluid and Sh
   <ChangeLogEntry href="/docs/tabs/gooey-tabs">
     <h3>Gooey Tabs</h3>
     <p>Icon tabs with one expanding label merged through an SVG goo filter.</p>
+  </ChangeLogEntry>
+  <ChangeLogEntry href="/docs/card/card-stack">
+    <h3>Card Stack</h3>
+    <p>Composable card stack that cycles infinitely with SVG photo masks and a synchronized shuffle animation.</p>
   </ChangeLogEntry>
 </ChangeLogComponents>
 

--- a/content/docs/changelog/2026-05.mdx
+++ b/content/docs/changelog/2026-05.mdx
@@ -73,7 +73,7 @@ Removed Scrolling Testimonials as a standalone component — that pattern now li
   </ChangeLogEntry>
   <ChangeLogEntry href="/docs/card/card-stack">
     <h3>Card Stack</h3>
-    <p>Top-card press feedback now runs through the same transform channel as the shuffle animation instead of a CSS active scale on the trigger.</p>
+    <p>Top-card press feedback ran through the same transform channel as the shuffle animation instead of a CSS active scale on the trigger.</p>
   </ChangeLogEntry>
   <ChangeLogEntry href="/docs/preloader/split-reveal">
     <h3>Split Reveal</h3>
@@ -92,7 +92,7 @@ Migrated from Yarn 4 to pnpm. Upgraded Tailwind CSS to 4.3 and re-synced sevente
 <ChangeLogComponents>
   <ChangeLogEntry href="/demo/hero/photographer-portfolio">
     <h3>Photographer portfolio demo</h3>
-    <p>Caption and print column now share one width constraint on short viewports so metadata lines up with the 4:5 frame on MacBook-sized screens.</p>
+    <p>Caption and print column shared one width constraint on short viewports so metadata lined up with the 4:5 frame on MacBook-sized screens.</p>
   </ChangeLogEntry>
   <ChangeLogEntry href="/docs/card/glowing-card">
     <h3>Glowing Card</h3>

--- a/content/docs/changelog/2026-05.mdx
+++ b/content/docs/changelog/2026-05.mdx
@@ -27,7 +27,7 @@ Four new components, live demos at `/demo`, significant updates to Fluid and Shi
   </ChangeLogEntry>
   <ChangeLogEntry href="/docs/preloader/split-reveal">
     <h3>Split Reveal</h3>
-    <p>Fixed overlay preloader that loads images, locks scroll, fades the progress UI, then splits from the center seam.</p>
+    <p>Fixed overlay preloader that loads images, locks scroll, fades the progress UI, then splits from the center seam with CSS keyframes — no Motion dependency.</p>
   </ChangeLogEntry>
 </ChangeLogComponents>
 
@@ -50,7 +50,7 @@ Full-page compositions at `/demo/{group}/{item}` with chrome that fades in on po
   </ChangeLogEntry>
   <ChangeLogEntry href="/demo/hero/photographer-portfolio">
     <h3>Photographer portfolio</h3>
-    <p>Wedding photographer hero with Card Stack, Trailing Image trail, and Split Reveal preload.</p>
+    <p>Wedding photographer hero with Card Stack, Trailing Image trail, and Split Reveal preload. Print sizing uses container queries and aspect-ratio — no ResizeObserver.</p>
   </ChangeLogEntry>
 </ChangeLogComponents>
 
@@ -71,6 +71,14 @@ Removed Scrolling Testimonials as a standalone component — that pattern now li
     <h3>Speed Dial</h3>
     <p>Click-to-open with keyboard menu support and CSS stagger — no hover-only or Motion.</p>
   </ChangeLogEntry>
+  <ChangeLogEntry href="/docs/card/card-stack">
+    <h3>Card Stack</h3>
+    <p>Top-card press feedback now runs through the same transform channel as the shuffle animation instead of a CSS active scale on the trigger.</p>
+  </ChangeLogEntry>
+  <ChangeLogEntry href="/docs/preloader/split-reveal">
+    <h3>Split Reveal</h3>
+    <p>Replaced Motion shutters with CSS keyframes and custom easing. Preload waits for decoded images before revealing — no sessionStorage skip or early timeouts.</p>
+  </ChangeLogEntry>
 </ChangeLogComponents>
 
 Registry installs for all three tab variants now bundle `animata/tabs/shared.ts` for focus rings and arrow-key behavior.
@@ -82,6 +90,10 @@ Migrated from Yarn 4 to pnpm. Upgraded Tailwind CSS to 4.3 and re-synced sevente
 ## Bug fixes
 
 <ChangeLogComponents>
+  <ChangeLogEntry href="/demo/hero/photographer-portfolio">
+    <h3>Photographer portfolio demo</h3>
+    <p>Caption and print column now share one width constraint on short viewports so metadata lines up with the 4:5 frame on MacBook-sized screens.</p>
+  </ChangeLogEntry>
   <ChangeLogEntry href="/docs/card/glowing-card">
     <h3>Glowing Card</h3>
     <p>Fixed layout overflow and documented the @theme blur/glow tokens from the v3 config.</p>

--- a/content/docs/preloader/split-reveal.mdx
+++ b/content/docs/preloader/split-reveal.mdx
@@ -59,6 +59,8 @@ Drop it next to your page — no wrapper required:
 
 Pass `children` instead of `renderProgress` when you want full control over shutters and progress.
 
+Progress fades out before the shutters move. Tune the gap with `progressFadeMs` (default `280`) and the post-load pause with `holdMs`.
+
 ## Credits
 
 Images in demos may come from [Lummi](https://www.lummi.ai).

--- a/content/docs/preloader/split-reveal.mdx
+++ b/content/docs/preloader/split-reveal.mdx
@@ -1,0 +1,64 @@
+---
+title: Split Reveal
+description: Fixed overlay that preloads images, locks scroll, and splits from the center seam when done
+---
+
+<ComponentPreview name="preloader-split-reveal--primary" />
+
+## Installation
+
+### CLI
+
+<RegistryInstall category="preloader" name="split-reveal" />
+
+### Manual
+
+<Steps>
+<Step>Install dependencies</Step>
+
+```bash
+npm install motion
+```
+
+<Step>Run the following command</Step>
+
+It will create a new file `split-reveal.tsx` inside the `components/animata/preloader` directory.
+
+```bash
+mkdir -p components/animata/preloader && touch components/animata/preloader/split-reveal.tsx
+```
+
+<Step>Paste the code</Step>{" "}
+
+Open the newly created file and paste the following code:
+
+```jsx file=<rootDir>/animata/preloader/split-reveal.tsx
+
+```
+
+</Steps>
+
+## Usage
+
+Drop it next to your page — no wrapper required:
+
+```tsx
+<section>{/* your layout */}</section>
+
+<SplitReveal
+  images={imageUrls}
+  lockScroll
+  onComplete={() => setReady(true)}
+  renderProgress={({ loaded, total }) => (
+    <p>
+      {loaded}/{total}
+    </p>
+  )}
+/>
+```
+
+Pass `children` instead of `renderProgress` when you want full control over shutters and progress.
+
+## Credits
+
+Images in demos may come from [Lummi](https://www.lummi.ai).

--- a/content/docs/preloader/split-reveal.mdx
+++ b/content/docs/preloader/split-reveal.mdx
@@ -1,6 +1,7 @@
 ---
 title: Split Reveal
-description: Fixed overlay that preloads images, locks scroll, and splits from the center seam when done
+description: Full-screen preloader that loads images, locks scroll, then opens from the center seam.
+author: hari
 ---
 
 <ComponentPreview name="preloader-split-reveal--primary" />
@@ -34,7 +35,7 @@ Open the newly created file and paste the following code:
 
 ## Usage
 
-Drop it next to your page — no wrapper required:
+Place it next to your page. No wrapper required.
 
 ```tsx
 <section>{/* your layout */}</section>
@@ -51,10 +52,20 @@ Drop it next to your page — no wrapper required:
 />
 ```
 
-Pass `children` instead of `renderProgress` when you want full control over shutters and progress.
+Use `renderProgress` to swap the center counter while keeping the default shutters. Pass `children` to replace the whole overlay.
 
-Progress fades out before the shutters move. Shutters use CSS keyframes with a custom cubic-bezier — tune timing with `revealDuration` (default `0.85`s), `progressFadeMs` (default `280`), and the post-load pause with `holdMs`.
+After the last image decodes, the loader waits (`holdMs`), fades the progress UI (`progressFadeMs`), then splits the shutters. Timing runs on CSS keyframes with a custom cubic-bezier. `revealDuration` defaults to `0.85`s.
+
+## How it works
+
+The component preloads every URL in `images` with `Image()` plus `decode()` when available. Scroll locks while the overlay is active and releases on `done`.
+
+Phases go `loading` → `fade-ui` → `reveal` → `done`. Shutters are plain divs animated with `@keyframes`; no Motion dependency. `useSplitReveal()` exposes phase, counts, and colors if you build a custom overlay in `children`.
+
+Restoring a tab from bfcache gets a fresh boot id so the preloader does not stick on a stale `0/0` count.
 
 ## Credits
 
-Images in demos may come from [Lummi](https://www.lummi.ai).
+Built by [hari](https://github.com/hari)
+
+Images from [Lummi](https://www.lummi.ai)

--- a/content/docs/preloader/split-reveal.mdx
+++ b/content/docs/preloader/split-reveal.mdx
@@ -14,12 +14,6 @@ description: Fixed overlay that preloads images, locks scroll, and splits from t
 ### Manual
 
 <Steps>
-<Step>Install dependencies</Step>
-
-```bash
-npm install motion
-```
-
 <Step>Run the following command</Step>
 
 It will create a new file `split-reveal.tsx` inside the `components/animata/preloader` directory.
@@ -59,7 +53,7 @@ Drop it next to your page — no wrapper required:
 
 Pass `children` instead of `renderProgress` when you want full control over shutters and progress.
 
-Progress fades out before the shutters move. Tune the gap with `progressFadeMs` (default `280`) and the post-load pause with `holdMs`.
+Progress fades out before the shutters move. Shutters use CSS keyframes with a custom cubic-bezier — tune timing with `revealDuration` (default `0.85`s), `progressFadeMs` (default `280`), and the post-load pause with `holdMs`.
 
 ## Credits
 

--- a/hooks/use-mouse-position.ts
+++ b/hooks/use-mouse-position.ts
@@ -1,37 +1,78 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
+
+type Point = {
+  x: number;
+  y: number;
+};
 
 export function useMousePosition(
   ref: React.RefObject<HTMLElement | null>,
-  callback?: ({ x, y }: { x: number; y: number }) => void,
+  callback?: (point: Point) => void,
 ) {
+  const callbackRef = useRef(callback);
+  const rectRef = useRef<DOMRect | null>(null);
+  const frameRef = useRef<number | null>(null);
+  const latestPointRef = useRef<Point | null>(null);
+
+  callbackRef.current = callback;
+
   useEffect(() => {
-    const handleMouseMove = (event: MouseEvent) => {
-      const { clientX, clientY } = event;
-      const { top, left } = ref.current?.getBoundingClientRect() || {
-        top: 0,
-        left: 0,
-      };
+    const node = ref.current;
+    if (!node) return;
 
-      callback?.({ x: clientX - left, y: clientY - top });
+    const updateRect = () => {
+      rectRef.current = node.getBoundingClientRect();
     };
 
-    const handleTouchMove = (event: TouchEvent) => {
-      const { clientX, clientY } = event.touches[0];
-      const { top, left } = ref.current?.getBoundingClientRect() || {
-        top: 0,
-        left: 0,
-      };
+    const flush = () => {
+      frameRef.current = null;
 
-      callback?.({ x: clientX - left, y: clientY - top });
+      if (latestPointRef.current) {
+        callbackRef.current?.(latestPointRef.current);
+      }
     };
 
-    ref.current?.addEventListener("mousemove", handleMouseMove);
-    ref.current?.addEventListener("touchmove", handleTouchMove);
+    const handlePointerMove = (event: PointerEvent) => {
+      if (!rectRef.current) {
+        updateRect();
+      }
 
-    const nodeRef = ref.current;
+      const currentRect = rectRef.current;
+      if (!currentRect) return;
+
+      latestPointRef.current = {
+        x: event.clientX - currentRect.left,
+        y: event.clientY - currentRect.top,
+      };
+
+      if (frameRef.current === null) {
+        frameRef.current = requestAnimationFrame(flush);
+      }
+    };
+
+    updateRect();
+
+    node.addEventListener("pointerenter", updateRect);
+    node.addEventListener("pointermove", handlePointerMove, {
+      passive: true,
+    });
+
+    window.addEventListener("resize", updateRect);
+    window.addEventListener("scroll", updateRect, {
+      passive: true,
+      capture: true,
+    });
+
     return () => {
-      nodeRef?.removeEventListener("mousemove", handleMouseMove);
-      nodeRef?.removeEventListener("touchmove", handleTouchMove);
+      node.removeEventListener("pointerenter", updateRect);
+      node.removeEventListener("pointermove", handlePointerMove);
+
+      window.removeEventListener("resize", updateRect);
+      window.removeEventListener("scroll", updateRect, true);
+
+      if (frameRef.current !== null) {
+        cancelAnimationFrame(frameRef.current);
+      }
     };
-  }, [ref, callback]);
+  }, [ref]);
 }

--- a/lib/inline-code.ts
+++ b/lib/inline-code.ts
@@ -40,9 +40,8 @@ export const inlineCodeProseCss = `
   .demo-notes-prose :is(p, li, td, th, dd, figcaption) code {
     position: relative;
     white-space: nowrap;
-    margin-inline: 0.06em 0.32em;
     border-radius: 0.35rem;
-    padding: 0.125rem 0.5rem 0.125rem 0.375rem;
+    padding: 0.125rem 0.5rem;
     font-family: var(--font-mono, ui-monospace, monospace);
     font-size: 0.88em;
     border: 1px solid ${inlineCodeLight.border};

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "lodash.startcase": "^4.4.0",
     "lucide-react": "^0.475.0",
     "mdast-util-toc": "^7.1.0",
-    "motion": "^12.0.0",
+    "motion": "^12.38.0",
     "next": "^16.1.5",
     "next-mdx-remote": "^6.0.0",
     "next-themes": "^0.4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,7 +108,7 @@ importers:
         specifier: ^7.1.0
         version: 7.1.0
       motion:
-        specifier: ^12.0.0
+        specifier: ^12.38.0
         version: 12.38.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       next:
         specifier: ^16.1.5

--- a/scripts/build-registry.js
+++ b/scripts/build-registry.js
@@ -202,15 +202,17 @@ function rewriteCoLocatedAnimataImports(content, fileRef) {
 }
 
 function registryFileEntry(ref, content) {
+  const installPath = ref.startsWith("components/") ? ref : `components/${ref}`;
+  const rewriteRef = ref.startsWith("components/") ? ref.slice("components/".length) : ref;
   return {
-    path: `components/${ref}`,
+    path: installPath,
     type: "registry:component",
-    target: `~/components/${ref}`,
-    content: rewriteCoLocatedAnimataImports(content, ref),
+    target: `~/${installPath}`,
+    content: rewriteCoLocatedAnimataImports(content, rewriteRef),
   };
 }
 
-function addAnimataSourceFile(ref, files, bundledRefs, queue) {
+function addBundledSourceFile(ref, files, bundledRefs, queue) {
   if (bundledRefs.has(ref)) return false;
   const abs = path.join(ROOT, ref);
   const content = readIfExists(abs);
@@ -235,19 +237,22 @@ function classifyImports(source) {
   const uiRefs = new Set();
   const hookRefs = new Set();
   const libRefs = new Set();
+  const shapeRefs = new Set();
   for (const spec of parseImports(source)) {
     if (spec.startsWith("@/animata/")) {
       const sub = spec.slice("@/animata/".length);
       animataRefs.add(sub);
     } else if (spec.startsWith("@/components/ui/")) {
       uiRefs.add(spec.slice("@/components/ui/".length));
+    } else if (spec.startsWith("@/components/shapes/")) {
+      shapeRefs.add(spec.slice("@/components/shapes/".length));
     } else if (spec.startsWith("@/hooks/")) {
       hookRefs.add(spec.slice("@/hooks/".length));
     } else if (spec.startsWith("@/lib/") && !spec.endsWith("/utils")) {
       libRefs.add(spec.slice("@/lib/".length));
     }
   }
-  return { animataRefs, uiRefs, hookRefs, libRefs };
+  return { animataRefs, uiRefs, hookRefs, libRefs, shapeRefs };
 }
 
 function toRegistryItemName(category, name) {
@@ -295,8 +300,8 @@ function buildItem(mdxPath) {
   const queue = [primarySource];
 
   for (const ref of fileRefs) {
-    if (!ref.startsWith("animata/") || ref === primaryRef) continue;
-    addAnimataSourceFile(ref, files, bundledRefs, queue);
+    if (ref === primaryRef) continue;
+    addBundledSourceFile(ref, files, bundledRefs, queue);
   }
 
   const dependencies = new Set(extractNpmDependencies(src));
@@ -304,13 +309,17 @@ function buildItem(mdxPath) {
   const processedHooks = new Set();
   while (queue.length) {
     const source = queue.shift();
-    const { animataRefs, uiRefs, hookRefs } = classifyImports(source);
+    const { animataRefs, uiRefs, hookRefs, shapeRefs } = classifyImports(source);
+
+    for (const shape of shapeRefs) {
+      addBundledSourceFile(`components/shapes/${shape}.tsx`, files, bundledRefs, queue);
+    }
 
     for (const sub of animataRefs) {
       const ref = resolveAnimataSourceRef(sub);
       if (ref && !hasPublishedRegistryDoc(sub)) {
         if (ref !== primaryRef) {
-          addAnimataSourceFile(ref, files, bundledRefs, queue);
+          addBundledSourceFile(ref, files, bundledRefs, queue);
         }
         if (ref === primaryRef || bundledRefs.has(ref)) {
           continue;

--- a/scripts/build-registry.js
+++ b/scripts/build-registry.js
@@ -301,6 +301,7 @@ function buildItem(mdxPath) {
 
   for (const ref of fileRefs) {
     if (ref === primaryRef) continue;
+    if (ref.startsWith("hooks/")) continue;
     addBundledSourceFile(ref, files, bundledRefs, queue);
   }
 


### PR DESCRIPTION
## Summary

- Added **Card Stack** component with SVG photo masks, infinite shuffle animation, and composable API.
- Added **Split Reveal** preloader — CSS keyframes (no Motion), fade-ui phase before curtain, proper image decode wait, bfcache-safe resume.
- Added **Photographer portfolio** live demo at `/demo/hero/photographer-portfolio` with Card Stack, Trailing Image trail, and Split Reveal; print sizing via container queries (no ResizeObserver).
- Updated May 2026 changelog, docs, registry, and demo sources.

## Test plan

- [ ] `/demo/hero/photographer-portfolio` — desktop + mobile layout, caption aligns with print on short viewports
- [ ] Card Stack shuffle + top-card press feedback feel natural
- [ ] Split Reveal: progress fades, shutters open, tab restore (Cmd+Shift+T) does not stick at 00/00
- [ ] Docs pages for Card Stack and Split Reveal render correctly
- [ ] `pnpm build` passes


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Card Stack: interactive animated card stack with masking, depth, autoplay, demo bento and profile card
  * Split Reveal: image preloader with phased progress, optional scroll-lock, and reveal timing
  * Trailing Image: reusable, prop-driven pointer trail with exclude-zones and z-index control
  * Photographer portfolio demo: new hero demo combining Card Stack, Trailing Image, and Split Reveal
  * New UI icons: animated MapPin and SwitchCamera
  * SVG shape library: reusable decorative shapes and mask defs

* **Documentation**
  * Guides, docs, and Storybook stories for Card Stack, Split Reveal, Trailing Image and demo

* **Bug Fixes**
  * Photographer portfolio layout tweak for short viewports

* **Chores**
  * Updated motion library dependency
* **Refactor**
  * Pointer tracking hook rewritten for Pointer Events and rAF batching
<!-- end of auto-generated comment: release notes by coderabbit.ai -->