### PR TITLE
chore(site): point default OG image at 2026 R2 asset

### DIFF
--- a/config/site.ts
+++ b/config/site.ts
@@ -1,7 +1,7 @@
 export const siteConfig = {
   name: "animata",
   url: "https://animata.design",
-  ogImage: "https://animata.design/og.png",
+  ogImage: "https://assets.animata.design/og/animata-og-2026.png",
   description:
     "Hand-crafted animated components that you can copy and paste into your apps. Free & Open Source.",
   links: {


### PR DESCRIPTION
Use the new site-wide social card on assets.animata.design instead of the legacy og.png on the main domain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the website's social media preview image to a new design for improved sharing experience across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->