### PR TITLE
fix(demo): polish picker UI and humanize demo notes

### DIFF
--- a/app/demo/demo-experience.tsx
+++ b/app/demo/demo-experience.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { Command as CommandPrimitive } from "cmdk";
 import {
+  CheckIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
   LayoutGridIcon,
@@ -21,7 +23,6 @@ import { Icons } from "@/components/icons";
 import {
   CommandEmpty,
   CommandGroup,
-  CommandInput,
   CommandItem,
   CommandList,
   Command as CommandRoot,
@@ -554,69 +555,76 @@ function DemoPicker({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogPortal>
-        <DialogOverlay className="bg-black/50 backdrop-blur-[3px] sm:bg-black/45" />
+        <DialogOverlay className="bg-black/50 backdrop-blur-[2px] sm:bg-black/40" />
         <DialogPrimitive.Content
           style={{ "--demo-accent": accentColor } as CSSProperties}
           aria-describedby={undefined}
           className={cn(
-            "demo-picker-shell fixed z-50 grid w-full gap-0 overflow-hidden border border-white/12 bg-[#141414]/96 text-white shadow-[0_28px_90px_-28px_rgb(0_0_0_/_0.88)] backdrop-blur-2xl outline-none",
-            "inset-x-0 bottom-0 top-auto max-h-[min(88svh,680px)] translate-x-0 translate-y-0 rounded-t-[28px] border-b-0",
+            "demo-picker-shell fixed z-50 flex w-full flex-col overflow-hidden border border-white/10 bg-[#141414] text-white shadow-[0_24px_80px_-32px_rgb(0_0_0_/_0.9)] outline-none",
+            "inset-x-0 bottom-0 top-auto max-h-[min(88svh,640px)] translate-x-0 translate-y-0 rounded-t-[20px] border-b-0",
             "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-bottom-4",
             "data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:slide-in-from-bottom-4",
-            "sm:inset-x-auto sm:bottom-auto sm:top-[50%] sm:left-[50%] sm:max-w-[min(92vw,28rem)] sm:translate-x-[-50%] sm:translate-y-[-50%] sm:rounded-[24px] sm:border-b",
+            "sm:inset-x-auto sm:bottom-auto sm:top-[50%] sm:left-[50%] sm:max-w-[min(92vw,24rem)] sm:translate-x-[-50%] sm:translate-y-[-50%] sm:rounded-[18px] sm:border-b",
             "sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=open]:zoom-in-95",
           )}
         >
           <div className="sm:hidden">
-            <div aria-hidden="true" className="mx-auto mt-2.5 h-1 w-10 rounded-full bg-white/18" />
+            <div aria-hidden="true" className="mx-auto mt-2 h-1 w-9 rounded-full bg-white/15" />
           </div>
 
-          <div className="flex items-start justify-between gap-3 border-b border-white/8 px-4 pb-3 pt-3 sm:pt-4">
-            <div className="min-w-0">
-              <DialogPrimitive.Title className="text-[15px] font-medium tracking-[-0.02em] text-white">
-                Browse demos
-              </DialogPrimitive.Title>
-              <DialogPrimitive.Description className="mt-0.5 text-[12px] text-white/45">
-                {DEMO_ITEMS.length} live {DEMO_ITEMS.length === 1 ? "experience" : "experiences"}
-              </DialogPrimitive.Description>
-            </div>
+          <div className="flex items-center justify-between gap-3 px-4 pb-3 pt-3.5 sm:pt-4">
+            <DialogPrimitive.Title className="text-[15px] font-medium tracking-[-0.01em] text-white">
+              Browse demos
+            </DialogPrimitive.Title>
+            <DialogPrimitive.Description className="sr-only">
+              Search and switch between live demo pages.
+            </DialogPrimitive.Description>
             <button
               type="button"
               aria-label="Close demo picker"
               onClick={() => onOpenChange(false)}
-              className="grid size-9 shrink-0 touch-manipulation place-items-center rounded-full text-white/55 transition-colors hover:bg-white/10 hover:text-white"
+              className="-mr-1 grid size-8 shrink-0 touch-manipulation place-items-center rounded-full text-white/45 transition-colors hover:bg-white/8 hover:text-white/75"
             >
               <XIcon aria-hidden="true" className="size-4" />
             </button>
           </div>
 
-          <CommandRoot className="bg-transparent">
-            <div className="px-3 pt-3">
-              <div className="demo-picker-search flex items-center gap-2 rounded-2xl border border-white/8 bg-white/[0.04] px-3">
-                <SearchIcon aria-hidden="true" className="size-4 shrink-0 text-white/35" />
-                <CommandInput
-                  placeholder="Search by name or category…"
-                  className="h-11 border-0 bg-transparent px-0 text-[15px] text-white placeholder:text-white/35 focus:ring-0"
-                />
-              </div>
+          <CommandRoot className="flex min-h-0 w-full flex-col bg-transparent">
+            <div
+              cmdk-input-wrapper=""
+              className="flex h-11 w-full shrink-0 items-center gap-2.5 border-y border-white/8 px-4"
+            >
+              <SearchIcon aria-hidden="true" className="size-4 shrink-0 text-white/30" />
+              <CommandPrimitive.Input
+                placeholder="Search demos…"
+                className="min-w-0 flex-1 bg-transparent text-[15px] text-white outline-none placeholder:text-white/35"
+              />
             </div>
 
-            <CommandList className="demo-picker-list max-h-[min(52svh,420px)] px-2 pb-2 pt-2">
-              <CommandEmpty className="rounded-2xl bg-white/[0.03] py-10 text-sm text-white/45">
-                No demos match that search.
+            <CommandList className="demo-picker-list max-h-[min(52svh,400px)] px-1.5 py-1 pb-3">
+              <CommandEmpty className="px-4 py-10 text-[14px] text-white/45">
+                Nothing matched that search.
               </CommandEmpty>
-              {DEMO_GROUPS.map((group) => (
+              {DEMO_GROUPS.map((group, groupIndex) => (
                 <CommandGroup
                   key={group.slug}
-                  heading={`${group.label} · ${group.items.length}`}
-                  className="pb-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-2 [&_[cmdk-group-heading]]:text-[10px] [&_[cmdk-group-heading]]:font-semibold [&_[cmdk-group-heading]]:tracking-[0.12em] [&_[cmdk-group-heading]]:text-white/40"
+                  heading={group.label}
+                  className="demo-picker-group p-0 [&:not(:last-child)]:pb-4 [&_[cmdk-group-heading]]:sr-only [&_[cmdk-item]:not(:last-child)]:mb-1"
                 >
+                  <div
+                    aria-hidden="true"
+                    className={cn(
+                      "px-3 pb-1.5 text-[12px] font-medium text-white/38",
+                      groupIndex === 0 ? "pt-2.5" : "pt-3",
+                    )}
+                  >
+                    {group.label}
+                  </div>
                   {group.items.map((rawItem) => {
                     const flatIndex = getItemIndex(group.slug, rawItem.slug);
                     const entry = DEMO_ITEMS[flatIndex];
                     const isActive =
                       entry.slug === activeItem.slug && entry.group.slug === activeGroup.slug;
-                    const itemAccent = demoThemeColor(entry, group);
 
                     return (
                       <CommandItem
@@ -626,33 +634,18 @@ function DemoPicker({
                         onFocus={() => onPrefetch(entry)}
                         onSelect={() => onSelect(entry)}
                         className={cn(
-                          "demo-picker-item mx-0.5 cursor-pointer rounded-2xl px-3 py-2.5 aria-selected:bg-white/[0.07] data-[selected=true]:bg-white/[0.07]",
-                          isActive && "demo-picker-item-live bg-white/[0.05]",
+                          "demo-picker-item mx-0.5 cursor-pointer rounded-lg px-3 py-2.5 aria-selected:bg-white/[0.07] data-[selected=true]:bg-white/[0.07]",
+                          isActive && "demo-picker-item-live bg-white/[0.04]",
                         )}
-                        style={
-                          isActive ? ({ "--item-accent": itemAccent } as CSSProperties) : undefined
-                        }
                       >
-                        <span
-                          aria-hidden="true"
-                          className={cn(
-                            "mt-1.5 size-1.5 shrink-0 rounded-full bg-white/20",
-                            isActive &&
-                              "bg-[var(--item-accent)] shadow-[0_0_10px_color-mix(in_srgb,var(--item-accent)_70%,transparent)]",
-                          )}
-                        />
-                        <span className="min-w-0 flex-1">
-                          <span className="block truncate text-[13px] font-medium tracking-[-0.015em] text-white/92">
-                            {entry.label}
-                          </span>
-                          <span className="mt-0.5 block truncate text-[12px] leading-snug text-white/42">
-                            {group.phrase}
-                          </span>
+                        <span className="min-w-0 flex-1 truncate text-[14px] text-white/88">
+                          {entry.label}
                         </span>
                         {isActive ? (
-                          <span className="shrink-0 self-center rounded-full border border-white/10 bg-white/[0.06] px-2 py-0.5 text-[10px] font-medium text-white/72">
-                            live
-                          </span>
+                          <CheckIcon
+                            aria-hidden="true"
+                            className="size-3.5 shrink-0 text-white/45"
+                          />
                         ) : null}
                       </CommandItem>
                     );
@@ -661,15 +654,6 @@ function DemoPicker({
               ))}
             </CommandList>
           </CommandRoot>
-
-          <div className="border-t border-white/8 px-4 py-2.5">
-            <p className="text-center font-mono text-[10px] leading-relaxed text-white/35 sm:hidden">
-              Swipe screen edges · tap grid to browse
-            </p>
-            <p className="hidden text-center font-mono text-[10px] leading-relaxed text-white/35 sm:block">
-              H home · ← → cycle · . picker · R refresh · F fullscreen
-            </p>
-          </div>
         </DialogPrimitive.Content>
       </DialogPortal>
     </Dialog>
@@ -980,24 +964,8 @@ function DemoShellStyles() {
         isolation: isolate;
       }
 
-      .demo-picker-shell::before {
-        content: "";
-        pointer-events: none;
-        position: absolute;
-        inset: 0;
-        border-radius: inherit;
-        background:
-          linear-gradient(180deg, rgb(255 255 255 / 0.08), transparent 22%),
-          radial-gradient(circle at 50% 0%, rgb(255 255 255 / 0.06), transparent 42%);
-      }
-
-      .demo-picker-search [cmdk-input-wrapper] {
-        border: 0;
-        padding: 0;
-      }
-
-      .demo-picker-search [cmdk-input-wrapper] svg {
-        display: none;
+      .demo-picker-group + .demo-picker-group {
+        border-top: 1px solid rgb(255 255 255 / 0.05);
       }
 
       .demo-picker-list {
@@ -1016,12 +984,8 @@ function DemoShellStyles() {
 
       .demo-picker-item {
         display: flex;
-        align-items: flex-start;
+        align-items: center;
         gap: 0.625rem;
-      }
-
-      .demo-picker-item-live {
-        box-shadow: inset 0 0 0 1px rgb(255 255 255 / 0.08);
       }
 
       .demo-chrome-pill {

--- a/app/demo/library/browse/cinema-row-notes.tsx
+++ b/app/demo/library/browse/cinema-row-notes.tsx
@@ -72,16 +72,15 @@ export function CinemaRowNotes() {
         id="demo-notes-title"
         eyebrow="Recipe"
         title="Stream browse"
-        description="Apple TV-style layout: gradient hero with staggered premiere copy, a scrolling poster rail, then a craft panel with twin vertical still columns. TMDB art — demo only."
+        description="Apple TV-style page: gradient hero, scrolling poster rail, craft panel with two vertical still columns. TMDB posters, demo only."
       />
 
       <DemoNotes.Section id="concept" index={1} title="Concept">
         <DemoNotes.Prose>
           <p>
-            Three bands on one page. The hero is type on a violet radial scrim — eyebrow, title,
-            tagline, runtime, and CTAs stagger in after load. Below that, premieres scroll
-            horizontally. The craft panel pairs short copy with two still columns drifting in
-            opposite directions.
+            Three bands stacked on one page. Hero copy sits on a violet radial scrim. Eyebrow,
+            title, tagline, runtime, and CTAs stagger in after load. Premieres scroll sideways
+            underneath. The craft panel is short copy plus two still columns moving opposite ways.
           </p>
         </DemoNotes.Prose>
       </DemoNotes.Section>
@@ -91,9 +90,9 @@ export function CinemaRowNotes() {
           <p>
             <code>WaveReveal</code> (<code>mode="word"</code>) on the hero title.{" "}
             <code>Marquee</code> on the premieres rail and both still columns (
-            <code>pauseOnHover</code>, <code>applyMask={"{false}"}</code> — local masks instead).
-            Hero rise/fall and delay math live in the demo file as <code>cinema-hero-rise</code>{" "}
-            plus <code>heroSequenceDelays()</code>.
+            <code>pauseOnHover</code>, <code>applyMask={"{false}"}</code>; we use local masks
+            instead). Hero rise/fall and delay math live in the demo file as{" "}
+            <code>cinema-hero-rise</code> plus <code>heroSequenceDelays()</code>.
           </p>
         </DemoNotes.Prose>
         <DemoNotes.ComponentLinks demoKey={DEMO_KEY} />
@@ -102,9 +101,9 @@ export function CinemaRowNotes() {
       <DemoNotes.Section id="build" index={3} title="How it's built">
         <DemoNotes.Prose>
           <p>
-            <code>heroSequenceDelays()</code> derives every entrance offset from the title word
-            count and <code>WaveReveal</code> timing — eyebrow through the premieres rail share one
-            sequence. <code>cinema-hero-rise</code> is a local keyframe (blur +{" "}
+            <code>heroSequenceDelays()</code> works out every entrance offset from the title word
+            count and <code>WaveReveal</code> timing. Eyebrow through the premieres rail all share
+            one sequence. <code>cinema-hero-rise</code> is a local keyframe (blur +{" "}
             <code>translateY</code>) on everything except the title words.
           </p>
           <p>
@@ -128,7 +127,7 @@ export function CinemaRowNotes() {
         <DemoNotes.Code caption="Hero delay sequence + WaveReveal">
           {HERO_SEQUENCE_SNIPPET}
         </DemoNotes.Code>
-        <DemoNotes.Code caption="Premieres rail — custom edge mask">
+        <DemoNotes.Code caption="Premieres rail, custom edge mask">
           {PREMIERES_SNIPPET}
         </DemoNotes.Code>
         <DemoNotes.Code caption="Craft panel still columns">{STILLS_SNIPPET}</DemoNotes.Code>

--- a/app/demo/library/footer/footer-wordmark-notes.tsx
+++ b/app/demo/library/footer/footer-wordmark-notes.tsx
@@ -43,7 +43,7 @@ export function FooterWordmarkNotes() {
             The type sits in the field. It doesn&apos;t float on top like a heading.
           </p>
           <p>
-            Not a clone — same hierarchy. One blue family in <code>oklch</code>, Syne 800 on the
+            Not a clone, but same hierarchy. One blue family in <code>oklch</code>, Syne 800 on the
             wordmark, IBM Plex on the links. Lucien uses a static texture; we put boids behind the
             gradient at low opacity instead.
           </p>
@@ -52,7 +52,7 @@ export function FooterWordmarkNotes() {
 
       <DemoNotes.Section id="components" index={2} title="Components used">
         <DemoNotes.Prose>
-          <p>Two Animata pieces — boids and SiblingFocusNav. The rest is layout and CSS.</p>
+          <p>Two Animata pieces: boids and SiblingFocusNav. The rest is layout and CSS.</p>
         </DemoNotes.Prose>
         <DemoNotes.ComponentLinks demoKey={DEMO_KEY} />
         <DemoNotes.Prose>
@@ -66,7 +66,7 @@ export function FooterWordmarkNotes() {
         <DemoNotes.Prose>
           <p>
             The wordmark is <strong>SVG</strong> <code>&lt;text&gt;</code>, not a styled heading.
-            That&apos;s the trick for edge-to-edge scaling — no clipping, no fighting{" "}
+            That&apos;s what makes edge-to-edge scaling work. No clipping, no fighting{" "}
             <code>clamp()</code> on a single HTML line.
           </p>
           <p>
@@ -90,7 +90,7 @@ export function FooterWordmarkNotes() {
       <DemoNotes.Section id="source" index={4} title="Full source">
         <DemoNotes.Prose>
           <p>
-            Pulled from the demo file at build time. Copy what you need below — component docs are
+            Pulled from the demo file at build time. Copy what you need below. Component docs are
             linked above.
           </p>
         </DemoNotes.Prose>

--- a/app/demo/library/hero/launch-shift-notes.tsx
+++ b/app/demo/library/hero/launch-shift-notes.tsx
@@ -30,8 +30,8 @@ export function LaunchShiftNotes() {
       <DemoNotes.Header
         id="demo-notes-title"
         eyebrow="Recipe"
-        title="Superhuman · platform hero"
-        description="The Grammarly → Superhuman rebrand hero from superhuman.com. Not affiliated; same headline and subhead, local layout."
+        title="Superhuman platform hero"
+        description="The Grammarly to Superhuman rebrand hero from superhuman.com. Not affiliated; same headline and subhead, local layout."
       />
 
       <DemoNotes.Section id="concept" index={1} title="Concept">
@@ -47,8 +47,8 @@ export function LaunchShiftNotes() {
           </p>
           <p>
             Black field, warm off-white body text, violet on the badge. Headline fades white to
-            gray, two lines so the gradient doesn&apos;t muddy the second row. Boids behind a
-            vignette for edge motion.
+            gray, split across two lines so the gradient doesn&apos;t muddy the second row. Boids
+            behind a vignette for edge motion.
           </p>
         </DemoNotes.Prose>
       </DemoNotes.Section>

--- a/app/demo/library/hero/photographer-portfolio-notes.tsx
+++ b/app/demo/library/hero/photographer-portfolio-notes.tsx
@@ -14,7 +14,7 @@ const TRAIL_EXCLUDE_SNIPPET = `<TrailingImage
   excludeRefs={[heroRef, captionRef]}
 />`;
 
-const LAYOUT_SNIPPET = `{/* mobile: column stack · desktop: 2:3 row, both pinned to bottom */}
+const LAYOUT_SNIPPET = `{/* mobile: column stack; desktop: 2:3 row, both pinned to bottom */}
 <div className="flex flex-col gap-8 md:h-full md:flex-1 md:flex-row md:gap-6">
   <div className="md:flex md:flex-[2] md:flex-col md:justify-end">{/* hero */}</div>
 
@@ -59,15 +59,15 @@ export function PhotographerPortfolioNotes() {
       <DemoNotes.Section id="concept" index={1} title="Concept">
         <DemoNotes.Prose>
           <p>
-            Fake site for Maya, a wedding photographer. White page, black type, not much else — name
-            and contact in the bottom-left, a tall stack of prints on the right. On phone the stack
-            goes full width; on desktop it sits on the right edge. Wedding stills from Lummi follow
-            the cursor behind everything.
+            Fake site for Maya, a wedding photographer. White page, black type, not much else. Name
+            and contact sit in the bottom-left; a tall stack of prints fills the right. On phone the
+            stack goes full width; on desktop it hugs the right edge. Wedding stills from Lummi
+            follow the cursor behind everything.
           </p>
           <p>
             The first thing you see is not the page. <code>SplitReveal</code> covers the screen,
             loads every image, and ticks progress on the center seam. When the batch finishes, the
-            halves slide apart. The layout was already there — just hidden.
+            halves slide apart. The layout was already there, just hidden.
           </p>
           <p>
             Whichever print is on top gets corner brackets, like a viewfinder. The rest are plain
@@ -79,14 +79,14 @@ export function PhotographerPortfolioNotes() {
       <DemoNotes.Section id="components" index={2} title="Components used">
         <DemoNotes.Prose>
           <p>
-            <code>SplitReveal</code> sits next to the page as a fixed overlay — pass{" "}
+            <code>SplitReveal</code> sits next to the page as a fixed overlay. Pass{" "}
             <code>images</code>, wire <code>onComplete</code>, done. We skipped the{" "}
             <code>.Content</code> wrapper on purpose; the real layout mounts normally underneath.
           </p>
           <p>
             <code>CardStack</code> advances the portfolio. Autoplay only starts after the preloader
             clears. <code>PrintCaption</code> mirrors the top frame with fake shutter metadata.
-            Camera and map pin icons are Lucide Animated — they only move on hover so the hero stays
+            Camera and map pin icons are Lucide Animated. They only move on hover so the hero stays
             quiet.
           </p>
           <p>
@@ -100,8 +100,8 @@ export function PhotographerPortfolioNotes() {
       <DemoNotes.Section id="build" index={3} title="How it's built">
         <DemoNotes.Prose>
           <p>
-            All image URLs live in <code>LUMMI_ASSETS</code> — six stack frames, twelve for trails,
-            one avatar — cropped through a shared <code>lummi()</code> helper.{" "}
+            All image URLs live in <code>LUMMI_ASSETS</code>: six stack frames, twelve for trails,
+            one avatar. All cropped through a shared <code>lummi()</code> helper.{" "}
             <code>PRELOAD_IMAGES</code> dedupes before SplitReveal sees them.
           </p>
           <p>
@@ -112,26 +112,26 @@ export function PhotographerPortfolioNotes() {
           <p>
             Print width was the annoying part. We tried JS measurement first; on desktop the caption
             and stack kept drifting out of sync. Switched to a size container on the print column
-            and capped width with <code>min(100cqw, calc((100cqh - 4.5rem) * 8 / 11))</code> — 4:5
-            frame plus a 10% peek strip (<code>aspect-[8/1]</code>) that fits the viewport height.
-            No <code>ResizeObserver</code>.
+            and capped width with <code>min(100cqw, calc((100cqh - 4.5rem) * 8 / 11))</code> for a
+            4:5 frame plus a 10% peek strip (<code>aspect-[8/1]</code>) that fits the viewport
+            height. No <code>ResizeObserver</code>.
           </p>
           <p>
             Caption had a white fill at one point. It fought the page background and made the
-            metadata feel like a sticker — dropped it; caption and page share the same canvas now.
+            metadata feel like a sticker. Dropped it; caption and page share the same canvas now.
           </p>
           <p>
-            For trails we first excluded the whole stack. Looked too clean — nothing ever crossed
-            the prints. Narrowed it to the hero and caption wrappers only.
+            For trails we first excluded the whole stack. Looked too clean; nothing ever crossed the
+            prints. Narrowed it to the hero and caption wrappers only.
           </p>
         </DemoNotes.Prose>
-        <DemoNotes.Code caption="Responsive print column — container query sizing">
+        <DemoNotes.Code caption="Responsive print column, container query sizing">
           {LAYOUT_SNIPPET}
         </DemoNotes.Code>
         <DemoNotes.Code caption="SplitReveal as a sibling overlay">
           {PRELOADER_SNIPPET}
         </DemoNotes.Code>
-        <DemoNotes.Code caption="Trail layer — exclude text wrappers">
+        <DemoNotes.Code caption="Trail layer, exclude text wrappers">
           {TRAIL_EXCLUDE_SNIPPET}
         </DemoNotes.Code>
       </DemoNotes.Section>
@@ -139,7 +139,7 @@ export function PhotographerPortfolioNotes() {
       <DemoNotes.Section id="credits" index={4} title="Credits">
         <DemoNotes.Prose>
           <p>
-            Photos from <a href="https://www.lummi.ai">Lummi</a> — wedding and event searches. IDs
+            Photos from <a href="https://www.lummi.ai">Lummi</a>, wedding and event searches. IDs
             are in <code>LUMMI_ASSETS</code>. Fine for demos; use your own shots for anything real.
           </p>
           <p>

--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -35,16 +35,27 @@ const CommandDialog = ({ children, ...props }: DialogProps) => {
   )
 }
 
+interface CommandInputProps
+  extends React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input> {
+  wrapperClassName?: string
+  hideIcon?: boolean
+}
+
 const CommandInput = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Input>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
->(({ className, ...props }, ref) => (
-  <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
-    <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+  CommandInputProps
+>(({ className, wrapperClassName, hideIcon, ...props }, ref) => (
+  <div
+    className={cn("flex min-w-0 flex-1 items-center border-b px-3", wrapperClassName)}
+    cmdk-input-wrapper=""
+  >
+    {hideIcon ? null : (
+      <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+    )}
     <CommandPrimitive.Input
       ref={ref}
       className={cn(
-        "flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+        "flex h-10 min-w-0 flex-1 rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "lint": "biome check .",
     "lint:fix": "biome check --fix .",
     "validate:demos": "node ./scripts/validate-demo-registry.js",
+    "validate:registry": "node ./scripts/validate-registry-install.js",
+    "validate:registry:build": "node ./scripts/validate-registry-install.js --build",
     "format": "biome format --write .",
     "storybook": "storybook dev -p 6006",
     "storybook:build": "storybook build -o public/preview",

--- a/scripts/validate-registry-install.js
+++ b/scripts/validate-registry-install.js
@@ -1,0 +1,355 @@
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const REGISTRY_DIR = path.join(ROOT, "public", "r");
+const SITE_URL = (process.env.NEXT_PUBLIC_APP_URL || "https://animata.design").replace(/\/$/, "");
+
+/** Representative installs — one dry-run per bundle shape. */
+const INSTALL_FIXTURES = [
+  {
+    id: "simple",
+    label: "single file, no npm deps",
+    item: "preloader/split-reveal.json",
+    expectFiles: ["components/animata/preloader/split-reveal.tsx"],
+    expectDeps: [],
+  },
+  {
+    id: "doc-bundled-shapes",
+    label: "mdx bundled file refs + shape imports",
+    item: "card/card-stack.json",
+    expectFiles: [
+      "components/animata/card/card-stack.tsx",
+      "components/shapes/card-stack-mask-defs.tsx",
+    ],
+    expectDeps: ["lucide-react", "motion"],
+  },
+  {
+    id: "co-located-shared",
+    label: "co-located helper rewritten to ./shared",
+    item: "tabs/fluid-tabs.json",
+    expectFiles: ["components/animata/tabs/fluid-tabs.tsx", "components/animata/tabs/shared.ts"],
+    expectDeps: ["lucide-react", "motion"],
+  },
+  {
+    id: "bundled-hook",
+    label: "bundled hook from @/hooks import",
+    item: "image/trailing-image.json",
+    expectFiles: ["components/animata/image/trailing-image.tsx", "hooks/use-mouse-position.ts"],
+    expectDeps: ["motion"],
+  },
+  {
+    id: "registry-dependencies",
+    label: "registryDependencies resolve to sibling items",
+    item: "card/card-spread.json",
+    localizeDeps: true,
+    expectFiles: [
+      "components/animata/card/card-spread.tsx",
+      "components/animata/widget/notes.tsx",
+      "components/animata/widget/shopping-list.tsx",
+    ],
+    expectDeps: [],
+  },
+];
+
+let failed = false;
+
+function error(message) {
+  console.error(`[registry-install] ${message}`);
+  failed = true;
+}
+
+function info(message) {
+  console.log(`[registry-install] ${message}`);
+}
+
+function walkRegistryJson(dir, acc = []) {
+  if (!fs.existsSync(dir)) return acc;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walkRegistryJson(full, acc);
+    } else if (entry.isFile() && entry.name.endsWith(".json")) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+function registryUrlToLocalPath(url) {
+  const prefix = `${SITE_URL}/r/`;
+  if (!url.startsWith(prefix)) return null;
+  return path.join(REGISTRY_DIR, url.slice(prefix.length));
+}
+
+function localizeRegistryItem(itemPath) {
+  const raw = JSON.parse(fs.readFileSync(itemPath, "utf8"));
+  if (!raw.registryDependencies?.length) return itemPath;
+
+  const localized = structuredClone(raw);
+  localized.registryDependencies = raw.registryDependencies.map((dep) => {
+    const local = registryUrlToLocalPath(dep);
+    if (!local) return dep;
+    if (!fs.existsSync(local)) {
+      error(
+        `missing local registry dependency for ${path.relative(REGISTRY_DIR, itemPath)}: ${dep}`,
+      );
+      return dep;
+    }
+    return local;
+  });
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "animata-registry-"));
+  const outPath = path.join(tmpDir, path.basename(itemPath));
+  fs.writeFileSync(outPath, `${JSON.stringify(localized, null, 2)}\n`);
+  return outPath;
+}
+
+function validateRegistryJsonStatic(jsonPath) {
+  const rel = path.relative(REGISTRY_DIR, jsonPath);
+  let item;
+
+  try {
+    item = JSON.parse(fs.readFileSync(jsonPath, "utf8"));
+  } catch {
+    error(`${rel}: invalid JSON`);
+    return;
+  }
+
+  if (!item.name || !item.type) {
+    error(`${rel}: missing name or type`);
+  }
+
+  if (!Array.isArray(item.files) || item.files.length === 0) {
+    error(`${rel}: files array is empty`);
+    return;
+  }
+
+  const paths = new Set();
+  for (const file of item.files) {
+    if (
+      !file.path ||
+      !file.type ||
+      typeof file.content !== "string" ||
+      file.content.trim() === ""
+    ) {
+      error(`${rel}: file entry missing path, type, or content`);
+      continue;
+    }
+    if (paths.has(file.path)) {
+      error(`${rel}: duplicate file path ${file.path}`);
+    }
+    paths.add(file.path);
+  }
+
+  for (const dep of item.registryDependencies ?? []) {
+    const local = registryUrlToLocalPath(dep);
+    if (local && !fs.existsSync(local)) {
+      error(`${rel}: registryDependency not found locally — ${dep}`);
+    }
+  }
+}
+
+function createShadcnWorkspace() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "animata-shadcn-"));
+
+  fs.writeFileSync(
+    path.join(dir, "package.json"),
+    `${JSON.stringify({ name: "animata-registry-install-test", private: true, type: "module", version: "0.0.0" }, null, 2)}\n`,
+  );
+
+  fs.writeFileSync(
+    path.join(dir, "tsconfig.json"),
+    `${JSON.stringify(
+      {
+        compilerOptions: {
+          target: "ES2017",
+          lib: ["dom", "dom.iterable", "esnext"],
+          allowJs: true,
+          skipLibCheck: true,
+          strict: true,
+          noEmit: true,
+          esModuleInterop: true,
+          module: "esnext",
+          moduleResolution: "bundler",
+          jsx: "preserve",
+          paths: { "@/*": ["./*"] },
+        },
+        include: ["**/*.ts", "**/*.tsx"],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  fs.mkdirSync(path.join(dir, "app"), { recursive: true });
+  fs.mkdirSync(path.join(dir, "lib"), { recursive: true });
+  fs.writeFileSync(path.join(dir, "app", "globals.css"), '@import "tailwindcss";\n');
+  fs.writeFileSync(
+    path.join(dir, "lib", "utils.ts"),
+    'export function cn(...inputs: Array<string | false | null | undefined>) {\n  return inputs.filter(Boolean).join(" ");\n}\n',
+  );
+
+  fs.writeFileSync(
+    path.join(dir, "components.json"),
+    `${JSON.stringify(
+      {
+        $schema: "https://ui.shadcn.com/schema.json",
+        style: "new-york",
+        rsc: true,
+        tsx: true,
+        tailwind: {
+          css: "app/globals.css",
+          baseColor: "stone",
+          cssVariables: true,
+          prefix: "",
+        },
+        aliases: {
+          components: "@/components",
+          utils: "@/lib/utils",
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  return dir;
+}
+
+function parseDryRunOutput(output) {
+  const files = [];
+  const deps = [];
+  let inDeps = false;
+
+  for (const line of output.split("\n")) {
+    const fileMatch = line.match(/^│ \+ (.+?) {2}create$/);
+    if (fileMatch) {
+      files.push(fileMatch[1].trim());
+      continue;
+    }
+
+    if (line.includes("├ Dependencies")) {
+      inDeps = true;
+      continue;
+    }
+
+    if (inDeps) {
+      const depMatch = line.match(/^│ \+ (.+)$/);
+      if (depMatch) {
+        deps.push(depMatch[1].trim().split("@")[0]);
+        continue;
+      }
+      if (line.includes("├ Files") || line.includes("│  ") || line.startsWith("└")) {
+        inDeps = false;
+      }
+    }
+  }
+
+  return { files, deps };
+}
+
+function runShadcnDryRun(workspaceDir, registryItemPath) {
+  const command = `npx shadcn@latest add -y --dry-run ${JSON.stringify(registryItemPath)}`;
+
+  try {
+    const output = execSync(command, {
+      cwd: workspaceDir,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 120_000,
+      env: { ...process.env, CI: "true" },
+    });
+    return { ok: true, output };
+  } catch (err) {
+    const stdout = err.stdout?.toString?.() ?? "";
+    const stderr = err.stderr?.toString?.() ?? "";
+    return { ok: false, output: `${stdout}\n${stderr}`.trim() };
+  }
+}
+
+function assertFixtureInstall(fixture, workspaceDir) {
+  const itemPath = path.join(REGISTRY_DIR, fixture.item);
+  if (!fs.existsSync(itemPath)) {
+    error(`fixture ${fixture.id}: missing ${fixture.item}`);
+    return;
+  }
+
+  const installPath = fixture.localizeDeps ? localizeRegistryItem(itemPath) : itemPath;
+  const result = runShadcnDryRun(workspaceDir, installPath);
+
+  if (!result.ok) {
+    error(`fixture ${fixture.id} (${fixture.label}): shadcn dry-run failed\n${result.output}`);
+    return;
+  }
+
+  const { files, deps } = parseDryRunOutput(result.output);
+
+  for (const expected of fixture.expectFiles) {
+    if (!files.includes(expected)) {
+      error(
+        `fixture ${fixture.id}: expected file "${expected}" in dry-run output. Got: ${files.join(", ") || "(none)"}`,
+      );
+    }
+  }
+
+  for (const expectedDep of fixture.expectDeps) {
+    if (!deps.includes(expectedDep)) {
+      error(
+        `fixture ${fixture.id}: expected npm dep "${expectedDep}". Got: ${deps.join(", ") || "(none)"}`,
+      );
+    }
+  }
+
+  info(`fixture ${fixture.id} OK — ${files.length} file(s), ${deps.length} npm dep(s)`);
+}
+
+function main() {
+  if (process.argv.includes("--build")) {
+    execSync("node ./scripts/build-registry.js", { cwd: ROOT, stdio: "inherit" });
+  }
+
+  if (!fs.existsSync(REGISTRY_DIR)) {
+    error(`registry output missing at ${REGISTRY_DIR} — run node scripts/build-registry.js first`);
+    process.exit(1);
+  }
+
+  const registryFiles = walkRegistryJson(REGISTRY_DIR);
+  if (registryFiles.length === 0) {
+    error("no registry JSON files found");
+    process.exit(1);
+  }
+
+  info(`static validation — ${registryFiles.length} item(s)`);
+  for (const jsonPath of registryFiles) {
+    validateRegistryJsonStatic(jsonPath);
+  }
+
+  if (failed) {
+    process.exit(1);
+  }
+
+  info(`shadcn dry-run — ${INSTALL_FIXTURES.length} fixture(s)`);
+  const workspaceDir = createShadcnWorkspace();
+
+  try {
+    for (const fixture of INSTALL_FIXTURES) {
+      assertFixtureInstall(fixture, workspaceDir);
+    }
+  } finally {
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+  }
+
+  if (failed) {
+    process.exit(1);
+  }
+
+  info(
+    `OK — ${registryFiles.length} registry item(s), ${INSTALL_FIXTURES.length} install fixture(s)`,
+  );
+}
+
+main();


### PR DESCRIPTION
Rework the demo browser layout and search field. Add registry install validation scripts. Strip em dashes from demo recipe copy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Demo picker now displays check icons to indicate active selections; improved visual styling with refined spacing, borders, and overlay effects.

* **Documentation**
  * Updated demo notes and descriptions across multiple example components including cinema row layouts, footer wordmark, platform hero, and photographer portfolio for enhanced clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->