### PR TITLE
fix(demo): card stack collapsing in WebKit on photographer portfolio

### DIFF
--- a/app/demo/generated/demo-sources.ts
+++ b/app/demo/generated/demo-sources.ts
@@ -2802,7 +2802,7 @@ function PrintStack() {
                 stackIndex={index}
                 className="!inset-x-0 !top-0 !h-fit !w-full gap-0 overflow-visible rounded-none !bg-transparent p-0 shadow-none ring-0"
               >
-                <figure className="relative aspect-[4/5] size-full overflow-hidden bg-black/5">
+                <figure className="relative aspect-[4/5] w-full overflow-hidden bg-black/5">
                   <img
                     src={item.image}
                     alt={\`\${PHOTOGRAPHER.studio} — \${item.title}\`}
@@ -3200,7 +3200,7 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#6F42C1">                stackIndex</span><span style="color:#D73A49">=</span><span style="color:#24292E">{index}</span></span>
 <span class="line"><span style="color:#6F42C1">                className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"!inset-x-0 !top-0 !h-fit !w-full gap-0 overflow-visible rounded-none !bg-transparent p-0 shadow-none ring-0"</span></span>
 <span class="line"><span style="color:#24292E">              ></span></span>
-<span class="line"><span style="color:#24292E">                &#x3C;</span><span style="color:#22863A">figure</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"relative aspect-[4/5] size-full overflow-hidden bg-black/5"</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">                &#x3C;</span><span style="color:#22863A">figure</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"relative aspect-[4/5] w-full overflow-hidden bg-black/5"</span><span style="color:#24292E">></span></span>
 <span class="line"><span style="color:#24292E">                  &#x3C;</span><span style="color:#22863A">img</span></span>
 <span class="line"><span style="color:#6F42C1">                    src</span><span style="color:#D73A49">=</span><span style="color:#24292E">{item.image}</span></span>
 <span class="line"><span style="color:#6F42C1">                    alt</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#032F62">\`\${</span><span style="color:#005CC5">PHOTOGRAPHER</span><span style="color:#032F62">.</span><span style="color:#24292E">studio</span><span style="color:#032F62">} — \${</span><span style="color:#24292E">item</span><span style="color:#032F62">.</span><span style="color:#24292E">title</span><span style="color:#032F62">}\`</span><span style="color:#24292E">}</span></span>
@@ -3598,7 +3598,7 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#B392F0">                stackIndex</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{index}</span></span>
 <span class="line"><span style="color:#B392F0">                className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"!inset-x-0 !top-0 !h-fit !w-full gap-0 overflow-visible rounded-none !bg-transparent p-0 shadow-none ring-0"</span></span>
 <span class="line"><span style="color:#E1E4E8">              ></span></span>
-<span class="line"><span style="color:#E1E4E8">                &#x3C;</span><span style="color:#85E89D">figure</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"relative aspect-[4/5] size-full overflow-hidden bg-black/5"</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">                &#x3C;</span><span style="color:#85E89D">figure</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"relative aspect-[4/5] w-full overflow-hidden bg-black/5"</span><span style="color:#E1E4E8">></span></span>
 <span class="line"><span style="color:#E1E4E8">                  &#x3C;</span><span style="color:#85E89D">img</span></span>
 <span class="line"><span style="color:#B392F0">                    src</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{item.image}</span></span>
 <span class="line"><span style="color:#B392F0">                    alt</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#9ECBFF">\`\${</span><span style="color:#79B8FF">PHOTOGRAPHER</span><span style="color:#9ECBFF">.</span><span style="color:#E1E4E8">studio</span><span style="color:#9ECBFF">} — \${</span><span style="color:#E1E4E8">item</span><span style="color:#9ECBFF">.</span><span style="color:#E1E4E8">title</span><span style="color:#9ECBFF">}\`</span><span style="color:#E1E4E8">}</span></span>

--- a/app/demo/library/hero/photographer-portfolio.tsx
+++ b/app/demo/library/hero/photographer-portfolio.tsx
@@ -256,7 +256,7 @@ function PrintStack() {
                 stackIndex={index}
                 className="!inset-x-0 !top-0 !h-fit !w-full gap-0 overflow-visible rounded-none !bg-transparent p-0 shadow-none ring-0"
               >
-                <figure className="relative aspect-[4/5] size-full overflow-hidden bg-black/5">
+                <figure className="relative aspect-[4/5] w-full overflow-hidden bg-black/5">
                   <img
                     src={item.image}
                     alt={`${PHOTOGRAPHER.studio} — ${item.title}`}


### PR DESCRIPTION
## What

The card stack in the photographer portfolio demo rendered invisible in **Safari and iOS Chrome** (both WebKit), while working fine in Chrome/Blink.

## Root cause

The print figure was sized `aspect-[4/5] size-full` inside an `!h-fit` card. `size-full` sets `height: 100%`, which resolves against the card's indefinite (`fit-content`) height — a circular height dependency:

- figure `height: 100%` ← resolves against the card's `h-fit` (indefinite) height
- card `h-fit` ← depends on its only child, the figure

Blink breaks the cycle by treating `height:100%`-of-indefinite as `auto` and falling back to the `aspect-ratio`. WebKit keeps `height: 100%`, skips the aspect-ratio fallback, and **collapses the figure to 0px** — so the cards existed in the DOM with zero height and nothing showed.

## Fix

Drop `h-full` (keep `w-full`) so height comes from `aspect-ratio` alone. Width is already definite via the `pb-[125%]` / `sm:aspect-[4/5]` wrapper, so the figure gets a real height in every browser.

The standalone Storybook story was unaffected because it uses `CardStack.Media` with a fixed `size-52`, which always had a definite content height.

## Test plan

- [ ] Verify the card stack renders on a real iOS device / Safari
- [x] No visual change in Chrome (height source swapped, result identical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated image frame sizing in the photographer portfolio for improved layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->