### PR TITLE
docs: add new badge labels to recent components

### DIFF
--- a/content/docs/card/collab-card.mdx
+++ b/content/docs/card/collab-card.mdx
@@ -1,7 +1,7 @@
 ---
 title: Collab Card
 description: Bento tile for realtime collaboration—not a generic card. Live presence, selection frame, teammate cursors.
-labels: ["bento", "collaboration", "animated"]
+labels: ["new", "bento", "collaboration", "animated"]
 ---
 
 <ComponentPreview name="card-collab-card--primary" />

--- a/content/docs/preloader/split-reveal.mdx
+++ b/content/docs/preloader/split-reveal.mdx
@@ -2,6 +2,7 @@
 title: Split Reveal
 description: Full-screen preloader that loads images, locks scroll, then opens from the center seam.
 author: hari
+labels: ["new"]
 ---
 
 <ComponentPreview name="preloader-split-reveal--primary" />

--- a/content/docs/tabs/gooey-tabs.mdx
+++ b/content/docs/tabs/gooey-tabs.mdx
@@ -1,7 +1,7 @@
 ---
 title: Gooey Tabs
 description: Icon tabs that merge with an SVG goo filter when one label expands to show its title.
-labels: ["requires interaction", "click"]
+labels: ["new", "requires interaction", "click"]
 author: harimanok_
 ---
 


### PR DESCRIPTION
Show the sidebar new label on Collab Card, Split Reveal, and Gooey Tabs. Sibling Focus Nav already had the new label on main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to mark newly available components, including the Collaboration Card, Split Reveal preloader, and Gooey Tabs, making recent additions easily identifiable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->