### PR TITLE
fix(landing): remove card stack row from stats bento

### DIFF
--- a/app/(main)/_landing/stats-bento.tsx
+++ b/app/(main)/_landing/stats-bento.tsx
@@ -16,8 +16,6 @@ import { docsConfig } from "@/config/docs";
 import { siteStats } from "@/config/site-stats";
 import { cn } from "@/lib/utils";
 
-import { CardStackBento } from "./card-stack-bento";
-
 // Get component categories from the sidebar nav (skip Getting Started + Contributing)
 const categories = docsConfig.sidebarNav
   .filter((item) => item.title !== "Getting Started" && item.title !== "Contributing")
@@ -300,12 +298,6 @@ export default function StatsBento() {
             <div className="mt-3 inline-block self-start rounded-full bg-foreground px-3 py-1 text-[11px] font-bold text-background sm:px-4 sm:py-1.5 sm:text-[12px]">
               MIT Licensed — free forever
             </div>
-          </BentoCard>
-        </div>
-
-        <div className="mt-3 sm:mt-4">
-          <BentoCard className="min-h-[22rem] sm:min-h-[24rem]">
-            <CardStackBento />
           </BentoCard>
         </div>
 


### PR DESCRIPTION
Drop the full-width CardStackBento slot so the landing stats section stays tighter and avoids the broken layout on the homepage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Redesigned the landing page statistics section with an updated full-width card layout. The new design features development hours and research hours statistics, replacing the previous component with a fresh visual presentation that better communicates the effort invested in product development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->