### PR TITLE
feat(docs): improve sidebar nav with filter and scroll fades

### DIFF
--- a/app/(main)/blog/layout.tsx
+++ b/app/(main)/blog/layout.tsx
@@ -12,7 +12,7 @@ export default function BlogLayout({ children }: BlogLayoutProps) {
       <div className="container flex-1 items-start md:grid md:grid-cols-[220px_minmax(0,1fr)] md:gap-4 lg:grid-cols-[240px_minmax(0,1fr)] lg:gap-6">
         <aside className="fixed top-[6.25rem] z-30 -ml-2 hidden h-[calc(100vh-6.25rem)] w-full shrink-0 md:sticky md:block">
           <ScrollArea className="h-full py-6 pr-6 lg:py-8">
-            <DocsSidebarNav items={blogSidebarNav} />
+            <DocsSidebarNav items={blogSidebarNav} variant="plain" />
           </ScrollArea>
         </aside>
         {children}

--- a/app/(main)/docs/layout.tsx
+++ b/app/(main)/docs/layout.tsx
@@ -1,5 +1,4 @@
 import { DocsSidebarNav } from "@/components/sidebar-nav";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { docsConfig } from "@/config/docs";
 
 import "@fontsource-variable/instrument-sans";
@@ -13,10 +12,8 @@ export default function DocsLayout({ children }: DocsLayoutProps) {
   return (
     <div className="docs-shell border-b border-border">
       <div className="mx-auto w-full max-w-7xl flex-1 items-start px-4 sm:px-6 md:grid md:grid-cols-[220px_minmax(0,1fr)] md:gap-4 lg:grid-cols-[240px_minmax(0,1fr)] lg:gap-6">
-        <aside className="fixed top-[6.25rem] z-30 -ml-2 hidden h-[calc(100vh-6.25rem)] w-full shrink-0 md:sticky md:block">
-          <ScrollArea className="h-full py-6 pr-6 lg:py-8">
-            <DocsSidebarNav items={docsConfig.sidebarNav} />
-          </ScrollArea>
+        <aside className="sticky hidden md:block top-(--site-header-height) h-[calc(100svh-var(--site-header-height))] w-full max-w-64 shrink-0 self-start overflow-hidden pt-6 pb-6 lg:pt-8">
+          <DocsSidebarNav items={docsConfig.sidebarNav} className="h-full" />
         </aside>
         {children}
       </div>

--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -11,7 +11,10 @@ export default function MainLayout({ children }: MainLayoutProps) {
   return (
     <CSPostHogProvider>
       <div vaul-drawer-wrapper="">
-        <div className="relative flex min-h-screen flex-col bg-background">
+        <div
+          style={{ "--site-header-height": "50px" }}
+          className="relative flex min-h-screen flex-col bg-background"
+        >
           <SiteHeader />
           <main className="flex-1">{children}</main>
           <SiteFooter />

--- a/components/sidebar-nav.tsx
+++ b/components/sidebar-nav.tsx
@@ -16,7 +16,17 @@ export interface DocsSidebarNavProps {
   variant?: "docs" | "plain";
 }
 
-const SPECIAL_HEADER_COUNT = 2;
+const SPECIAL_HEADER_TITLES = new Set(["Getting Started", "Contributing"]);
+
+function isSpecialHeader(item: SidebarNavItem) {
+  return SPECIAL_HEADER_TITLES.has(item.title);
+}
+
+function findSidebarLink(pathname: string, root: ParentNode = document) {
+  return Array.from(root.querySelectorAll("[data-sidebar-link]")).find(
+    (element) => element.getAttribute("data-sidebar-link") === pathname,
+  );
+}
 
 function normalizeForFilter(value: string) {
   return value
@@ -173,7 +183,7 @@ export function DocsSidebarNav({ items, variant = "docs", className }: DocsSideb
       return next;
     });
 
-    const node = document.querySelector(`[data-sidebar-link="${pathname}"]`);
+    const node = findSidebarLink(pathname);
     node?.scrollIntoView({ behavior: "instant", block: "nearest" });
     updateEdges();
   }, [items, pathname, updateEdges]);
@@ -192,7 +202,7 @@ export function DocsSidebarNav({ items, variant = "docs", className }: DocsSideb
 
   const navList = filteredItems.length ? (
     <div className="w-full pb-4">
-      {filteredItems.map((item, index) => {
+      {filteredItems.map((item) => {
         const sectionKey = getCategoryKey(item);
         const isOpen = isFiltering || !closed.has(sectionKey);
         const categoryHref = item.href ?? item.items?.[0]?.href;
@@ -232,8 +242,8 @@ export function DocsSidebarNav({ items, variant = "docs", className }: DocsSideb
                   )}
                 >
                   <span className="truncate">{item.title}</span>
-                  {hasChildren && index >= SPECIAL_HEADER_COUNT ? (
-                    <span className="flex aspect-square shrink-0 items-center justify-center rounded-full bg-gray-200 px-1 py-0.5 text-[10px] leading-none text-[#000000] no-underline">
+                  {hasChildren && !isSpecialHeader(item) ? (
+                    <span className="flex aspect-square shrink-0 items-center justify-center rounded-full bg-muted px-1 py-0.5 text-[10px] leading-none text-muted-foreground no-underline">
                       {item.label || item.items?.length}
                     </span>
                   ) : null}
@@ -255,7 +265,7 @@ export function DocsSidebarNav({ items, variant = "docs", className }: DocsSideb
               </div>
             ) : null}
 
-            {index === SPECIAL_HEADER_COUNT - 1 ? (
+            {item.title === "Contributing" ? (
               <div className="mt-2 mb-1 pl-4 text-xs font-semibold text-muted-foreground uppercase">
                 Components
               </div>
@@ -352,7 +362,7 @@ export function DocsSidebarNavItems({ items, pathname }: DocsSidebarNavItemsProp
             >
               <span className="truncate">{item.title}</span>
               {item.label ? (
-                <span className="ml-2 rounded-md bg-lime-300 px-1.5 py-0.5 text-xs leading-none text-[#000000] no-underline group-hover:no-underline">
+                <span className="ml-2 rounded-md bg-[var(--footer-gold)] px-1.5 py-0.5 text-xs leading-none text-neutral-900 no-underline group-hover:no-underline">
                   {item.label}
                 </span>
               ) : null}

--- a/components/sidebar-nav.tsx
+++ b/components/sidebar-nav.tsx
@@ -1,102 +1,324 @@
 "use client";
 
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, Search, X } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
+import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 import type { SidebarNavItem } from "@/types";
 
-import { Icons } from "./icons";
-
 export interface DocsSidebarNavProps {
   items: SidebarNavItem[];
+  className?: string;
+  /** Docs layout: filter bar + scroll-driven edge fade. Blog keeps the simple list. */
+  variant?: "docs" | "plain";
 }
 
-export function DocsSidebarNav({ items }: DocsSidebarNavProps) {
+const SPECIAL_HEADER_COUNT = 2;
+
+function normalizeForFilter(value: string) {
+  return value
+    .toLowerCase()
+    .replace(/[-_/\\s]+/g, " ")
+    .trim();
+}
+
+function matchesFilter(query: string, ...parts: Array<string | undefined>) {
+  const tokens = normalizeForFilter(query).split(/\s+/).filter(Boolean);
+  if (!tokens.length) {
+    return true;
+  }
+
+  const haystack = normalizeForFilter(parts.filter(Boolean).join(" "));
+  return tokens.every((token) => haystack.includes(token));
+}
+
+function collectSearchParts(item: SidebarNavItem): string[] {
+  return [item.title, item.href ?? "", ...(item.items?.flatMap(collectSearchParts) ?? [])];
+}
+
+function filterSidebarItems(items: SidebarNavItem[], query: string): SidebarNavItem[] {
+  const trimmed = query.trim();
+  if (!trimmed) {
+    return items;
+  }
+
+  return items.reduce<SidebarNavItem[]>((acc, item) => {
+    const categoryMatches = matchesFilter(trimmed, ...collectSearchParts(item));
+    const filteredChildren = item.items ? filterNestedItems(item.items, trimmed) : [];
+
+    if (categoryMatches) {
+      acc.push(item);
+      return acc;
+    }
+
+    if (filteredChildren.length) {
+      acc.push({ ...item, items: filteredChildren });
+    }
+
+    return acc;
+  }, []);
+}
+
+function filterNestedItems(items: SidebarNavItem[], query: string): SidebarNavItem[] {
+  return items.reduce<SidebarNavItem[]>((acc, item) => {
+    const childMatches = matchesFilter(query, ...collectSearchParts(item));
+    const filteredChildren = item.items ? filterNestedItems(item.items, query) : [];
+
+    if (childMatches) {
+      acc.push(item);
+      return acc;
+    }
+
+    if (filteredChildren.length) {
+      acc.push({ ...item, items: filteredChildren });
+    }
+
+    return acc;
+  }, []);
+}
+
+function isCategoryActive(item: SidebarNavItem, pathname: string | null): boolean {
+  if (!pathname) {
+    return false;
+  }
+
+  if (item.href && pathname === item.href) {
+    return true;
+  }
+
+  return item.items?.some((child) => isCategoryActive(child, pathname)) ?? false;
+}
+
+function getCategoryKey(item: SidebarNavItem) {
+  return item.href ?? item.title;
+}
+
+function useSidebarScrollEdges(enabled: boolean) {
+  const scrollerRef = useRef<HTMLDivElement>(null);
+  const [edges, setEdges] = useState({ top: false, bottom: false });
+
+  const updateEdges = useCallback(() => {
+    const node = scrollerRef.current;
+    if (!node) {
+      return;
+    }
+
+    const { scrollTop, clientHeight, scrollHeight } = node;
+    const overflow = scrollHeight - clientHeight > 1;
+
+    setEdges({
+      top: overflow && scrollTop > 1,
+      bottom: overflow && scrollTop + clientHeight < scrollHeight - 1,
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    updateEdges();
+
+    const node = scrollerRef.current;
+    if (!node) {
+      return;
+    }
+
+    node.addEventListener("scroll", updateEdges, { passive: true });
+    const resizeObserver = new ResizeObserver(updateEdges);
+    resizeObserver.observe(node);
+
+    const content = node.firstElementChild;
+    if (content) {
+      resizeObserver.observe(content);
+    }
+
+    return () => {
+      node.removeEventListener("scroll", updateEdges);
+      resizeObserver.disconnect();
+    };
+  }, [enabled, updateEdges]);
+
+  return { scrollerRef, edges, updateEdges };
+}
+
+export function DocsSidebarNav({ items, variant = "docs", className }: DocsSidebarNavProps) {
   const pathname = usePathname();
+  const [query, setQuery] = useState("");
   const [closed, setClosed] = useState(new Set<string>());
+  const { scrollerRef, edges, updateEdges } = useSidebarScrollEdges(variant === "docs");
+
+  const filteredItems = useMemo(() => filterSidebarItems(items, query), [items, query]);
+  const isFiltering = query.trim().length > 0;
 
   useEffect(() => {
     setClosed((current) => {
       const next = new Set(current);
-      // Open the current section if one of the child pages is active
-      const path = `/docs/${pathname.split("/")[1]}`;
-      if (next.has(path)) {
-        next.delete(path);
+      const segments = pathname.split("/").filter(Boolean);
+      const categorySlug = segments[1];
+
+      if (categorySlug) {
+        next.delete(`/docs/${categorySlug}`);
       }
+
+      for (const item of items) {
+        if (isCategoryActive(item, pathname)) {
+          next.delete(getCategoryKey(item));
+        }
+      }
+
       return next;
     });
 
-    const node = document.querySelector(`[href="${pathname}"]`);
-    if (node) {
-      node.scrollIntoView({ behavior: "instant", block: "nearest" });
-    }
-  }, [pathname]);
+    const node = document.querySelector(`[data-sidebar-link="${pathname}"]`);
+    node?.scrollIntoView({ behavior: "instant", block: "nearest" });
+    updateEdges();
+  }, [items, pathname, updateEdges]);
 
-  return items.length ? (
-    <div className="w-full">
-      {items.map((item, index) => {
-        const isOpen = !closed.has(item.href ?? item.title);
-        const Icon = item.icon && Icons[item.icon as keyof typeof Icons];
+  const toggleSection = (key: string) => {
+    setClosed((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  };
 
-        const toggle = () => {
-          setClosed((prev) => {
-            const next = new Set(prev);
-            if (isOpen) {
-              next.add(item.href ?? item.title);
-            } else {
-              next.delete(item.href ?? item.title);
-            }
-            return next;
-          });
-        };
+  const navList = filteredItems.length ? (
+    <div className="w-full pb-4">
+      {filteredItems.map((item, index) => {
+        const sectionKey = getCategoryKey(item);
+        const isOpen = isFiltering || !closed.has(sectionKey);
+        const categoryHref = item.href ?? item.items?.[0]?.href;
+        const isActive = isCategoryActive(item, pathname);
+        const hasChildren = Boolean(item.items?.length || item.label);
 
-        const specialHeaderCount = 2; // Getting started & contributing;
+        const toggle = () => toggleSection(sectionKey);
 
         return (
-          <div key={index}>
-            <Link
-              href={item.href ?? (item.items?.[0].href as string)}
-              className="cursor-pointer"
-              onClick={toggle}
-            >
-              <h4 className="mb-1 flex items-center gap-1 rounded-md py-1 pr-2 text-sm font-semibold">
-                {Icon ? (
-                  <Icon className="w-4" />
-                ) : (
+          <div key={sectionKey}>
+            <div className="mb-1 flex items-center gap-0.5 rounded-md py-1 pr-2">
+              {item.items?.length ? (
+                <button
+                  type="button"
+                  aria-expanded={isOpen}
+                  aria-label={isOpen ? `Collapse ${item.title}` : `Expand ${item.title}`}
+                  onClick={toggle}
+                  className="rounded-sm p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+                >
                   <ChevronDown
-                    className={cn("w-4 transform transition-all hover:opacity-50", {
+                    className={cn("size-4 shrink-0 transition-transform", {
                       "-rotate-90": !isOpen,
                     })}
                   />
-                )}
-                {item.title}
-                {Boolean(item.items?.length || item.label) && index >= specialHeaderCount && (
-                  <span className="flex aspect-square items-center justify-center rounded-full bg-gray-200 px-1 py-0.5 text-[10px] leading-none text-[#000000] no-underline">
-                    {item.label || item.items?.length}
-                  </span>
-                )}
-              </h4>
-            </Link>
-            {!!item?.items?.length && (
+                </button>
+              ) : (
+                <span className="size-5 shrink-0" aria-hidden="true" />
+              )}
+
+              {categoryHref ? (
+                <Link
+                  href={categoryHref}
+                  data-sidebar-link={categoryHref}
+                  className={cn(
+                    "flex min-w-0 flex-1 items-center gap-1 text-sm font-semibold hover:underline",
+                    isActive ? "text-foreground" : "text-foreground/90",
+                  )}
+                >
+                  <span className="truncate">{item.title}</span>
+                  {hasChildren && index >= SPECIAL_HEADER_COUNT ? (
+                    <span className="flex aspect-square shrink-0 items-center justify-center rounded-full bg-gray-200 px-1 py-0.5 text-[10px] leading-none text-[#000000] no-underline">
+                      {item.label || item.items?.length}
+                    </span>
+                  ) : null}
+                </Link>
+              ) : (
+                <span className="flex min-w-0 flex-1 items-center gap-1 text-sm font-semibold text-foreground">
+                  <span className="truncate">{item.title}</span>
+                </span>
+              )}
+            </div>
+
+            {item.items?.length ? (
               <div
                 className={cn("pb-3 pl-3", {
                   hidden: !isOpen,
                 })}
               >
-                <DocsSidebarNavItems items={item.items} pathname={pathname} />
+                <DocsSidebarNavItems items={item.items} pathname={pathname} query={query} />
               </div>
-            )}
-            {index === specialHeaderCount - 1 && (
-              <div className="mb-1 mt-2 pl-4 text-xs font-semibold uppercase text-muted-foreground">
-                COMPONENTS
+            ) : null}
+
+            {index === SPECIAL_HEADER_COUNT - 1 ? (
+              <div className="mt-2 mb-1 pl-4 text-xs font-semibold text-muted-foreground uppercase">
+                Components
               </div>
-            )}
+            ) : null}
           </div>
         );
       })}
+    </div>
+  ) : (
+    <p className="px-1 text-sm text-muted-foreground">No matches for &ldquo;{query}&rdquo;</p>
+  );
+
+  if (variant === "plain") {
+    return items.length ? navList : null;
+  }
+
+  return items.length ? (
+    <div className={cn("grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)]", className)}>
+      <div className="pr-6 pb-3">
+        <div className="relative">
+          <Search className="pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Filter docs..."
+            className="h-8 rounded-lg bg-[hsl(var(--surface-alt))] pl-8 pr-8 text-sm shadow-none"
+            aria-label="Filter documentation"
+          />
+          {query ? (
+            <button
+              type="button"
+              onClick={() => setQuery("")}
+              className="absolute top-1/2 right-2 -translate-y-1/2 rounded-sm p-0.5 text-muted-foreground hover:text-foreground"
+              aria-label="Clear filter"
+            >
+              <X className="size-3.5" />
+            </button>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="relative min-h-0 overflow-hidden">
+        <div
+          ref={scrollerRef}
+          className="docs-sidebar-scroller absolute inset-0 overflow-y-auto overscroll-contain pr-6"
+        >
+          {navList}
+        </div>
+        <div
+          aria-hidden
+          className={cn(
+            "pointer-events-none absolute inset-x-0 top-0 z-10 h-8 bg-gradient-to-b from-background to-transparent transition-opacity duration-150",
+            edges.top ? "opacity-100" : "opacity-0",
+          )}
+        />
+        <div
+          aria-hidden
+          className={cn(
+            "pointer-events-none absolute inset-x-0 bottom-0 z-10 h-8 bg-gradient-to-t from-background to-transparent transition-opacity duration-150",
+            edges.bottom ? "opacity-100" : "opacity-0",
+          )}
+        />
+      </div>
     </div>
   ) : null;
 }
@@ -104,50 +326,108 @@ export function DocsSidebarNav({ items }: DocsSidebarNavProps) {
 interface DocsSidebarNavItemsProps {
   items: SidebarNavItem[];
   pathname: string | null;
+  query?: string;
+  depth?: number;
 }
 
-export function DocsSidebarNavItems({ items, pathname }: DocsSidebarNavItemsProps) {
+export function DocsSidebarNavItems({
+  items,
+  pathname,
+  query = "",
+  depth = 0,
+}: DocsSidebarNavItemsProps) {
   return items?.length ? (
-    <div className="grid grid-flow-row auto-rows-max text-sm">
-      {items.map((item, index) =>
-        item.href && !item.disabled ? (
-          <Link
-            key={index}
-            href={item.href}
-            className={cn(
-              "group flex w-full items-center rounded-md border border-transparent px-2 py-1 capitalize hover:underline",
-              item.disabled && "cursor-not-allowed opacity-60",
-              pathname === item.href
-                ? "bg-muted font-normal text-foreground"
-                : "text-muted-foreground",
-            )}
-            target={item.external ? "_blank" : ""}
-            rel={item.external ? "noreferrer" : ""}
-          >
-            <span className="truncate">{item.title}</span>
-            {item.label && (
-              <span className="ml-2 rounded-md bg-lime-300 px-1.5 py-0.5 text-xs leading-none text-[#000000] no-underline group-hover:no-underline">
-                {item.label}
-              </span>
-            )}
-          </Link>
-        ) : (
+    <div
+      className={cn("grid auto-rows-max grid-flow-row gap-0.5 text-sm", depth > 0 && "mt-1 pl-2")}
+    >
+      {items.map((item) => {
+        const itemKey = item.href ?? `${item.title}-${depth}`;
+        const childMatches = matchesFilter(query, ...collectSearchParts(item));
+        const visibleChildren = item.items ? filterNestedItems(item.items, query) : [];
+        const showNestedSection =
+          Boolean(item.items?.length) && (childMatches || visibleChildren.length);
+
+        if (item.items?.length && showNestedSection) {
+          const nestedHref = item.href;
+          const nestedActive = nestedHref ? pathname === nestedHref : false;
+
+          return (
+            <div key={itemKey} className="grid gap-0.5">
+              {nestedHref && !item.disabled ? (
+                <Link
+                  href={nestedHref}
+                  data-sidebar-link={nestedHref}
+                  className={cn(
+                    "group flex w-full items-center rounded-md border border-transparent px-2 py-1 capitalize hover:underline",
+                    nestedActive ? "bg-muted font-normal text-foreground" : "text-muted-foreground",
+                  )}
+                >
+                  <span className="truncate">{item.title}</span>
+                  {item.label ? (
+                    <span className="ml-2 rounded-md bg-lime-300 px-1.5 py-0.5 text-xs leading-none text-[#000000] no-underline group-hover:no-underline">
+                      {item.label}
+                    </span>
+                  ) : null}
+                </Link>
+              ) : (
+                <span className="px-2 py-1 text-xs font-medium tracking-wide text-muted-foreground uppercase">
+                  {item.title}
+                </span>
+              )}
+
+              <DocsSidebarNavItems
+                items={query.trim() ? visibleChildren : item.items}
+                pathname={pathname}
+                query={query}
+                depth={depth + 1}
+              />
+            </div>
+          );
+        }
+
+        if (item.href && !item.disabled) {
+          return (
+            <Link
+              key={itemKey}
+              href={item.href}
+              data-sidebar-link={item.href}
+              className={cn(
+                "group flex w-full items-center rounded-md border border-transparent px-2 py-1 capitalize hover:underline",
+                item.disabled && "cursor-not-allowed opacity-60",
+                pathname === item.href
+                  ? "bg-muted font-normal text-foreground"
+                  : "text-muted-foreground",
+              )}
+              target={item.external ? "_blank" : ""}
+              rel={item.external ? "noreferrer" : ""}
+            >
+              <span className="truncate">{item.title}</span>
+              {item.label ? (
+                <span className="ml-2 rounded-md bg-lime-300 px-1.5 py-0.5 text-xs leading-none text-[#000000] no-underline group-hover:no-underline">
+                  {item.label}
+                </span>
+              ) : null}
+            </Link>
+          );
+        }
+
+        return (
           <span
-            key={index}
+            key={itemKey}
             className={cn(
               "flex w-full cursor-not-allowed items-center rounded-md p-2 text-muted-foreground hover:underline",
               item.disabled && "cursor-not-allowed opacity-60",
             )}
           >
             <span className="truncate">{item.title}</span>
-            {item.label && (
+            {item.label ? (
               <span className="ml-2 rounded-md bg-muted px-1.5 py-0.5 text-xs leading-none text-muted-foreground no-underline group-hover:no-underline">
                 {item.label}
               </span>
-            )}
+            ) : null}
           </span>
-        ),
-      )}
+        );
+      })}
     </div>
   ) : null;
 }

--- a/components/sidebar-nav.tsx
+++ b/components/sidebar-nav.tsx
@@ -251,7 +251,7 @@ export function DocsSidebarNav({ items, variant = "docs", className }: DocsSideb
                   hidden: !isOpen,
                 })}
               >
-                <DocsSidebarNavItems items={item.items} pathname={pathname} query={query} />
+                <DocsSidebarNavItems items={item.items} pathname={pathname} />
               </div>
             ) : null}
 
@@ -326,64 +326,13 @@ export function DocsSidebarNav({ items, variant = "docs", className }: DocsSideb
 interface DocsSidebarNavItemsProps {
   items: SidebarNavItem[];
   pathname: string | null;
-  query?: string;
-  depth?: number;
 }
 
-export function DocsSidebarNavItems({
-  items,
-  pathname,
-  query = "",
-  depth = 0,
-}: DocsSidebarNavItemsProps) {
+export function DocsSidebarNavItems({ items, pathname }: DocsSidebarNavItemsProps) {
   return items?.length ? (
-    <div
-      className={cn("grid auto-rows-max grid-flow-row gap-0.5 text-sm", depth > 0 && "mt-1 pl-2")}
-    >
+    <div className="grid auto-rows-max grid-flow-row gap-0.5 text-sm">
       {items.map((item) => {
-        const itemKey = item.href ?? `${item.title}-${depth}`;
-        const childMatches = matchesFilter(query, ...collectSearchParts(item));
-        const visibleChildren = item.items ? filterNestedItems(item.items, query) : [];
-        const showNestedSection =
-          Boolean(item.items?.length) && (childMatches || visibleChildren.length);
-
-        if (item.items?.length && showNestedSection) {
-          const nestedHref = item.href;
-          const nestedActive = nestedHref ? pathname === nestedHref : false;
-
-          return (
-            <div key={itemKey} className="grid gap-0.5">
-              {nestedHref && !item.disabled ? (
-                <Link
-                  href={nestedHref}
-                  data-sidebar-link={nestedHref}
-                  className={cn(
-                    "group flex w-full items-center rounded-md border border-transparent px-2 py-1 capitalize hover:underline",
-                    nestedActive ? "bg-muted font-normal text-foreground" : "text-muted-foreground",
-                  )}
-                >
-                  <span className="truncate">{item.title}</span>
-                  {item.label ? (
-                    <span className="ml-2 rounded-md bg-lime-300 px-1.5 py-0.5 text-xs leading-none text-[#000000] no-underline group-hover:no-underline">
-                      {item.label}
-                    </span>
-                  ) : null}
-                </Link>
-              ) : (
-                <span className="px-2 py-1 text-xs font-medium tracking-wide text-muted-foreground uppercase">
-                  {item.title}
-                </span>
-              )}
-
-              <DocsSidebarNavItems
-                items={query.trim() ? visibleChildren : item.items}
-                pathname={pathname}
-                query={query}
-                depth={depth + 1}
-              />
-            </div>
-          );
-        }
+        const itemKey = item.href ?? item.title;
 
         if (item.href && !item.disabled) {
           return (

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -39,7 +39,7 @@ export function SiteHeader() {
 
       <header
         className={cn(
-          "sticky top-0 z-50 w-full border-b bg-background/80 py-2 backdrop-blur-lg backdrop-saturate-150 transition-[background-color,border-color] duration-300",
+          "sticky h-(--site-header-height) top-0 z-50 w-full border-b bg-background/80 py-2 backdrop-blur-lg backdrop-saturate-150 transition-[background-color,border-color] duration-300",
           scrolled ? "border-border/50" : "border-transparent",
           isIndexPage && !scrolled && "bg-transparent",
         )}

--- a/config/docs.ts
+++ b/config/docs.ts
@@ -19,11 +19,15 @@ const sortAlphabetically = (a: SidebarNavItem, b: SidebarNavItem) => {
 
 const createLinks = (category: string) => {
   return allDocs
-    .filter((doc) => doc.slug.startsWith(`/docs/${category}`) && doc.published)
+    .filter(
+      (doc) =>
+        doc.slug.startsWith(`/docs/${category}`) &&
+        doc.published &&
+        doc.slug !== `/docs/${category}`,
+    )
     .map((doc) => ({
-      // Make sure the index page is the first item
       title: doc.title,
-      sortId: doc.slug === `/docs/${category}` ? "000" : doc.title,
+      sortId: doc.title,
       href: doc.slug,
       label: doc.labels?.includes("new") ? "new" : undefined,
       items: [],
@@ -34,6 +38,7 @@ const createLinks = (category: string) => {
 const sidebarNav: SidebarNavItem[] = [
   {
     title: "Getting Started",
+    href: "/docs",
     items: [
       {
         title: "Introduction",
@@ -49,7 +54,6 @@ const sidebarNav: SidebarNavItem[] = [
         title: "Changelog",
         href: "/docs/changelog",
         items: [
-          { title: "Overview", href: "/docs/changelog", items: [] },
           { title: "June 2026", href: "/docs/changelog/2026-06", items: [] },
           { title: "May 2026", href: "/docs/changelog/2026-05", items: [] },
           { title: "April 2026", href: "/docs/changelog/2026-04", items: [] },
@@ -71,11 +75,6 @@ const sidebarNav: SidebarNavItem[] = [
     href: "/docs/contributing",
     items: [
       {
-        title: "Overview",
-        href: "/docs/contributing",
-        items: [],
-      },
-      {
         title: "Running locally",
         href: "/docs/contributing/running-locally",
         items: [],
@@ -83,6 +82,11 @@ const sidebarNav: SidebarNavItem[] = [
       {
         title: "Adding components",
         href: "/docs/contributing/components",
+        items: [],
+      },
+      {
+        title: "Category glyph tiles",
+        href: "/docs/contributing/category-glyphs",
         items: [],
       },
       {
@@ -108,7 +112,6 @@ const sidebarNav: SidebarNavItem[] = [
     ],
   },
   {
-    icon: "text",
     title: "Text",
     label: `${publishedCategoryItemCount("text")}`,
     href: "/docs/text",
@@ -185,21 +188,18 @@ const sidebarNav: SidebarNavItem[] = [
     items: createLinks("overlay"),
   },
   {
-    icon: "button",
     title: "Button",
     label: `${publishedCategoryItemCount("button")}`,
     href: "/docs/button",
     items: createLinks("button"),
   },
   {
-    icon: "widget",
     title: "Widget",
     label: `${publishedCategoryItemCount("widget")}`,
     href: "/docs/widget",
     items: createLinks("widget"),
   },
   {
-    icon: "bento",
     title: "Bento grid",
     label: `${publishedCategoryItemCount("bento-grid")}`,
     href: "/docs/bento-grid",

--- a/styles/docs.css
+++ b/styles/docs.css
@@ -13,3 +13,8 @@
 .docs-shell .font-heading {
   font-family: var(--font-docs);
 }
+
+.docs-sidebar-scroller {
+  scrollbar-width: thin;
+  scrollbar-color: hsl(var(--border)) transparent;
+}


### PR DESCRIPTION
Rework the docs sidebar so category titles link to overview pages, add smart filtering, and keep the nav list scrollable with edge fades.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added search/filter in the docs sidebar and a simplified "plain" sidebar variant for blog pages.

* **Improvements**
  * Sidebar is now sticky with a consistent header height for smoother navigation.
  * Top/bottom scroll-fade indicators and a thinner themed scrollbar improve scroll affordance.
  * Active sidebar links now auto-reveal for better context.

* **Chores**
  * Reorganized and cleaned sidebar content and group ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->