### PR TITLE
refactor(card-stack): bare-bones API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,44 +21,43 @@ Animata is a free, open-source library of animated React components built with N
 
 ## Changelog rule — ALWAYS update this
 
-The changelog lives at `content/docs/changelog/` — one MDX file per month plus an index.
+Release notes use **four tiers**. Full process, examples, and checklist: [contributing changelog](/docs/contributing/changelog).
 
-### Structure
+| Tier | Where | Length |
+| --- | --- | --- |
+| 1 — Site overview | `content/docs/changelog/index.mdx` | One line per month |
+| 2 — Monthly release | `content/docs/changelog/YYYY-MM.mdx` | Paragraph + component cards |
+| 3 — Category index | `content/docs/{category}/index.mdx` | Table: date · component · change |
+| 4 — Component doc | `content/docs/{category}/{name}.mdx` → `## Changelog` | Dated bullets, most detail |
 
 ```text
 content/docs/changelog/
-  index.mdx        # overview page — shows 2 most recent months + table linking all others
-  2026-04.mdx      # April 2026 (newest first)
-  2026-03.mdx
-  ...
+  index.mdx        # tier 1 — recent months + table of all months
+  YYYY-MM.mdx      # tier 2 — one file per month (newest first)
+content/docs/{category}/
+  index.mdx        # tier 3 — Recent changes table
+  {name}.mdx       # tier 4 — ## Changelog at bottom
 ```
 
 ### When adding a new month
 
-1. Create `content/docs/changelog/YYYY-MM.mdx` with this frontmatter:
-   ```yaml
-   ---
-   title: Month YYYY
-   description: One-line summary of the main themes.
-   date: YYYY-MM-DD
-   ---
-   ```
-2. Write the content as prose, not bullet lists. Each new component gets a short paragraph — what it is, when you'd use it, anything notable about the implementation.
-3. Add the new month to `config/docs.ts` under the Changelog items array (newest first).
-4. Update `content/docs/changelog/index.mdx`: promote the new month to "Recent releases" and move the oldest of the current two into the table.
+1. Create `content/docs/changelog/YYYY-MM.mdx` with frontmatter (`title`, `description`, `date`).
+2. Write tier-2 prose and `<ChangeLogEntry>` blocks — see [contributing changelog](/docs/contributing/changelog).
+3. Add the month to `config/docs.ts` under Changelog (newest first).
+4. Update tier 1 in `changelog/index.mdx`: promote to **Recent releases**, demote oldest to **All releases**.
 
 ### When updating an existing month
 
-Add to the relevant `YYYY-MM.mdx` file. No need to touch the index unless the summary line there is now misleading.
+Add to the relevant `YYYY-MM.mdx`. Update tier 3 (category index table) and tier 4 (component `## Changelog`). Touch tier 1 only if the month summary line is now misleading.
 
 ### What warrants a changelog entry
 
-| Action | Update changelog? |
-|---|---|
-| New component | Yes — new section in the current month file |
-| Landing/docs UI update | Yes — brief paragraph |
-| Major dependency upgrade | Yes — explain what changed and why it matters |
-| User-visible bug fix | Yes — one sentence is fine |
+| Action | Update? |
+| --- | --- |
+| New component | All four tiers |
+| User-visible update or fix | Tiers 2–4; tier 1 if it shapes the month |
+| Landing/docs UI (site-wide) | Tiers 1–2 |
+| Major dependency upgrade | Tiers 1–2 |
 | Dependency patch bumps | No |
 | CI / GitHub Actions only | No |
 | Typo fix in docs | No |
@@ -66,9 +65,8 @@ Add to the relevant `YYYY-MM.mdx` file. No need to touch the index unless the su
 ### Writing style
 
 - Past tense. "Added X" not "We're excited to announce X."
-- No emojis, no prefix symbols (no ✨ 🛠 🐛).
-- Each component gets a description of what it does and when you'd use it — not just its name.
-- If a fix has a root cause worth knowing, say so briefly.
+- No emojis, no prefix symbols.
+- Detail increases down the tiers — one line at the top, bullets at the component doc.
 
 ## File map (quick reference)
 
@@ -97,6 +95,7 @@ content/docs/
   contributing/
     category-glyphs.mdx      # Category tile SVG guide (published)
     category-glyphs-spec.md  # Full spec — keep in sync; not under animata/
+    changelog.mdx            # Four-tier release notes process
 config/
   docs.ts              # Sidebar nav config — register new component categories here
 styles/globals.css     # Tailwind v4 theme tokens

--- a/animata/card/card-stack-profile.tsx
+++ b/animata/card/card-stack-profile.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+import type { LucideIcon } from "lucide-react";
+import { Heart, MessageCircle } from "lucide-react";
+import type { ComponentProps, ReactNode } from "react";
+
+import CardStack, {
+  type CardStackItem,
+  type CardStackLayerMotion,
+} from "@/animata/card/card-stack";
+import { CardStackMaskDefs } from "@/components/shapes/card-stack-mask-defs";
+import { cn } from "@/lib/utils";
+
+export const CARD_STACK_MASK_IDS = [
+  "cardstack_mask_ellipse-1",
+  "cardstack_mask_flower-14",
+  "cardstack_mask_flower-1",
+  "cardstack_mask_misc-5",
+] as const;
+
+export type CardStackProfileMaskId = (typeof CARD_STACK_MASK_IDS)[number];
+
+export type CardStackProfileMediaAspect = "fill" | "square" | "4/5" | "3/4" | "16/10";
+
+export interface CardStackProfileItem extends CardStackItem {
+  image: string;
+  title: string;
+  tagline: string;
+  counts?: {
+    like: number;
+    comment: number;
+  };
+  maskId: CardStackProfileMaskId;
+}
+
+const CARD_STACK_MASK_STYLE = {
+  maskSize: "cover",
+  maskPosition: "center",
+  maskRepeat: "no-repeat",
+} as const;
+
+const MEDIA_ASPECT_CLASS: Record<Exclude<CardStackProfileMediaAspect, "fill">, string> = {
+  square: "aspect-square",
+  "4/5": "aspect-[4/5]",
+  "3/4": "aspect-[3/4]",
+  "16/10": "aspect-[16/10]",
+};
+
+export function CardStackProfileMasks({ className }: { className?: string }) {
+  return <CardStackMaskDefs className={cn("pointer-events-none absolute", className)} />;
+}
+
+export function CardStackProfileLiveRegion({
+  className,
+  item,
+}: {
+  className?: string;
+  item: CardStackProfileItem | undefined;
+}) {
+  return (
+    <p className={cn("sr-only", className)} aria-live="polite" aria-atomic="true">
+      {item ? `Showing ${item.title}, ${item.tagline}` : "No cards available"}
+    </p>
+  );
+}
+
+export function CardStackProfileHeader({ className, ...props }: ComponentProps<"header">) {
+  return <header className={cn("flex items-center gap-2 p-4", className)} {...props} />;
+}
+
+export function CardStackProfileAvatar({
+  src,
+  className,
+  ...props
+}: ComponentProps<"div"> & { src: string }) {
+  return (
+    <div
+      className={cn(
+        "relative size-7 shrink-0 overflow-hidden rounded-full ring-2 ring-border",
+        className,
+      )}
+      {...props}
+    >
+      <img
+        src={src}
+        alt=""
+        aria-hidden
+        width={28}
+        height={28}
+        decoding="async"
+        className="size-full object-cover"
+      />
+    </div>
+  );
+}
+
+export function CardStackProfileMeta({
+  title,
+  tagline,
+  className,
+  ...props
+}: ComponentProps<"div"> & { title: string; tagline: string }) {
+  return (
+    <div className={cn("flex min-w-0 flex-col items-start gap-0.5", className)} {...props}>
+      <h3 className="truncate text-xs font-medium leading-none tracking-wide text-foreground">
+        {title}
+      </h3>
+      <p className="truncate overflow-visible text-[10px] leading-none text-muted-foreground">
+        {tagline}
+      </p>
+    </div>
+  );
+}
+
+export function CardStackProfileMedia({
+  src,
+  alt,
+  maskId,
+  aspect = "square",
+  className,
+  style,
+  ...props
+}: Omit<ComponentProps<"img">, "src" | "alt"> & {
+  src: string;
+  alt: string;
+  maskId: CardStackProfileMaskId;
+  aspect?: CardStackProfileMediaAspect;
+}) {
+  const maskStyle = {
+    ...CARD_STACK_MASK_STYLE,
+    maskImage: `url(#${maskId})`,
+    WebkitMaskImage: `url(#${maskId})`,
+    WebkitMaskSize: CARD_STACK_MASK_STYLE.maskSize,
+    WebkitMaskPosition: CARD_STACK_MASK_STYLE.maskPosition,
+    WebkitMaskRepeat: CARD_STACK_MASK_STYLE.maskRepeat,
+    ...style,
+  };
+
+  return (
+    <figure
+      className={cn(
+        "mx-auto shrink-0 overflow-hidden",
+        aspect === "square" && "aspect-square size-52",
+        aspect === "fill" && "min-h-0 w-full flex-1",
+        aspect !== "square" && aspect !== "fill" && MEDIA_ASPECT_CLASS[aspect],
+        className,
+      )}
+    >
+      <img
+        src={src}
+        alt={alt}
+        width={208}
+        height={208}
+        decoding="async"
+        draggable={false}
+        className="size-full object-cover"
+        style={maskStyle}
+        {...props}
+      />
+    </figure>
+  );
+}
+
+export function CardStackProfileFooter({ className, ...props }: ComponentProps<"footer">) {
+  return (
+    <footer
+      className={cn("flex items-center gap-3 px-4 pb-4 pt-1 text-sm text-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+export function CardStackProfileMetric({
+  icon: Icon,
+  label,
+  value,
+  className,
+  ...props
+}: ComponentProps<"span"> & { icon: LucideIcon; label: string; value: number | string }) {
+  return (
+    <span className={cn("inline-flex items-center gap-1", className)} {...props}>
+      <Icon aria-hidden className="size-6 shrink-0" />
+      <span className="sr-only">{label}: </span>
+      {value}
+    </span>
+  );
+}
+
+interface CardStackProfileCardProps {
+  item: CardStackProfileItem;
+  index: number;
+  layer: CardStackLayerMotion;
+  className?: string;
+  footerTrailing?: ReactNode;
+  showMetrics?: boolean;
+}
+
+/** Profile-style card for demos and Storybook — not part of the core stack API. */
+export function CardStackProfileCard({
+  item,
+  index,
+  layer,
+  className,
+  footerTrailing,
+  showMetrics = true,
+}: CardStackProfileCardProps) {
+  return (
+    <CardStack.Card
+      layer={layer}
+      stackIndex={index}
+      className={cn(
+        "flex flex-col gap-3 rounded-4xl bg-linear-to-br from-pink-100 via-white to-white p-0 shadow-xl ring-1 ring-border",
+        "dark:from-pink-950 dark:via-card dark:to-card",
+        className,
+      )}
+    >
+      <CardStackProfileHeader>
+        <CardStackProfileAvatar src={item.image} />
+        <CardStackProfileMeta title={item.title} tagline={item.tagline} />
+      </CardStackProfileHeader>
+
+      <CardStackProfileMedia
+        src={item.image}
+        alt={`Portrait of ${item.title}`}
+        maskId={item.maskId}
+      />
+
+      {showMetrics || footerTrailing ? (
+        <CardStackProfileFooter>
+          {showMetrics ? (
+            <>
+              <CardStackProfileMetric icon={Heart} label="Likes" value={item.counts?.like ?? 0} />
+              <CardStackProfileMetric
+                icon={MessageCircle}
+                label="Comments"
+                value={item.counts?.comment ?? 0}
+                className="ms-1"
+              />
+            </>
+          ) : null}
+          {footerTrailing}
+        </CardStackProfileFooter>
+      ) : null}
+    </CardStack.Card>
+  );
+}

--- a/animata/card/card-stack.stories.tsx
+++ b/animata/card/card-stack.stories.tsx
@@ -1,8 +1,16 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { ArrowRight, Heart, MessageCircle } from "lucide-react";
-import CardStack, { CARD_STACK_MASK_IDS, type CardStackItem } from "@/animata/card/card-stack";
+import { ArrowRight } from "lucide-react";
 
-const demoCards: CardStackItem[] = [
+import CardStack, { useCardStack } from "@/animata/card/card-stack";
+import {
+  CARD_STACK_MASK_IDS,
+  CardStackProfileCard,
+  type CardStackProfileItem,
+  CardStackProfileLiveRegion,
+  CardStackProfileMasks,
+} from "@/animata/card/card-stack-profile";
+
+const demoCards: CardStackProfileItem[] = [
   {
     id: "hari",
     image:
@@ -59,6 +67,11 @@ const demoCards: CardStackItem[] = [
   },
 ];
 
+function StoryLiveRegion() {
+  const { activeItem } = useCardStack<CardStackProfileItem>();
+  return <CardStackProfileLiveRegion item={activeItem} />;
+}
+
 const meta = {
   title: "Card/Card Stack",
   component: CardStack,
@@ -84,52 +97,44 @@ export const Primary: Story = {
   render: ({ items, depth }) => (
     <div className="full-content w-full">
       <CardStack items={items} depth={depth}>
-        <CardStack.Frame className="relative w-full max-w-sm mx-auto overflow-hidden">
-          <CardStack.Masks />
+        <section
+          aria-label="Interactive card stack"
+          className="relative mx-auto w-full max-w-sm overflow-hidden"
+        >
+          <CardStackProfileMasks />
 
           <div className="relative flex flex-col px-4 pb-10 pt-16 sm:px-6 sm:pt-20">
-            <CardStack.LiveRegion />
+            <StoryLiveRegion />
 
-            <CardStack.Trigger className="w-full drop-shadow-2xl">
-              <CardStack.Viewport>
-                <CardStack.List>
-                  {(item, index, layer) => (
-                    <CardStack.Card key={item.id} layer={layer} stackIndex={index}>
-                      <CardStack.Header>
-                        <CardStack.Avatar src={item.image} />
-                        <CardStack.Meta title={item.title} tagline={item.tagline} />
-                      </CardStack.Header>
-
-                      <CardStack.Media
-                        src={item.image}
-                        alt={`Portrait of ${item.title}`}
-                        maskId={item.maskId}
-                      />
-
-                      <CardStack.Footer>
-                        <CardStack.Metric
-                          icon={Heart}
-                          label="Likes"
-                          value={item.counts?.like ?? 0}
-                        />
-                        <CardStack.Metric
-                          icon={MessageCircle}
-                          label="Comments"
-                          value={item.counts?.comment ?? 0}
-                          className="ms-1"
-                        />
+            <CardStack.Viewport className="min-h-[26rem] pt-20 sm:min-h-[28rem] sm:pt-24">
+              <CardStack.List>
+                {(item: CardStackProfileItem, index, layer) => (
+                  <CardStackProfileCard
+                    key={item.id}
+                    item={item}
+                    index={index}
+                    layer={layer}
+                    footerTrailing={
+                      index === 0 ? (
+                        <CardStack.Trigger aria-label="Show next card" className="ml-auto">
+                          <ArrowRight
+                            aria-hidden
+                            className="size-6 shrink-0 text-muted-foreground"
+                          />
+                        </CardStack.Trigger>
+                      ) : (
                         <ArrowRight
                           aria-hidden
                           className="ml-auto size-6 shrink-0 text-muted-foreground"
                         />
-                      </CardStack.Footer>
-                    </CardStack.Card>
-                  )}
-                </CardStack.List>
-              </CardStack.Viewport>
-            </CardStack.Trigger>
+                      )
+                    }
+                  />
+                )}
+              </CardStack.List>
+            </CardStack.Viewport>
           </div>
-        </CardStack.Frame>
+        </section>
       </CardStack>
     </div>
   ),

--- a/animata/card/card-stack.tsx
+++ b/animata/card/card-stack.tsx
@@ -258,6 +258,10 @@ function CardStackRoot<T extends CardStackItem>({
   const stepTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const autoplayTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const advanceRef = useRef<() => void>(() => {});
+  const onItemsChangeRef = useRef(onItemsChange);
+  onItemsChangeRef.current = onItemsChange;
+  const skipItemsChangeNotifyRef = useRef(false);
+  const hasUserRotatedRef = useRef(false);
 
   const visibleItems = itemList.slice(0, stackDepth);
   const activeItem = visibleItems[0];
@@ -281,18 +285,28 @@ function CardStackRoot<T extends CardStackItem>({
     clearAutoplayTimer();
     isAnimatingRef.current = false;
     setIsAnimating(false);
+    skipItemsChangeNotifyRef.current = true;
     setItemList(items);
   }, [items, clearStepTimer, clearAutoplayTimer]);
 
+  useEffect(() => {
+    if (skipItemsChangeNotifyRef.current) {
+      skipItemsChangeNotifyRef.current = false;
+      return;
+    }
+    if (!hasUserRotatedRef.current) return;
+    onItemsChangeRef.current?.(itemList as T[]);
+  }, [itemList]);
+
   const rotateOne = useCallback(() => {
+    hasUserRotatedRef.current = true;
     setItemList((current) => {
       if (current.length <= 1) return current;
       const next = [...current];
       next.push(next.shift()!);
-      onItemsChange?.(next as T[]);
       return next;
     });
-  }, [onItemsChange]);
+  }, []);
 
   const finishStep = useCallback(() => {
     clearStepTimer();
@@ -530,6 +544,7 @@ function CardStackTrigger({
       onPointerLeave={handlers.onPointerLeave}
       onPointerCancel={handlers.onPointerCancel}
       onClick={handlers.onClick}
+      onKeyDown={onKeyDown}
       className={cn(
         "inline-flex shrink-0 cursor-pointer items-center justify-center outline-none",
         "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",

--- a/animata/card/card-stack.tsx
+++ b/animata/card/card-stack.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import type { LucideIcon } from "lucide-react";
 import { AnimatePresence, type HTMLMotionProps, motion, type Transition } from "motion/react";
 import {
   type ComponentProps,
@@ -17,39 +16,19 @@ import {
   useSyncExternalStore,
 } from "react";
 
-import { CardStackMaskDefs } from "@/components/shapes/card-stack-mask-defs";
 import { cn } from "@/lib/utils";
-
-export const CARD_STACK_MASK_IDS = [
-  "cardstack_mask_ellipse-1",
-  "cardstack_mask_flower-14",
-  "cardstack_mask_flower-1",
-  "cardstack_mask_misc-5",
-] as const;
-
-export type CardStackMaskId = (typeof CARD_STACK_MASK_IDS)[number];
-
-export type CardStackMediaAspect = "fill" | "square" | "4/5" | "3/4" | "16/10";
 
 export interface CardStackItem {
   id: string;
-  image: string;
-  title: string;
-  tagline: string;
-  counts?: {
-    like: number;
-    comment: number;
-  };
-  maskId: CardStackMaskId;
 }
 
 export interface CardStackLayerMotion {
   className: string;
-  initial: HTMLMotionProps<"article">["initial"];
-  animate: HTMLMotionProps<"article">["animate"];
-  exit?: HTMLMotionProps<"article">["exit"];
+  initial: HTMLMotionProps<"div">["initial"];
+  animate: HTMLMotionProps<"div">["animate"];
+  exit?: HTMLMotionProps<"div">["exit"];
   transition: Transition;
-  style?: HTMLMotionProps<"article">["style"];
+  style?: HTMLMotionProps<"div">["style"];
 }
 
 const DEFAULT_STACK_DEPTH = 3;
@@ -107,19 +86,6 @@ export function createCardStackThrowImpulse(): CardStackThrowImpulse {
 
 const CARD_STACK_STACK_ORIGIN = "50% 0%";
 const CARD_STACK_EXIT_Y = "200%";
-
-const CARD_STACK_MASK_STYLE = {
-  maskSize: "cover",
-  maskPosition: "center",
-  maskRepeat: "no-repeat",
-} as const;
-
-const MEDIA_ASPECT_CLASS: Record<Exclude<CardStackMediaAspect, "fill">, string> = {
-  square: "aspect-square",
-  "4/5": "aspect-[4/5]",
-  "3/4": "aspect-[3/4]",
-  "16/10": "aspect-[16/10]",
-};
 
 function subscribeReducedMotion(callback: () => void) {
   const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
@@ -195,7 +161,7 @@ function getCardStackInitial(
   stackIndex: number,
   depth: number,
   layer: CardStackLayerMotion,
-): HTMLMotionProps<"article">["initial"] {
+): HTMLMotionProps<"div">["initial"] {
   if (stackIndex !== 0 && stackIndex !== depth - 1) {
     return false;
   }
@@ -208,7 +174,7 @@ function getCardStackExit(
   layer: CardStackLayerMotion,
   reducedMotion: boolean,
   throwImpulse: CardStackThrowImpulse | null,
-): HTMLMotionProps<"article">["exit"] {
+): HTMLMotionProps<"div">["exit"] {
   if (stackIndex !== 0) {
     return undefined;
   }
@@ -236,10 +202,10 @@ function getCardStackExit(
   };
 }
 
-interface CardStackContextValue {
-  items: CardStackItem[];
-  visibleItems: CardStackItem[];
-  activeItem: CardStackItem | undefined;
+interface CardStackContextValue<T extends CardStackItem = CardStackItem> {
+  items: T[];
+  visibleItems: T[];
+  activeItem: T | undefined;
   depth: number;
   isAnimating: boolean;
   pressActive: boolean;
@@ -253,31 +219,31 @@ interface CardStackContextValue {
 
 const CardStackContext = createContext<CardStackContextValue | null>(null);
 
-export function useCardStack() {
+export function useCardStack<T extends CardStackItem = CardStackItem>() {
   const context = use(CardStackContext);
   if (!context) {
     throw new Error("CardStack primitives must be used within <CardStack>.");
   }
-  return context;
+  return context as CardStackContextValue<T>;
 }
 
-interface CardStackRootProps {
-  items: CardStackItem[];
+interface CardStackRootProps<T extends CardStackItem> {
+  items: T[];
   depth?: number;
   autoplay?: boolean;
   autoplayInterval?: number;
-  onItemsChange?: (items: CardStackItem[]) => void;
+  onItemsChange?: (items: T[]) => void;
   children: ReactNode;
 }
 
-function CardStackRoot({
+function CardStackRoot<T extends CardStackItem>({
   items,
   depth = DEFAULT_STACK_DEPTH,
   autoplay = false,
   autoplayInterval = DEFAULT_AUTOPLAY_INTERVAL,
   onItemsChange,
   children,
-}: CardStackRootProps) {
+}: CardStackRootProps<T>) {
   const reducedMotion = usePrefersReducedMotion();
   const stackDepth = Math.min(Math.max(1, depth), STACK_LAYER_PRESETS.length);
   const layers = useMemo(
@@ -323,7 +289,7 @@ function CardStackRoot({
       if (current.length <= 1) return current;
       const next = [...current];
       next.push(next.shift()!);
-      onItemsChange?.(next);
+      onItemsChange?.(next as T[]);
       return next;
     });
   }, [onItemsChange]);
@@ -442,84 +408,133 @@ function CardStackRoot({
   return <CardStackContext value={value}>{children}</CardStackContext>;
 }
 
-function CardStackFrame({
-  "aria-label": ariaLabel = "Interactive card stack",
-  className,
-  children,
-  ...props
-}: ComponentProps<"section">) {
-  return (
-    <section aria-label={ariaLabel} className={cn("relative", className)} {...props}>
-      {children}
-    </section>
-  );
+export interface CardStackTriggerProps {
+  /** When true, renders an absolute inset-0 overlay for click-anywhere advance. When false (default), renders a real `<button>` for a discrete control. */
+  full?: boolean;
+  "aria-label"?: string;
+  className?: string;
+  children?: ReactNode;
+  onClick?: (event: React.MouseEvent<HTMLElement>) => void;
+  onKeyDown?: (event: React.KeyboardEvent<HTMLElement>) => void;
+  onPointerDown?: (event: React.PointerEvent<HTMLElement>) => void;
+  onPointerUp?: (event: React.PointerEvent<HTMLElement>) => void;
+  onPointerLeave?: (event: React.PointerEvent<HTMLElement>) => void;
+  onPointerCancel?: (event: React.PointerEvent<HTMLElement>) => void;
 }
 
-function CardStackPanel({ className, children, ...props }: ComponentProps<"div">) {
-  return (
-    <div className={cn("relative z-10", className)} {...props}>
-      {children}
-    </div>
-  );
-}
-
-function CardStackLiveRegion({ className }: { className?: string }) {
-  const { activeItem } = useCardStack();
-
-  return (
-    <p className={cn("sr-only", className)} aria-live="polite" aria-atomic="true">
-      {activeItem ? `Showing ${activeItem.title}, ${activeItem.tagline}` : "No cards available"}
-    </p>
-  );
-}
-
-function CardStackTrigger({
-  "aria-label": ariaLabel = "Show next card",
-  className,
-  children,
+function useCardStackTriggerHandlers({
+  isAnimating,
+  setPressActive,
+  advance,
   onClick,
+  onKeyDown,
   onPointerDown,
   onPointerUp,
   onPointerLeave,
   onPointerCancel,
-  ...props
-}: ComponentProps<"button">) {
+}: {
+  isAnimating: boolean;
+  setPressActive: (active: boolean) => void;
+  advance: () => void;
+  onClick?: (event: React.MouseEvent<HTMLElement>) => void;
+  onKeyDown?: (event: React.KeyboardEvent<HTMLElement>) => void;
+  onPointerDown?: (event: React.PointerEvent<HTMLElement>) => void;
+  onPointerUp?: (event: React.PointerEvent<HTMLElement>) => void;
+  onPointerLeave?: (event: React.PointerEvent<HTMLElement>) => void;
+  onPointerCancel?: (event: React.PointerEvent<HTMLElement>) => void;
+}) {
+  return {
+    onPointerDown: (event: React.PointerEvent<HTMLElement>) => {
+      onPointerDown?.(event);
+      if (!event.defaultPrevented && !isAnimating) {
+        setPressActive(true);
+      }
+    },
+    onPointerUp: (event: React.PointerEvent<HTMLElement>) => {
+      onPointerUp?.(event);
+      window.setTimeout(() => setPressActive(false), 0);
+    },
+    onPointerLeave: (event: React.PointerEvent<HTMLElement>) => {
+      onPointerLeave?.(event);
+      setPressActive(false);
+    },
+    onPointerCancel: (event: React.PointerEvent<HTMLElement>) => {
+      onPointerCancel?.(event);
+      setPressActive(false);
+    },
+    onClick: (event: React.MouseEvent<HTMLElement>) => {
+      onClick?.(event);
+      if (!event.defaultPrevented) {
+        advance();
+      }
+    },
+    onKeyDown: (event: React.KeyboardEvent<HTMLElement>) => {
+      onKeyDown?.(event);
+      if (event.defaultPrevented) return;
+      if (event.key === "Enter" || event.key === " " || event.key === "Spacebar") {
+        event.preventDefault();
+        advance();
+      }
+    },
+  };
+}
+
+function CardStackTrigger({
+  full = false,
+  "aria-label": ariaLabel = "Show next card",
+  className,
+  children,
+  onClick,
+  onKeyDown,
+  onPointerDown,
+  onPointerUp,
+  onPointerLeave,
+  onPointerCancel,
+}: CardStackTriggerProps) {
   const { advance, isAnimating, setPressActive } = useCardStack();
+  const handlers = useCardStackTriggerHandlers({
+    isAnimating,
+    setPressActive,
+    advance,
+    onClick,
+    onKeyDown,
+    onPointerDown,
+    onPointerUp,
+    onPointerLeave,
+    onPointerCancel,
+  });
+
+  if (full) {
+    return (
+      // biome-ignore lint/a11y/useSemanticElements: overlay sits above card content; a wrapping <button> would be invalid markup
+      <div
+        role="button"
+        tabIndex={0}
+        aria-label={ariaLabel}
+        {...handlers}
+        className={cn(
+          "absolute inset-0 z-40 cursor-pointer outline-none",
+          "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+          className,
+        )}
+      />
+    );
+  }
 
   return (
     <button
       type="button"
       aria-label={ariaLabel}
-      onPointerDown={(event) => {
-        onPointerDown?.(event);
-        if (!event.defaultPrevented && !isAnimating) {
-          setPressActive(true);
-        }
-      }}
-      onPointerUp={(event) => {
-        onPointerUp?.(event);
-        window.setTimeout(() => setPressActive(false), 0);
-      }}
-      onPointerLeave={(event) => {
-        onPointerLeave?.(event);
-        setPressActive(false);
-      }}
-      onPointerCancel={(event) => {
-        onPointerCancel?.(event);
-        setPressActive(false);
-      }}
-      onClick={(event) => {
-        onClick?.(event);
-        if (!event.defaultPrevented) {
-          advance();
-        }
-      }}
+      onPointerDown={handlers.onPointerDown}
+      onPointerUp={handlers.onPointerUp}
+      onPointerLeave={handlers.onPointerLeave}
+      onPointerCancel={handlers.onPointerCancel}
+      onClick={handlers.onClick}
       className={cn(
-        "relative block w-full cursor-pointer outline-none",
+        "inline-flex shrink-0 cursor-pointer items-center justify-center outline-none",
         "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
         className,
       )}
-      {...props}
     >
       {children}
     </button>
@@ -528,24 +543,18 @@ function CardStackTrigger({
 
 function CardStackViewport({ className, children, ...props }: ComponentProps<"div">) {
   return (
-    <div
-      className={cn(
-        "relative mx-auto w-full overflow-visible pt-20 sm:pt-24 min-h-[26rem] sm:min-h-[28rem]",
-        className,
-      )}
-      {...props}
-    >
+    <div className={cn("relative w-full overflow-visible", className)} {...props}>
       {children}
     </div>
   );
 }
 
-interface CardStackListProps {
-  children: (item: CardStackItem, index: number, layer: CardStackLayerMotion) => ReactNode;
+interface CardStackListProps<T extends CardStackItem> {
+  children: (item: T, index: number, layer: CardStackLayerMotion) => ReactNode;
 }
 
-function CardStackList({ children }: CardStackListProps) {
-  const { visibleItems, layers, handleExitComplete } = useCardStack();
+function CardStackList<T extends CardStackItem>({ children }: CardStackListProps<T>) {
+  const { visibleItems, layers, handleExitComplete } = useCardStack<T>();
 
   return (
     <AnimatePresence initial={false} mode="sync" onExitComplete={handleExitComplete}>
@@ -567,7 +576,7 @@ function CardStackList({ children }: CardStackListProps) {
   );
 }
 
-interface CardStackCardProps extends HTMLMotionProps<"article"> {
+interface CardStackCardProps extends HTMLMotionProps<"div"> {
   layer: CardStackLayerMotion;
   stackIndex: number;
   stackDepth?: number;
@@ -598,12 +607,9 @@ function CardStackCard({
   const transition = isPressed ? PRESS_SPRING : layer.transition;
 
   return (
-    <motion.article
+    <motion.div
       className={cn(
-        "absolute inset-x-0 top-0 flex h-fit w-full flex-col gap-3 rounded-4xl p-0",
-        "bg-linear-to-br from-pink-100 via-white to-white shadow-xl ring-1 ring-border",
-        "will-change-transform motion-reduce:transition-none",
-        "dark:from-pink-950 dark:via-card dark:to-card",
+        "absolute inset-x-0 top-0 w-full will-change-transform motion-reduce:transition-none",
         layer.className,
         className,
       )}
@@ -622,197 +628,23 @@ function CardStackCard({
   );
 }
 
-function CardStackHeader({ className, ...props }: ComponentProps<"header">) {
-  return <header className={cn("flex gap-2 p-4 items-center", className)} {...props} />;
-}
-
-interface CardStackAvatarProps extends ComponentProps<"div"> {
-  src: string;
-}
-
-function CardStackAvatar({ src, className, ...props }: CardStackAvatarProps) {
-  return (
-    <div
-      className={cn(
-        "relative size-7 shrink-0 overflow-hidden rounded-full ring-2 ring-border",
-        className,
-      )}
-      {...props}
-    >
-      <img
-        src={src}
-        alt=""
-        aria-hidden
-        width={28}
-        height={28}
-        decoding="async"
-        className="size-full object-cover"
-      />
-    </div>
-  );
-}
-
-interface CardStackMetaProps extends ComponentProps<"div"> {
-  title: string;
-  tagline: string;
-}
-
-function CardStackMeta({ title, tagline, className, ...props }: CardStackMetaProps) {
-  return (
-    <div className={cn("min-w-0 flex flex-col gap-0.5 items-start", className)} {...props}>
-      <h3 className="truncate text-xs font-medium leading-none tracking-wide text-foreground">
-        {title}
-      </h3>
-      <p className="truncate text-[10px] leading-none overflow-visible text-muted-foreground">
-        {tagline}
-      </p>
-    </div>
-  );
-}
-
-interface CardStackMediaProps extends Omit<ComponentProps<"img">, "src" | "alt"> {
-  src: string;
-  alt: string;
-  maskId: CardStackMaskId;
-  aspect?: CardStackMediaAspect;
-}
-
-function CardStackMedia({
-  src,
-  alt,
-  maskId,
-  aspect = "square",
-  className,
-  style,
-  ...props
-}: CardStackMediaProps) {
-  const maskStyle = {
-    ...CARD_STACK_MASK_STYLE,
-    maskImage: `url(#${maskId})`,
-    WebkitMaskImage: `url(#${maskId})`,
-    WebkitMaskSize: CARD_STACK_MASK_STYLE.maskSize,
-    WebkitMaskPosition: CARD_STACK_MASK_STYLE.maskPosition,
-    WebkitMaskRepeat: CARD_STACK_MASK_STYLE.maskRepeat,
-    ...style,
-  };
-
-  return (
-    <figure
-      className={cn(
-        "mx-auto shrink-0 overflow-hidden",
-        aspect === "square" && "aspect-square size-52",
-        aspect === "fill" && "min-h-0 w-full flex-1",
-        aspect !== "square" && aspect !== "fill" && MEDIA_ASPECT_CLASS[aspect],
-        className,
-      )}
-    >
-      <img
-        src={src}
-        alt={alt}
-        width={208}
-        height={208}
-        decoding="async"
-        draggable={false}
-        className="size-full object-cover"
-        style={maskStyle}
-        {...props}
-      />
-    </figure>
-  );
-}
-
-function CardStackBody({ className, ...props }: ComponentProps<"div">) {
-  return <div className={cn("flex flex-1 flex-col bg-card", className)} {...props} />;
-}
-
-function CardStackFooter({ className, ...props }: ComponentProps<"footer">) {
-  return (
-    <footer
-      className={cn("flex items-center gap-3 px-4 pb-4 pt-1 text-sm text-foreground", className)}
-      {...props}
-    />
-  );
-}
-
-interface CardStackMetricProps extends ComponentProps<"span"> {
-  icon: LucideIcon;
-  label: string;
-  value: number | string;
-}
-
-function CardStackMetric({ icon: Icon, label, value, className, ...props }: CardStackMetricProps) {
-  return (
-    <span className={cn("inline-flex items-center gap-1", className)} {...props}>
-      <Icon aria-hidden className="size-6 shrink-0" />
-      <span className="sr-only">{label}: </span>
-      {value}
-    </span>
-  );
-}
-
-interface CardStackActionProps extends ComponentProps<"span"> {
-  icon?: LucideIcon;
-}
-
-function CardStackAction({ icon: Icon, className, children, ...props }: CardStackActionProps) {
-  return (
-    <span
-      className={cn(
-        "ml-auto inline-flex items-center gap-1.5 text-xs font-medium text-muted-foreground",
-        className,
-      )}
-      {...props}
-    >
-      {children}
-      {Icon ? <Icon aria-hidden className="size-4 shrink-0" /> : null}
-    </span>
-  );
-}
-
-interface CardStackMasksProps {
-  className?: string;
-}
-
-function CardStackMasks({ className }: CardStackMasksProps) {
-  return <CardStackMaskDefs className={cn("pointer-events-none absolute", className)} />;
-}
-
 const CardStack = Object.assign(CardStackRoot, {
-  Frame: CardStackFrame,
-  Panel: CardStackPanel,
-  LiveRegion: CardStackLiveRegion,
   Trigger: CardStackTrigger,
   Viewport: CardStackViewport,
   List: CardStackList,
   Card: CardStackCard,
-  Header: CardStackHeader,
-  Avatar: CardStackAvatar,
-  Meta: CardStackMeta,
-  Body: CardStackBody,
-  Media: CardStackMedia,
-  Footer: CardStackFooter,
-  Metric: CardStackMetric,
-  Action: CardStackAction,
-  Masks: CardStackMasks,
-});
+}) as typeof CardStackRoot & {
+  Trigger: typeof CardStackTrigger;
+  Viewport: typeof CardStackViewport;
+  List: typeof CardStackList;
+  Card: typeof CardStackCard;
+};
 
 export default CardStack;
 export {
   CardStack,
-  CardStackAction,
-  CardStackAvatar,
-  CardStackBody,
   CardStackCard,
-  CardStackFooter,
-  CardStackFrame,
-  CardStackHeader,
   CardStackList,
-  CardStackLiveRegion,
-  CardStackMasks,
-  CardStackMedia,
-  CardStackMeta,
-  CardStackMetric,
-  CardStackPanel,
   CardStackRoot,
   CardStackTrigger,
   CardStackViewport,

--- a/app/(main)/_landing/card-stack-bento.tsx
+++ b/app/(main)/_landing/card-stack-bento.tsx
@@ -15,8 +15,7 @@ import { cn } from "@/lib/utils";
 
 const BENTO_PEOPLE = DEMO_PEOPLE.slice(0, 4);
 
-function BentoStackInner() {
-  const [viewed, setViewed] = useState(0);
+function BentoStackInner({ viewed }: { viewed: number }) {
   const { activeItem } = useCardStack<CardStackProfileItem>();
 
   return (
@@ -36,10 +35,7 @@ function BentoStackInner() {
           )}
         </CardStack.List>
       </CardStack.Viewport>
-      <CardStack.Trigger
-        full
-        onClick={() => setViewed((count) => Math.min(BENTO_PEOPLE.length, count + 1))}
-      />
+      <CardStack.Trigger full />
       <p className="mt-3 text-center text-[11px] text-muted-foreground">
         {viewed}/{BENTO_PEOPLE.length} viewed
         {activeItem ? ` · ${activeItem.title.split(" ")[0]}` : ""}
@@ -49,6 +45,8 @@ function BentoStackInner() {
 }
 
 export function CardStackBento() {
+  const [viewed, setViewed] = useState(1);
+
   return (
     <div className={cn("flex h-full flex-col")}>
       <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground sm:text-xs">
@@ -56,8 +54,12 @@ export function CardStackBento() {
       </span>
       <p className="mt-2 text-sm text-foreground">Click through the deck</p>
       <div className="mt-auto flex justify-center pt-4">
-        <CardStack items={BENTO_PEOPLE} depth={3}>
-          <BentoStackInner />
+        <CardStack
+          items={BENTO_PEOPLE}
+          depth={3}
+          onItemsChange={() => setViewed((count) => Math.min(BENTO_PEOPLE.length, count + 1))}
+        >
+          <BentoStackInner viewed={viewed} />
         </CardStack>
       </div>
       <Link

--- a/app/(main)/_landing/card-stack-bento.tsx
+++ b/app/(main)/_landing/card-stack-bento.tsx
@@ -4,6 +4,11 @@ import Link from "next/link";
 import { useState } from "react";
 
 import CardStack, { useCardStack } from "@/animata/card/card-stack";
+import {
+  type CardStackProfileItem,
+  CardStackProfileLiveRegion,
+  CardStackProfileMasks,
+} from "@/animata/card/card-stack-profile";
 import { DEMO_PEOPLE } from "@/app/demo/library/shared/card-stack-people";
 import { ProfileStackCard } from "@/app/demo/library/shared/profile-stack-card";
 import { cn } from "@/lib/utils";
@@ -12,35 +17,34 @@ const BENTO_PEOPLE = DEMO_PEOPLE.slice(0, 4);
 
 function BentoStackInner() {
   const [viewed, setViewed] = useState(0);
-  const { activeItem } = useCardStack();
+  const { activeItem } = useCardStack<CardStackProfileItem>();
 
   return (
-    <CardStack.Frame className="mx-auto w-full max-w-[16rem]">
-      <CardStack.Masks />
-      <CardStack.LiveRegion />
+    <section className="relative mx-auto w-full max-w-[16rem]">
+      <CardStackProfileMasks />
+      <CardStackProfileLiveRegion item={activeItem} />
+      <CardStack.Viewport className="min-h-[14rem] sm:min-h-[15rem]">
+        <CardStack.List>
+          {(item: CardStackProfileItem, index, layer) => (
+            <ProfileStackCard
+              key={item.id}
+              item={item}
+              index={index}
+              layer={layer}
+              cardClassName="shadow-lg ring-border/60"
+            />
+          )}
+        </CardStack.List>
+      </CardStack.Viewport>
       <CardStack.Trigger
-        className="w-full"
+        full
         onClick={() => setViewed((count) => Math.min(BENTO_PEOPLE.length, count + 1))}
-      >
-        <CardStack.Viewport className="min-h-[14rem] sm:min-h-[15rem]">
-          <CardStack.List>
-            {(item, index, layer) => (
-              <ProfileStackCard
-                key={item.id}
-                item={item}
-                index={index}
-                layer={layer}
-                cardClassName="shadow-lg ring-border/60"
-              />
-            )}
-          </CardStack.List>
-        </CardStack.Viewport>
-      </CardStack.Trigger>
+      />
       <p className="mt-3 text-center text-[11px] text-muted-foreground">
         {viewed}/{BENTO_PEOPLE.length} viewed
         {activeItem ? ` · ${activeItem.title.split(" ")[0]}` : ""}
       </p>
-    </CardStack.Frame>
+    </section>
   );
 }
 

--- a/app/demo/generated/demo-sources.ts
+++ b/app/demo/generated/demo-sources.ts
@@ -2549,11 +2549,7 @@ export default function CinemaRow() {
 import "@fontsource-variable/instrument-sans";
 import { type CSSProperties, type ReactNode, type RefObject, useRef, useState } from "react";
 
-import CardStack, {
-  CARD_STACK_MASK_IDS,
-  type CardStackItem,
-  useCardStack,
-} from "@/animata/card/card-stack";
+import CardStack, { type CardStackItem, useCardStack } from "@/animata/card/card-stack";
 import TrailingImage from "@/animata/image/trailing-image";
 import SplitReveal from "@/animata/preloader/split-reveal";
 import { MapPinIcon } from "@/components/ui/map-pin";
@@ -2625,48 +2621,48 @@ const HERO_TONE = {
   ink: "text-black",
 } as const;
 
-const PORTFOLIO: CardStackItem[] = [
+type PortfolioItem = CardStackItem & {
+  image: string;
+  title: string;
+  tagline: string;
+};
+
+const PORTFOLIO: PortfolioItem[] = [
   {
     id: "vows",
     image: lummi(LUMMI_ASSETS.portfolio.vows),
     title: "Vows",
     tagline: "Cliffside ceremony",
-    maskId: CARD_STACK_MASK_IDS[0],
   },
   {
     id: "ceremony",
     image: lummi(LUMMI_ASSETS.portfolio.ceremony),
     title: "Ceremony",
     tagline: "Church exit",
-    maskId: CARD_STACK_MASK_IDS[0],
   },
   {
     id: "reception",
     image: lummi(LUMMI_ASSETS.portfolio.reception),
     title: "Reception",
     tagline: "Evening dance",
-    maskId: CARD_STACK_MASK_IDS[0],
   },
   {
     id: "candid",
     image: lummi(LUMMI_ASSETS.portfolio.candid),
     title: "Candid",
     tagline: "Real laughter",
-    maskId: CARD_STACK_MASK_IDS[0],
   },
   {
     id: "florals",
     image: lummi(LUMMI_ASSETS.portfolio.florals),
     title: "Florals",
     tagline: "Bouquet detail",
-    maskId: CARD_STACK_MASK_IDS[0],
   },
   {
     id: "festival",
     image: lummi(LUMMI_ASSETS.portfolio.festival),
     title: "Event",
     tagline: "Summer festival",
-    maskId: CARD_STACK_MASK_IDS[0],
   },
 ];
 
@@ -2747,7 +2743,7 @@ function ViewfinderFrame() {
 }
 
 function PrintCaption() {
-  const { activeItem } = useCardStack();
+  const { activeItem } = useCardStack<PortfolioItem>();
   const rawIndex = activeItem ? PORTFOLIO.findIndex((item) => item.id === activeItem.id) : -1;
   const index = rawIndex === -1 ? 1 : rawIndex + 1;
   const settings =
@@ -2790,36 +2786,34 @@ const STACK_PEEK = "aspect-[8/1]";
 
 function PrintStack() {
   return (
-    <CardStack.Frame className="absolute inset-0 overflow-visible">
-      <CardStack.LiveRegion />
-      <CardStack.Trigger aria-label="Show next photo" className="absolute inset-0 block text-left">
-        <CardStack.Viewport className="absolute inset-0 overflow-visible !min-h-0 pt-[14%] sm:pt-0">
-          <CardStack.List>
-            {(item, index, layer) => (
-              <CardStack.Card
-                key={item.id}
-                layer={layer}
-                stackIndex={index}
-                className="!inset-x-0 !top-0 !h-fit !w-full gap-0 overflow-visible rounded-none !bg-transparent p-0 shadow-none ring-0"
-              >
-                <figure className="relative aspect-[4/5] w-full overflow-hidden bg-black/5">
-                  <img
-                    src={item.image}
-                    alt={\`\${PHOTOGRAPHER.studio} — \${item.title}\`}
-                    width={PRINT_WIDTH}
-                    height={PRINT_HEIGHT}
-                    decoding="async"
-                    draggable={false}
-                    className="size-full object-cover object-center"
-                  />
-                  {index === 0 ? <ViewfinderFrame /> : null}
-                </figure>
-              </CardStack.Card>
-            )}
-          </CardStack.List>
-        </CardStack.Viewport>
-      </CardStack.Trigger>
-    </CardStack.Frame>
+    <section className="absolute inset-0 overflow-visible" aria-label="Photo stack">
+      <CardStack.Viewport className="absolute inset-0 overflow-visible pt-[14%] sm:pt-0">
+        <CardStack.List>
+          {(item: PortfolioItem, index, layer) => (
+            <CardStack.Card
+              key={item.id}
+              layer={layer}
+              stackIndex={index}
+              className="!inset-x-0 !top-0 !h-fit !w-full overflow-visible rounded-none p-0 shadow-none ring-0"
+            >
+              <figure className="relative aspect-[4/5] w-full overflow-hidden bg-black/5">
+                <img
+                  src={item.image}
+                  alt={\`\${PHOTOGRAPHER.studio} — \${item.title}\`}
+                  width={PRINT_WIDTH}
+                  height={PRINT_HEIGHT}
+                  decoding="async"
+                  draggable={false}
+                  className="size-full object-cover object-center"
+                />
+                {index === 0 ? <ViewfinderFrame /> : null}
+              </figure>
+            </CardStack.Card>
+          )}
+        </CardStack.List>
+      </CardStack.Viewport>
+      <CardStack.Trigger full aria-label="Show next photo" />
+    </section>
   );
 }
 
@@ -2947,11 +2941,7 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#D73A49">import</span><span style="color:#032F62"> "@fontsource-variable/instrument-sans"</span><span style="color:#24292E">;</span></span>
 <span class="line"><span style="color:#D73A49">import</span><span style="color:#24292E"> { </span><span style="color:#D73A49">type</span><span style="color:#24292E"> CSSProperties, </span><span style="color:#D73A49">type</span><span style="color:#24292E"> ReactNode, </span><span style="color:#D73A49">type</span><span style="color:#24292E"> RefObject, useRef, useState } </span><span style="color:#D73A49">from</span><span style="color:#032F62"> "react"</span><span style="color:#24292E">;</span></span>
 <span class="line"></span>
-<span class="line"><span style="color:#D73A49">import</span><span style="color:#24292E"> CardStack, {</span></span>
-<span class="line"><span style="color:#24292E">  CARD_STACK_MASK_IDS,</span></span>
-<span class="line"><span style="color:#D73A49">  type</span><span style="color:#24292E"> CardStackItem,</span></span>
-<span class="line"><span style="color:#24292E">  useCardStack,</span></span>
-<span class="line"><span style="color:#24292E">} </span><span style="color:#D73A49">from</span><span style="color:#032F62"> "@/animata/card/card-stack"</span><span style="color:#24292E">;</span></span>
+<span class="line"><span style="color:#D73A49">import</span><span style="color:#24292E"> CardStack, { </span><span style="color:#D73A49">type</span><span style="color:#24292E"> CardStackItem, useCardStack } </span><span style="color:#D73A49">from</span><span style="color:#032F62"> "@/animata/card/card-stack"</span><span style="color:#24292E">;</span></span>
 <span class="line"><span style="color:#D73A49">import</span><span style="color:#24292E"> TrailingImage </span><span style="color:#D73A49">from</span><span style="color:#032F62"> "@/animata/image/trailing-image"</span><span style="color:#24292E">;</span></span>
 <span class="line"><span style="color:#D73A49">import</span><span style="color:#24292E"> SplitReveal </span><span style="color:#D73A49">from</span><span style="color:#032F62"> "@/animata/preloader/split-reveal"</span><span style="color:#24292E">;</span></span>
 <span class="line"><span style="color:#D73A49">import</span><span style="color:#24292E"> { MapPinIcon } </span><span style="color:#D73A49">from</span><span style="color:#032F62"> "@/components/ui/map-pin"</span><span style="color:#24292E">;</span></span>
@@ -3023,48 +3013,48 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#24292E">  ink: </span><span style="color:#032F62">"text-black"</span><span style="color:#24292E">,</span></span>
 <span class="line"><span style="color:#24292E">} </span><span style="color:#D73A49">as</span><span style="color:#D73A49"> const</span><span style="color:#24292E">;</span></span>
 <span class="line"></span>
-<span class="line"><span style="color:#D73A49">const</span><span style="color:#005CC5"> PORTFOLIO</span><span style="color:#D73A49">:</span><span style="color:#6F42C1"> CardStackItem</span><span style="color:#24292E">[] </span><span style="color:#D73A49">=</span><span style="color:#24292E"> [</span></span>
+<span class="line"><span style="color:#D73A49">type</span><span style="color:#6F42C1"> PortfolioItem</span><span style="color:#D73A49"> =</span><span style="color:#6F42C1"> CardStackItem</span><span style="color:#D73A49"> &#x26;</span><span style="color:#24292E"> {</span></span>
+<span class="line"><span style="color:#E36209">  image</span><span style="color:#D73A49">:</span><span style="color:#005CC5"> string</span><span style="color:#24292E">;</span></span>
+<span class="line"><span style="color:#E36209">  title</span><span style="color:#D73A49">:</span><span style="color:#005CC5"> string</span><span style="color:#24292E">;</span></span>
+<span class="line"><span style="color:#E36209">  tagline</span><span style="color:#D73A49">:</span><span style="color:#005CC5"> string</span><span style="color:#24292E">;</span></span>
+<span class="line"><span style="color:#24292E">};</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#D73A49">const</span><span style="color:#005CC5"> PORTFOLIO</span><span style="color:#D73A49">:</span><span style="color:#6F42C1"> PortfolioItem</span><span style="color:#24292E">[] </span><span style="color:#D73A49">=</span><span style="color:#24292E"> [</span></span>
 <span class="line"><span style="color:#24292E">  {</span></span>
 <span class="line"><span style="color:#24292E">    id: </span><span style="color:#032F62">"vows"</span><span style="color:#24292E">,</span></span>
 <span class="line"><span style="color:#24292E">    image: </span><span style="color:#6F42C1">lummi</span><span style="color:#24292E">(</span><span style="color:#005CC5">LUMMI_ASSETS</span><span style="color:#24292E">.portfolio.vows),</span></span>
 <span class="line"><span style="color:#24292E">    title: </span><span style="color:#032F62">"Vows"</span><span style="color:#24292E">,</span></span>
 <span class="line"><span style="color:#24292E">    tagline: </span><span style="color:#032F62">"Cliffside ceremony"</span><span style="color:#24292E">,</span></span>
-<span class="line"><span style="color:#24292E">    maskId: </span><span style="color:#005CC5">CARD_STACK_MASK_IDS</span><span style="color:#24292E">[</span><span style="color:#005CC5">0</span><span style="color:#24292E">],</span></span>
 <span class="line"><span style="color:#24292E">  },</span></span>
 <span class="line"><span style="color:#24292E">  {</span></span>
 <span class="line"><span style="color:#24292E">    id: </span><span style="color:#032F62">"ceremony"</span><span style="color:#24292E">,</span></span>
 <span class="line"><span style="color:#24292E">    image: </span><span style="color:#6F42C1">lummi</span><span style="color:#24292E">(</span><span style="color:#005CC5">LUMMI_ASSETS</span><span style="color:#24292E">.portfolio.ceremony),</span></span>
 <span class="line"><span style="color:#24292E">    title: </span><span style="color:#032F62">"Ceremony"</span><span style="color:#24292E">,</span></span>
 <span class="line"><span style="color:#24292E">    tagline: </span><span style="color:#032F62">"Church exit"</span><span style="color:#24292E">,</span></span>
-<span class="line"><span style="color:#24292E">    maskId: </span><span style="color:#005CC5">CARD_STACK_MASK_IDS</span><span style="color:#24292E">[</span><span style="color:#005CC5">0</span><span style="color:#24292E">],</span></span>
 <span class="line"><span style="color:#24292E">  },</span></span>
 <span class="line"><span style="color:#24292E">  {</span></span>
 <span class="line"><span style="color:#24292E">    id: </span><span style="color:#032F62">"reception"</span><span style="color:#24292E">,</span></span>
 <span class="line"><span style="color:#24292E">    image: </span><span style="color:#6F42C1">lummi</span><span style="color:#24292E">(</span><span style="color:#005CC5">LUMMI_ASSETS</span><span style="color:#24292E">.portfolio.reception),</span></span>
 <span class="line"><span style="color:#24292E">    title: </span><span style="color:#032F62">"Reception"</span><span style="color:#24292E">,</span></span>
 <span class="line"><span style="color:#24292E">    tagline: </span><span style="color:#032F62">"Evening dance"</span><span style="color:#24292E">,</span></span>
-<span class="line"><span style="color:#24292E">    maskId: </span><span style="color:#005CC5">CARD_STACK_MASK_IDS</span><span style="color:#24292E">[</span><span style="color:#005CC5">0</span><span style="color:#24292E">],</span></span>
 <span class="line"><span style="color:#24292E">  },</span></span>
 <span class="line"><span style="color:#24292E">  {</span></span>
 <span class="line"><span style="color:#24292E">    id: </span><span style="color:#032F62">"candid"</span><span style="color:#24292E">,</span></span>
 <span class="line"><span style="color:#24292E">    image: </span><span style="color:#6F42C1">lummi</span><span style="color:#24292E">(</span><span style="color:#005CC5">LUMMI_ASSETS</span><span style="color:#24292E">.portfolio.candid),</span></span>
 <span class="line"><span style="color:#24292E">    title: </span><span style="color:#032F62">"Candid"</span><span style="color:#24292E">,</span></span>
 <span class="line"><span style="color:#24292E">    tagline: </span><span style="color:#032F62">"Real laughter"</span><span style="color:#24292E">,</span></span>
-<span class="line"><span style="color:#24292E">    maskId: </span><span style="color:#005CC5">CARD_STACK_MASK_IDS</span><span style="color:#24292E">[</span><span style="color:#005CC5">0</span><span style="color:#24292E">],</span></span>
 <span class="line"><span style="color:#24292E">  },</span></span>
 <span class="line"><span style="color:#24292E">  {</span></span>
 <span class="line"><span style="color:#24292E">    id: </span><span style="color:#032F62">"florals"</span><span style="color:#24292E">,</span></span>
 <span class="line"><span style="color:#24292E">    image: </span><span style="color:#6F42C1">lummi</span><span style="color:#24292E">(</span><span style="color:#005CC5">LUMMI_ASSETS</span><span style="color:#24292E">.portfolio.florals),</span></span>
 <span class="line"><span style="color:#24292E">    title: </span><span style="color:#032F62">"Florals"</span><span style="color:#24292E">,</span></span>
 <span class="line"><span style="color:#24292E">    tagline: </span><span style="color:#032F62">"Bouquet detail"</span><span style="color:#24292E">,</span></span>
-<span class="line"><span style="color:#24292E">    maskId: </span><span style="color:#005CC5">CARD_STACK_MASK_IDS</span><span style="color:#24292E">[</span><span style="color:#005CC5">0</span><span style="color:#24292E">],</span></span>
 <span class="line"><span style="color:#24292E">  },</span></span>
 <span class="line"><span style="color:#24292E">  {</span></span>
 <span class="line"><span style="color:#24292E">    id: </span><span style="color:#032F62">"festival"</span><span style="color:#24292E">,</span></span>
 <span class="line"><span style="color:#24292E">    image: </span><span style="color:#6F42C1">lummi</span><span style="color:#24292E">(</span><span style="color:#005CC5">LUMMI_ASSETS</span><span style="color:#24292E">.portfolio.festival),</span></span>
 <span class="line"><span style="color:#24292E">    title: </span><span style="color:#032F62">"Event"</span><span style="color:#24292E">,</span></span>
 <span class="line"><span style="color:#24292E">    tagline: </span><span style="color:#032F62">"Summer festival"</span><span style="color:#24292E">,</span></span>
-<span class="line"><span style="color:#24292E">    maskId: </span><span style="color:#005CC5">CARD_STACK_MASK_IDS</span><span style="color:#24292E">[</span><span style="color:#005CC5">0</span><span style="color:#24292E">],</span></span>
 <span class="line"><span style="color:#24292E">  },</span></span>
 <span class="line"><span style="color:#24292E">];</span></span>
 <span class="line"></span>
@@ -3145,7 +3135,7 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#24292E">}</span></span>
 <span class="line"></span>
 <span class="line"><span style="color:#D73A49">function</span><span style="color:#6F42C1"> PrintCaption</span><span style="color:#24292E">() {</span></span>
-<span class="line"><span style="color:#D73A49">  const</span><span style="color:#24292E"> { </span><span style="color:#005CC5">activeItem</span><span style="color:#24292E"> } </span><span style="color:#D73A49">=</span><span style="color:#6F42C1"> useCardStack</span><span style="color:#24292E">();</span></span>
+<span class="line"><span style="color:#D73A49">  const</span><span style="color:#24292E"> { </span><span style="color:#005CC5">activeItem</span><span style="color:#24292E"> } </span><span style="color:#D73A49">=</span><span style="color:#6F42C1"> useCardStack</span><span style="color:#24292E">&#x3C;</span><span style="color:#6F42C1">PortfolioItem</span><span style="color:#24292E">>();</span></span>
 <span class="line"><span style="color:#D73A49">  const</span><span style="color:#005CC5"> rawIndex</span><span style="color:#D73A49"> =</span><span style="color:#24292E"> activeItem </span><span style="color:#D73A49">?</span><span style="color:#005CC5"> PORTFOLIO</span><span style="color:#24292E">.</span><span style="color:#6F42C1">findIndex</span><span style="color:#24292E">((</span><span style="color:#E36209">item</span><span style="color:#24292E">) </span><span style="color:#D73A49">=></span><span style="color:#24292E"> item.id </span><span style="color:#D73A49">===</span><span style="color:#24292E"> activeItem.id) </span><span style="color:#D73A49">:</span><span style="color:#D73A49"> -</span><span style="color:#005CC5">1</span><span style="color:#24292E">;</span></span>
 <span class="line"><span style="color:#D73A49">  const</span><span style="color:#005CC5"> index</span><span style="color:#D73A49"> =</span><span style="color:#24292E"> rawIndex </span><span style="color:#D73A49">===</span><span style="color:#D73A49"> -</span><span style="color:#005CC5">1</span><span style="color:#D73A49"> ?</span><span style="color:#005CC5"> 1</span><span style="color:#D73A49"> :</span><span style="color:#24292E"> rawIndex </span><span style="color:#D73A49">+</span><span style="color:#005CC5"> 1</span><span style="color:#24292E">;</span></span>
 <span class="line"><span style="color:#D73A49">  const</span><span style="color:#005CC5"> settings</span><span style="color:#D73A49"> =</span></span>
@@ -3188,36 +3178,34 @@ export default function PhotographerPortfolio() {
 <span class="line"></span>
 <span class="line"><span style="color:#D73A49">function</span><span style="color:#6F42C1"> PrintStack</span><span style="color:#24292E">() {</span></span>
 <span class="line"><span style="color:#D73A49">  return</span><span style="color:#24292E"> (</span></span>
-<span class="line"><span style="color:#24292E">    &#x3C;</span><span style="color:#005CC5">CardStack.Frame</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"absolute inset-0 overflow-visible"</span><span style="color:#24292E">></span></span>
-<span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#005CC5">CardStack.LiveRegion</span><span style="color:#24292E"> /></span></span>
-<span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#005CC5">CardStack.Trigger</span><span style="color:#6F42C1"> aria-label</span><span style="color:#D73A49">=</span><span style="color:#032F62">"Show next photo"</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"absolute inset-0 block text-left"</span><span style="color:#24292E">></span></span>
-<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#005CC5">CardStack.Viewport</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"absolute inset-0 overflow-visible !min-h-0 pt-[14%] sm:pt-0"</span><span style="color:#24292E">></span></span>
-<span class="line"><span style="color:#24292E">          &#x3C;</span><span style="color:#005CC5">CardStack.List</span><span style="color:#24292E">></span></span>
-<span class="line"><span style="color:#24292E">            {(</span><span style="color:#E36209">item</span><span style="color:#24292E">, </span><span style="color:#E36209">index</span><span style="color:#24292E">, </span><span style="color:#E36209">layer</span><span style="color:#24292E">) </span><span style="color:#D73A49">=></span><span style="color:#24292E"> (</span></span>
-<span class="line"><span style="color:#24292E">              &#x3C;</span><span style="color:#005CC5">CardStack.Card</span></span>
-<span class="line"><span style="color:#6F42C1">                key</span><span style="color:#D73A49">=</span><span style="color:#24292E">{item.id}</span></span>
-<span class="line"><span style="color:#6F42C1">                layer</span><span style="color:#D73A49">=</span><span style="color:#24292E">{layer}</span></span>
-<span class="line"><span style="color:#6F42C1">                stackIndex</span><span style="color:#D73A49">=</span><span style="color:#24292E">{index}</span></span>
-<span class="line"><span style="color:#6F42C1">                className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"!inset-x-0 !top-0 !h-fit !w-full gap-0 overflow-visible rounded-none !bg-transparent p-0 shadow-none ring-0"</span></span>
-<span class="line"><span style="color:#24292E">              ></span></span>
-<span class="line"><span style="color:#24292E">                &#x3C;</span><span style="color:#22863A">figure</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"relative aspect-[4/5] w-full overflow-hidden bg-black/5"</span><span style="color:#24292E">></span></span>
-<span class="line"><span style="color:#24292E">                  &#x3C;</span><span style="color:#22863A">img</span></span>
-<span class="line"><span style="color:#6F42C1">                    src</span><span style="color:#D73A49">=</span><span style="color:#24292E">{item.image}</span></span>
-<span class="line"><span style="color:#6F42C1">                    alt</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#032F62">\`\${</span><span style="color:#005CC5">PHOTOGRAPHER</span><span style="color:#032F62">.</span><span style="color:#24292E">studio</span><span style="color:#032F62">} — \${</span><span style="color:#24292E">item</span><span style="color:#032F62">.</span><span style="color:#24292E">title</span><span style="color:#032F62">}\`</span><span style="color:#24292E">}</span></span>
-<span class="line"><span style="color:#6F42C1">                    width</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">PRINT_WIDTH</span><span style="color:#24292E">}</span></span>
-<span class="line"><span style="color:#6F42C1">                    height</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">PRINT_HEIGHT</span><span style="color:#24292E">}</span></span>
-<span class="line"><span style="color:#6F42C1">                    decoding</span><span style="color:#D73A49">=</span><span style="color:#032F62">"async"</span></span>
-<span class="line"><span style="color:#6F42C1">                    draggable</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">false</span><span style="color:#24292E">}</span></span>
-<span class="line"><span style="color:#6F42C1">                    className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"size-full object-cover object-center"</span></span>
-<span class="line"><span style="color:#24292E">                  /></span></span>
-<span class="line"><span style="color:#24292E">                  {index </span><span style="color:#D73A49">===</span><span style="color:#005CC5"> 0</span><span style="color:#D73A49"> ?</span><span style="color:#24292E"> &#x3C;</span><span style="color:#005CC5">ViewfinderFrame</span><span style="color:#24292E"> /> </span><span style="color:#D73A49">:</span><span style="color:#005CC5"> null</span><span style="color:#24292E">}</span></span>
-<span class="line"><span style="color:#24292E">                &#x3C;/</span><span style="color:#22863A">figure</span><span style="color:#24292E">></span></span>
-<span class="line"><span style="color:#24292E">              &#x3C;/</span><span style="color:#005CC5">CardStack.Card</span><span style="color:#24292E">></span></span>
-<span class="line"><span style="color:#24292E">            )}</span></span>
-<span class="line"><span style="color:#24292E">          &#x3C;/</span><span style="color:#005CC5">CardStack.List</span><span style="color:#24292E">></span></span>
-<span class="line"><span style="color:#24292E">        &#x3C;/</span><span style="color:#005CC5">CardStack.Viewport</span><span style="color:#24292E">></span></span>
-<span class="line"><span style="color:#24292E">      &#x3C;/</span><span style="color:#005CC5">CardStack.Trigger</span><span style="color:#24292E">></span></span>
-<span class="line"><span style="color:#24292E">    &#x3C;/</span><span style="color:#005CC5">CardStack.Frame</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">    &#x3C;</span><span style="color:#22863A">section</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"absolute inset-0 overflow-visible"</span><span style="color:#6F42C1"> aria-label</span><span style="color:#D73A49">=</span><span style="color:#032F62">"Photo stack"</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#005CC5">CardStack.Viewport</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"absolute inset-0 overflow-visible pt-[14%] sm:pt-0"</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;</span><span style="color:#005CC5">CardStack.List</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">          {(</span><span style="color:#E36209">item</span><span style="color:#D73A49">:</span><span style="color:#6F42C1"> PortfolioItem</span><span style="color:#24292E">, </span><span style="color:#E36209">index</span><span style="color:#24292E">, </span><span style="color:#E36209">layer</span><span style="color:#24292E">) </span><span style="color:#D73A49">=></span><span style="color:#24292E"> (</span></span>
+<span class="line"><span style="color:#24292E">            &#x3C;</span><span style="color:#005CC5">CardStack.Card</span></span>
+<span class="line"><span style="color:#6F42C1">              key</span><span style="color:#D73A49">=</span><span style="color:#24292E">{item.id}</span></span>
+<span class="line"><span style="color:#6F42C1">              layer</span><span style="color:#D73A49">=</span><span style="color:#24292E">{layer}</span></span>
+<span class="line"><span style="color:#6F42C1">              stackIndex</span><span style="color:#D73A49">=</span><span style="color:#24292E">{index}</span></span>
+<span class="line"><span style="color:#6F42C1">              className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"!inset-x-0 !top-0 !h-fit !w-full overflow-visible rounded-none p-0 shadow-none ring-0"</span></span>
+<span class="line"><span style="color:#24292E">            ></span></span>
+<span class="line"><span style="color:#24292E">              &#x3C;</span><span style="color:#22863A">figure</span><span style="color:#6F42C1"> className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"relative aspect-[4/5] w-full overflow-hidden bg-black/5"</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">                &#x3C;</span><span style="color:#22863A">img</span></span>
+<span class="line"><span style="color:#6F42C1">                  src</span><span style="color:#D73A49">=</span><span style="color:#24292E">{item.image}</span></span>
+<span class="line"><span style="color:#6F42C1">                  alt</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#032F62">\`\${</span><span style="color:#005CC5">PHOTOGRAPHER</span><span style="color:#032F62">.</span><span style="color:#24292E">studio</span><span style="color:#032F62">} — \${</span><span style="color:#24292E">item</span><span style="color:#032F62">.</span><span style="color:#24292E">title</span><span style="color:#032F62">}\`</span><span style="color:#24292E">}</span></span>
+<span class="line"><span style="color:#6F42C1">                  width</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">PRINT_WIDTH</span><span style="color:#24292E">}</span></span>
+<span class="line"><span style="color:#6F42C1">                  height</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">PRINT_HEIGHT</span><span style="color:#24292E">}</span></span>
+<span class="line"><span style="color:#6F42C1">                  decoding</span><span style="color:#D73A49">=</span><span style="color:#032F62">"async"</span></span>
+<span class="line"><span style="color:#6F42C1">                  draggable</span><span style="color:#D73A49">=</span><span style="color:#24292E">{</span><span style="color:#005CC5">false</span><span style="color:#24292E">}</span></span>
+<span class="line"><span style="color:#6F42C1">                  className</span><span style="color:#D73A49">=</span><span style="color:#032F62">"size-full object-cover object-center"</span></span>
+<span class="line"><span style="color:#24292E">                /></span></span>
+<span class="line"><span style="color:#24292E">                {index </span><span style="color:#D73A49">===</span><span style="color:#005CC5"> 0</span><span style="color:#D73A49"> ?</span><span style="color:#24292E"> &#x3C;</span><span style="color:#005CC5">ViewfinderFrame</span><span style="color:#24292E"> /> </span><span style="color:#D73A49">:</span><span style="color:#005CC5"> null</span><span style="color:#24292E">}</span></span>
+<span class="line"><span style="color:#24292E">              &#x3C;/</span><span style="color:#22863A">figure</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">            &#x3C;/</span><span style="color:#005CC5">CardStack.Card</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">          )}</span></span>
+<span class="line"><span style="color:#24292E">        &#x3C;/</span><span style="color:#005CC5">CardStack.List</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">      &#x3C;/</span><span style="color:#005CC5">CardStack.Viewport</span><span style="color:#24292E">></span></span>
+<span class="line"><span style="color:#24292E">      &#x3C;</span><span style="color:#005CC5">CardStack.Trigger</span><span style="color:#6F42C1"> full</span><span style="color:#6F42C1"> aria-label</span><span style="color:#D73A49">=</span><span style="color:#032F62">"Show next photo"</span><span style="color:#24292E"> /></span></span>
+<span class="line"><span style="color:#24292E">    &#x3C;/</span><span style="color:#22863A">section</span><span style="color:#24292E">></span></span>
 <span class="line"><span style="color:#24292E">  );</span></span>
 <span class="line"><span style="color:#24292E">}</span></span>
 <span class="line"></span>
@@ -3345,11 +3333,7 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#F97583">import</span><span style="color:#9ECBFF"> "@fontsource-variable/instrument-sans"</span><span style="color:#E1E4E8">;</span></span>
 <span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> { </span><span style="color:#F97583">type</span><span style="color:#E1E4E8"> CSSProperties, </span><span style="color:#F97583">type</span><span style="color:#E1E4E8"> ReactNode, </span><span style="color:#F97583">type</span><span style="color:#E1E4E8"> RefObject, useRef, useState } </span><span style="color:#F97583">from</span><span style="color:#9ECBFF"> "react"</span><span style="color:#E1E4E8">;</span></span>
 <span class="line"></span>
-<span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> CardStack, {</span></span>
-<span class="line"><span style="color:#E1E4E8">  CARD_STACK_MASK_IDS,</span></span>
-<span class="line"><span style="color:#F97583">  type</span><span style="color:#E1E4E8"> CardStackItem,</span></span>
-<span class="line"><span style="color:#E1E4E8">  useCardStack,</span></span>
-<span class="line"><span style="color:#E1E4E8">} </span><span style="color:#F97583">from</span><span style="color:#9ECBFF"> "@/animata/card/card-stack"</span><span style="color:#E1E4E8">;</span></span>
+<span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> CardStack, { </span><span style="color:#F97583">type</span><span style="color:#E1E4E8"> CardStackItem, useCardStack } </span><span style="color:#F97583">from</span><span style="color:#9ECBFF"> "@/animata/card/card-stack"</span><span style="color:#E1E4E8">;</span></span>
 <span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> TrailingImage </span><span style="color:#F97583">from</span><span style="color:#9ECBFF"> "@/animata/image/trailing-image"</span><span style="color:#E1E4E8">;</span></span>
 <span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> SplitReveal </span><span style="color:#F97583">from</span><span style="color:#9ECBFF"> "@/animata/preloader/split-reveal"</span><span style="color:#E1E4E8">;</span></span>
 <span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> { MapPinIcon } </span><span style="color:#F97583">from</span><span style="color:#9ECBFF"> "@/components/ui/map-pin"</span><span style="color:#E1E4E8">;</span></span>
@@ -3421,48 +3405,48 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#E1E4E8">  ink: </span><span style="color:#9ECBFF">"text-black"</span><span style="color:#E1E4E8">,</span></span>
 <span class="line"><span style="color:#E1E4E8">} </span><span style="color:#F97583">as</span><span style="color:#F97583"> const</span><span style="color:#E1E4E8">;</span></span>
 <span class="line"></span>
-<span class="line"><span style="color:#F97583">const</span><span style="color:#79B8FF"> PORTFOLIO</span><span style="color:#F97583">:</span><span style="color:#B392F0"> CardStackItem</span><span style="color:#E1E4E8">[] </span><span style="color:#F97583">=</span><span style="color:#E1E4E8"> [</span></span>
+<span class="line"><span style="color:#F97583">type</span><span style="color:#B392F0"> PortfolioItem</span><span style="color:#F97583"> =</span><span style="color:#B392F0"> CardStackItem</span><span style="color:#F97583"> &#x26;</span><span style="color:#E1E4E8"> {</span></span>
+<span class="line"><span style="color:#FFAB70">  image</span><span style="color:#F97583">:</span><span style="color:#79B8FF"> string</span><span style="color:#E1E4E8">;</span></span>
+<span class="line"><span style="color:#FFAB70">  title</span><span style="color:#F97583">:</span><span style="color:#79B8FF"> string</span><span style="color:#E1E4E8">;</span></span>
+<span class="line"><span style="color:#FFAB70">  tagline</span><span style="color:#F97583">:</span><span style="color:#79B8FF"> string</span><span style="color:#E1E4E8">;</span></span>
+<span class="line"><span style="color:#E1E4E8">};</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#F97583">const</span><span style="color:#79B8FF"> PORTFOLIO</span><span style="color:#F97583">:</span><span style="color:#B392F0"> PortfolioItem</span><span style="color:#E1E4E8">[] </span><span style="color:#F97583">=</span><span style="color:#E1E4E8"> [</span></span>
 <span class="line"><span style="color:#E1E4E8">  {</span></span>
 <span class="line"><span style="color:#E1E4E8">    id: </span><span style="color:#9ECBFF">"vows"</span><span style="color:#E1E4E8">,</span></span>
 <span class="line"><span style="color:#E1E4E8">    image: </span><span style="color:#B392F0">lummi</span><span style="color:#E1E4E8">(</span><span style="color:#79B8FF">LUMMI_ASSETS</span><span style="color:#E1E4E8">.portfolio.vows),</span></span>
 <span class="line"><span style="color:#E1E4E8">    title: </span><span style="color:#9ECBFF">"Vows"</span><span style="color:#E1E4E8">,</span></span>
 <span class="line"><span style="color:#E1E4E8">    tagline: </span><span style="color:#9ECBFF">"Cliffside ceremony"</span><span style="color:#E1E4E8">,</span></span>
-<span class="line"><span style="color:#E1E4E8">    maskId: </span><span style="color:#79B8FF">CARD_STACK_MASK_IDS</span><span style="color:#E1E4E8">[</span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8">],</span></span>
 <span class="line"><span style="color:#E1E4E8">  },</span></span>
 <span class="line"><span style="color:#E1E4E8">  {</span></span>
 <span class="line"><span style="color:#E1E4E8">    id: </span><span style="color:#9ECBFF">"ceremony"</span><span style="color:#E1E4E8">,</span></span>
 <span class="line"><span style="color:#E1E4E8">    image: </span><span style="color:#B392F0">lummi</span><span style="color:#E1E4E8">(</span><span style="color:#79B8FF">LUMMI_ASSETS</span><span style="color:#E1E4E8">.portfolio.ceremony),</span></span>
 <span class="line"><span style="color:#E1E4E8">    title: </span><span style="color:#9ECBFF">"Ceremony"</span><span style="color:#E1E4E8">,</span></span>
 <span class="line"><span style="color:#E1E4E8">    tagline: </span><span style="color:#9ECBFF">"Church exit"</span><span style="color:#E1E4E8">,</span></span>
-<span class="line"><span style="color:#E1E4E8">    maskId: </span><span style="color:#79B8FF">CARD_STACK_MASK_IDS</span><span style="color:#E1E4E8">[</span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8">],</span></span>
 <span class="line"><span style="color:#E1E4E8">  },</span></span>
 <span class="line"><span style="color:#E1E4E8">  {</span></span>
 <span class="line"><span style="color:#E1E4E8">    id: </span><span style="color:#9ECBFF">"reception"</span><span style="color:#E1E4E8">,</span></span>
 <span class="line"><span style="color:#E1E4E8">    image: </span><span style="color:#B392F0">lummi</span><span style="color:#E1E4E8">(</span><span style="color:#79B8FF">LUMMI_ASSETS</span><span style="color:#E1E4E8">.portfolio.reception),</span></span>
 <span class="line"><span style="color:#E1E4E8">    title: </span><span style="color:#9ECBFF">"Reception"</span><span style="color:#E1E4E8">,</span></span>
 <span class="line"><span style="color:#E1E4E8">    tagline: </span><span style="color:#9ECBFF">"Evening dance"</span><span style="color:#E1E4E8">,</span></span>
-<span class="line"><span style="color:#E1E4E8">    maskId: </span><span style="color:#79B8FF">CARD_STACK_MASK_IDS</span><span style="color:#E1E4E8">[</span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8">],</span></span>
 <span class="line"><span style="color:#E1E4E8">  },</span></span>
 <span class="line"><span style="color:#E1E4E8">  {</span></span>
 <span class="line"><span style="color:#E1E4E8">    id: </span><span style="color:#9ECBFF">"candid"</span><span style="color:#E1E4E8">,</span></span>
 <span class="line"><span style="color:#E1E4E8">    image: </span><span style="color:#B392F0">lummi</span><span style="color:#E1E4E8">(</span><span style="color:#79B8FF">LUMMI_ASSETS</span><span style="color:#E1E4E8">.portfolio.candid),</span></span>
 <span class="line"><span style="color:#E1E4E8">    title: </span><span style="color:#9ECBFF">"Candid"</span><span style="color:#E1E4E8">,</span></span>
 <span class="line"><span style="color:#E1E4E8">    tagline: </span><span style="color:#9ECBFF">"Real laughter"</span><span style="color:#E1E4E8">,</span></span>
-<span class="line"><span style="color:#E1E4E8">    maskId: </span><span style="color:#79B8FF">CARD_STACK_MASK_IDS</span><span style="color:#E1E4E8">[</span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8">],</span></span>
 <span class="line"><span style="color:#E1E4E8">  },</span></span>
 <span class="line"><span style="color:#E1E4E8">  {</span></span>
 <span class="line"><span style="color:#E1E4E8">    id: </span><span style="color:#9ECBFF">"florals"</span><span style="color:#E1E4E8">,</span></span>
 <span class="line"><span style="color:#E1E4E8">    image: </span><span style="color:#B392F0">lummi</span><span style="color:#E1E4E8">(</span><span style="color:#79B8FF">LUMMI_ASSETS</span><span style="color:#E1E4E8">.portfolio.florals),</span></span>
 <span class="line"><span style="color:#E1E4E8">    title: </span><span style="color:#9ECBFF">"Florals"</span><span style="color:#E1E4E8">,</span></span>
 <span class="line"><span style="color:#E1E4E8">    tagline: </span><span style="color:#9ECBFF">"Bouquet detail"</span><span style="color:#E1E4E8">,</span></span>
-<span class="line"><span style="color:#E1E4E8">    maskId: </span><span style="color:#79B8FF">CARD_STACK_MASK_IDS</span><span style="color:#E1E4E8">[</span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8">],</span></span>
 <span class="line"><span style="color:#E1E4E8">  },</span></span>
 <span class="line"><span style="color:#E1E4E8">  {</span></span>
 <span class="line"><span style="color:#E1E4E8">    id: </span><span style="color:#9ECBFF">"festival"</span><span style="color:#E1E4E8">,</span></span>
 <span class="line"><span style="color:#E1E4E8">    image: </span><span style="color:#B392F0">lummi</span><span style="color:#E1E4E8">(</span><span style="color:#79B8FF">LUMMI_ASSETS</span><span style="color:#E1E4E8">.portfolio.festival),</span></span>
 <span class="line"><span style="color:#E1E4E8">    title: </span><span style="color:#9ECBFF">"Event"</span><span style="color:#E1E4E8">,</span></span>
 <span class="line"><span style="color:#E1E4E8">    tagline: </span><span style="color:#9ECBFF">"Summer festival"</span><span style="color:#E1E4E8">,</span></span>
-<span class="line"><span style="color:#E1E4E8">    maskId: </span><span style="color:#79B8FF">CARD_STACK_MASK_IDS</span><span style="color:#E1E4E8">[</span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8">],</span></span>
 <span class="line"><span style="color:#E1E4E8">  },</span></span>
 <span class="line"><span style="color:#E1E4E8">];</span></span>
 <span class="line"></span>
@@ -3543,7 +3527,7 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#E1E4E8">}</span></span>
 <span class="line"></span>
 <span class="line"><span style="color:#F97583">function</span><span style="color:#B392F0"> PrintCaption</span><span style="color:#E1E4E8">() {</span></span>
-<span class="line"><span style="color:#F97583">  const</span><span style="color:#E1E4E8"> { </span><span style="color:#79B8FF">activeItem</span><span style="color:#E1E4E8"> } </span><span style="color:#F97583">=</span><span style="color:#B392F0"> useCardStack</span><span style="color:#E1E4E8">();</span></span>
+<span class="line"><span style="color:#F97583">  const</span><span style="color:#E1E4E8"> { </span><span style="color:#79B8FF">activeItem</span><span style="color:#E1E4E8"> } </span><span style="color:#F97583">=</span><span style="color:#B392F0"> useCardStack</span><span style="color:#E1E4E8">&#x3C;</span><span style="color:#B392F0">PortfolioItem</span><span style="color:#E1E4E8">>();</span></span>
 <span class="line"><span style="color:#F97583">  const</span><span style="color:#79B8FF"> rawIndex</span><span style="color:#F97583"> =</span><span style="color:#E1E4E8"> activeItem </span><span style="color:#F97583">?</span><span style="color:#79B8FF"> PORTFOLIO</span><span style="color:#E1E4E8">.</span><span style="color:#B392F0">findIndex</span><span style="color:#E1E4E8">((</span><span style="color:#FFAB70">item</span><span style="color:#E1E4E8">) </span><span style="color:#F97583">=></span><span style="color:#E1E4E8"> item.id </span><span style="color:#F97583">===</span><span style="color:#E1E4E8"> activeItem.id) </span><span style="color:#F97583">:</span><span style="color:#F97583"> -</span><span style="color:#79B8FF">1</span><span style="color:#E1E4E8">;</span></span>
 <span class="line"><span style="color:#F97583">  const</span><span style="color:#79B8FF"> index</span><span style="color:#F97583"> =</span><span style="color:#E1E4E8"> rawIndex </span><span style="color:#F97583">===</span><span style="color:#F97583"> -</span><span style="color:#79B8FF">1</span><span style="color:#F97583"> ?</span><span style="color:#79B8FF"> 1</span><span style="color:#F97583"> :</span><span style="color:#E1E4E8"> rawIndex </span><span style="color:#F97583">+</span><span style="color:#79B8FF"> 1</span><span style="color:#E1E4E8">;</span></span>
 <span class="line"><span style="color:#F97583">  const</span><span style="color:#79B8FF"> settings</span><span style="color:#F97583"> =</span></span>
@@ -3586,36 +3570,34 @@ export default function PhotographerPortfolio() {
 <span class="line"></span>
 <span class="line"><span style="color:#F97583">function</span><span style="color:#B392F0"> PrintStack</span><span style="color:#E1E4E8">() {</span></span>
 <span class="line"><span style="color:#F97583">  return</span><span style="color:#E1E4E8"> (</span></span>
-<span class="line"><span style="color:#E1E4E8">    &#x3C;</span><span style="color:#79B8FF">CardStack.Frame</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"absolute inset-0 overflow-visible"</span><span style="color:#E1E4E8">></span></span>
-<span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#79B8FF">CardStack.LiveRegion</span><span style="color:#E1E4E8"> /></span></span>
-<span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#79B8FF">CardStack.Trigger</span><span style="color:#B392F0"> aria-label</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"Show next photo"</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"absolute inset-0 block text-left"</span><span style="color:#E1E4E8">></span></span>
-<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#79B8FF">CardStack.Viewport</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"absolute inset-0 overflow-visible !min-h-0 pt-[14%] sm:pt-0"</span><span style="color:#E1E4E8">></span></span>
-<span class="line"><span style="color:#E1E4E8">          &#x3C;</span><span style="color:#79B8FF">CardStack.List</span><span style="color:#E1E4E8">></span></span>
-<span class="line"><span style="color:#E1E4E8">            {(</span><span style="color:#FFAB70">item</span><span style="color:#E1E4E8">, </span><span style="color:#FFAB70">index</span><span style="color:#E1E4E8">, </span><span style="color:#FFAB70">layer</span><span style="color:#E1E4E8">) </span><span style="color:#F97583">=></span><span style="color:#E1E4E8"> (</span></span>
-<span class="line"><span style="color:#E1E4E8">              &#x3C;</span><span style="color:#79B8FF">CardStack.Card</span></span>
-<span class="line"><span style="color:#B392F0">                key</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{item.id}</span></span>
-<span class="line"><span style="color:#B392F0">                layer</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{layer}</span></span>
-<span class="line"><span style="color:#B392F0">                stackIndex</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{index}</span></span>
-<span class="line"><span style="color:#B392F0">                className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"!inset-x-0 !top-0 !h-fit !w-full gap-0 overflow-visible rounded-none !bg-transparent p-0 shadow-none ring-0"</span></span>
-<span class="line"><span style="color:#E1E4E8">              ></span></span>
-<span class="line"><span style="color:#E1E4E8">                &#x3C;</span><span style="color:#85E89D">figure</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"relative aspect-[4/5] w-full overflow-hidden bg-black/5"</span><span style="color:#E1E4E8">></span></span>
-<span class="line"><span style="color:#E1E4E8">                  &#x3C;</span><span style="color:#85E89D">img</span></span>
-<span class="line"><span style="color:#B392F0">                    src</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{item.image}</span></span>
-<span class="line"><span style="color:#B392F0">                    alt</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#9ECBFF">\`\${</span><span style="color:#79B8FF">PHOTOGRAPHER</span><span style="color:#9ECBFF">.</span><span style="color:#E1E4E8">studio</span><span style="color:#9ECBFF">} — \${</span><span style="color:#E1E4E8">item</span><span style="color:#9ECBFF">.</span><span style="color:#E1E4E8">title</span><span style="color:#9ECBFF">}\`</span><span style="color:#E1E4E8">}</span></span>
-<span class="line"><span style="color:#B392F0">                    width</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">PRINT_WIDTH</span><span style="color:#E1E4E8">}</span></span>
-<span class="line"><span style="color:#B392F0">                    height</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">PRINT_HEIGHT</span><span style="color:#E1E4E8">}</span></span>
-<span class="line"><span style="color:#B392F0">                    decoding</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"async"</span></span>
-<span class="line"><span style="color:#B392F0">                    draggable</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">false</span><span style="color:#E1E4E8">}</span></span>
-<span class="line"><span style="color:#B392F0">                    className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"size-full object-cover object-center"</span></span>
-<span class="line"><span style="color:#E1E4E8">                  /></span></span>
-<span class="line"><span style="color:#E1E4E8">                  {index </span><span style="color:#F97583">===</span><span style="color:#79B8FF"> 0</span><span style="color:#F97583"> ?</span><span style="color:#E1E4E8"> &#x3C;</span><span style="color:#79B8FF">ViewfinderFrame</span><span style="color:#E1E4E8"> /> </span><span style="color:#F97583">:</span><span style="color:#79B8FF"> null</span><span style="color:#E1E4E8">}</span></span>
-<span class="line"><span style="color:#E1E4E8">                &#x3C;/</span><span style="color:#85E89D">figure</span><span style="color:#E1E4E8">></span></span>
-<span class="line"><span style="color:#E1E4E8">              &#x3C;/</span><span style="color:#79B8FF">CardStack.Card</span><span style="color:#E1E4E8">></span></span>
-<span class="line"><span style="color:#E1E4E8">            )}</span></span>
-<span class="line"><span style="color:#E1E4E8">          &#x3C;/</span><span style="color:#79B8FF">CardStack.List</span><span style="color:#E1E4E8">></span></span>
-<span class="line"><span style="color:#E1E4E8">        &#x3C;/</span><span style="color:#79B8FF">CardStack.Viewport</span><span style="color:#E1E4E8">></span></span>
-<span class="line"><span style="color:#E1E4E8">      &#x3C;/</span><span style="color:#79B8FF">CardStack.Trigger</span><span style="color:#E1E4E8">></span></span>
-<span class="line"><span style="color:#E1E4E8">    &#x3C;/</span><span style="color:#79B8FF">CardStack.Frame</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">    &#x3C;</span><span style="color:#85E89D">section</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"absolute inset-0 overflow-visible"</span><span style="color:#B392F0"> aria-label</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"Photo stack"</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#79B8FF">CardStack.Viewport</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"absolute inset-0 overflow-visible pt-[14%] sm:pt-0"</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;</span><span style="color:#79B8FF">CardStack.List</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">          {(</span><span style="color:#FFAB70">item</span><span style="color:#F97583">:</span><span style="color:#B392F0"> PortfolioItem</span><span style="color:#E1E4E8">, </span><span style="color:#FFAB70">index</span><span style="color:#E1E4E8">, </span><span style="color:#FFAB70">layer</span><span style="color:#E1E4E8">) </span><span style="color:#F97583">=></span><span style="color:#E1E4E8"> (</span></span>
+<span class="line"><span style="color:#E1E4E8">            &#x3C;</span><span style="color:#79B8FF">CardStack.Card</span></span>
+<span class="line"><span style="color:#B392F0">              key</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{item.id}</span></span>
+<span class="line"><span style="color:#B392F0">              layer</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{layer}</span></span>
+<span class="line"><span style="color:#B392F0">              stackIndex</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{index}</span></span>
+<span class="line"><span style="color:#B392F0">              className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"!inset-x-0 !top-0 !h-fit !w-full overflow-visible rounded-none p-0 shadow-none ring-0"</span></span>
+<span class="line"><span style="color:#E1E4E8">            ></span></span>
+<span class="line"><span style="color:#E1E4E8">              &#x3C;</span><span style="color:#85E89D">figure</span><span style="color:#B392F0"> className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"relative aspect-[4/5] w-full overflow-hidden bg-black/5"</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">                &#x3C;</span><span style="color:#85E89D">img</span></span>
+<span class="line"><span style="color:#B392F0">                  src</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{item.image}</span></span>
+<span class="line"><span style="color:#B392F0">                  alt</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#9ECBFF">\`\${</span><span style="color:#79B8FF">PHOTOGRAPHER</span><span style="color:#9ECBFF">.</span><span style="color:#E1E4E8">studio</span><span style="color:#9ECBFF">} — \${</span><span style="color:#E1E4E8">item</span><span style="color:#9ECBFF">.</span><span style="color:#E1E4E8">title</span><span style="color:#9ECBFF">}\`</span><span style="color:#E1E4E8">}</span></span>
+<span class="line"><span style="color:#B392F0">                  width</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">PRINT_WIDTH</span><span style="color:#E1E4E8">}</span></span>
+<span class="line"><span style="color:#B392F0">                  height</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">PRINT_HEIGHT</span><span style="color:#E1E4E8">}</span></span>
+<span class="line"><span style="color:#B392F0">                  decoding</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"async"</span></span>
+<span class="line"><span style="color:#B392F0">                  draggable</span><span style="color:#F97583">=</span><span style="color:#E1E4E8">{</span><span style="color:#79B8FF">false</span><span style="color:#E1E4E8">}</span></span>
+<span class="line"><span style="color:#B392F0">                  className</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"size-full object-cover object-center"</span></span>
+<span class="line"><span style="color:#E1E4E8">                /></span></span>
+<span class="line"><span style="color:#E1E4E8">                {index </span><span style="color:#F97583">===</span><span style="color:#79B8FF"> 0</span><span style="color:#F97583"> ?</span><span style="color:#E1E4E8"> &#x3C;</span><span style="color:#79B8FF">ViewfinderFrame</span><span style="color:#E1E4E8"> /> </span><span style="color:#F97583">:</span><span style="color:#79B8FF"> null</span><span style="color:#E1E4E8">}</span></span>
+<span class="line"><span style="color:#E1E4E8">              &#x3C;/</span><span style="color:#85E89D">figure</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">            &#x3C;/</span><span style="color:#79B8FF">CardStack.Card</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">          )}</span></span>
+<span class="line"><span style="color:#E1E4E8">        &#x3C;/</span><span style="color:#79B8FF">CardStack.List</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">      &#x3C;/</span><span style="color:#79B8FF">CardStack.Viewport</span><span style="color:#E1E4E8">></span></span>
+<span class="line"><span style="color:#E1E4E8">      &#x3C;</span><span style="color:#79B8FF">CardStack.Trigger</span><span style="color:#B392F0"> full</span><span style="color:#B392F0"> aria-label</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">"Show next photo"</span><span style="color:#E1E4E8"> /></span></span>
+<span class="line"><span style="color:#E1E4E8">    &#x3C;/</span><span style="color:#85E89D">section</span><span style="color:#E1E4E8">></span></span>
 <span class="line"><span style="color:#E1E4E8">  );</span></span>
 <span class="line"><span style="color:#E1E4E8">}</span></span>
 <span class="line"></span>

--- a/app/demo/generated/demo-sources.ts
+++ b/app/demo/generated/demo-sources.ts
@@ -2622,6 +2622,7 @@ const HERO_TONE = {
 } as const;
 
 type PortfolioItem = CardStackItem & {
+  id: PortfolioId;
   image: string;
   title: string;
   tagline: string;
@@ -2746,10 +2747,7 @@ function PrintCaption() {
   const { activeItem } = useCardStack<PortfolioItem>();
   const rawIndex = activeItem ? PORTFOLIO.findIndex((item) => item.id === activeItem.id) : -1;
   const index = rawIndex === -1 ? 1 : rawIndex + 1;
-  const settings =
-    activeItem && activeItem.id in SHOT_SETTINGS
-      ? SHOT_SETTINGS[activeItem.id as PortfolioId]
-      : SHOT_SETTINGS.vows;
+  const settings = activeItem ? SHOT_SETTINGS[activeItem.id] : SHOT_SETTINGS.vows;
 
   if (!activeItem || !settings) {
     return null;
@@ -3014,6 +3012,7 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#24292E">} </span><span style="color:#D73A49">as</span><span style="color:#D73A49"> const</span><span style="color:#24292E">;</span></span>
 <span class="line"></span>
 <span class="line"><span style="color:#D73A49">type</span><span style="color:#6F42C1"> PortfolioItem</span><span style="color:#D73A49"> =</span><span style="color:#6F42C1"> CardStackItem</span><span style="color:#D73A49"> &#x26;</span><span style="color:#24292E"> {</span></span>
+<span class="line"><span style="color:#E36209">  id</span><span style="color:#D73A49">:</span><span style="color:#6F42C1"> PortfolioId</span><span style="color:#24292E">;</span></span>
 <span class="line"><span style="color:#E36209">  image</span><span style="color:#D73A49">:</span><span style="color:#005CC5"> string</span><span style="color:#24292E">;</span></span>
 <span class="line"><span style="color:#E36209">  title</span><span style="color:#D73A49">:</span><span style="color:#005CC5"> string</span><span style="color:#24292E">;</span></span>
 <span class="line"><span style="color:#E36209">  tagline</span><span style="color:#D73A49">:</span><span style="color:#005CC5"> string</span><span style="color:#24292E">;</span></span>
@@ -3138,10 +3137,7 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#D73A49">  const</span><span style="color:#24292E"> { </span><span style="color:#005CC5">activeItem</span><span style="color:#24292E"> } </span><span style="color:#D73A49">=</span><span style="color:#6F42C1"> useCardStack</span><span style="color:#24292E">&#x3C;</span><span style="color:#6F42C1">PortfolioItem</span><span style="color:#24292E">>();</span></span>
 <span class="line"><span style="color:#D73A49">  const</span><span style="color:#005CC5"> rawIndex</span><span style="color:#D73A49"> =</span><span style="color:#24292E"> activeItem </span><span style="color:#D73A49">?</span><span style="color:#005CC5"> PORTFOLIO</span><span style="color:#24292E">.</span><span style="color:#6F42C1">findIndex</span><span style="color:#24292E">((</span><span style="color:#E36209">item</span><span style="color:#24292E">) </span><span style="color:#D73A49">=></span><span style="color:#24292E"> item.id </span><span style="color:#D73A49">===</span><span style="color:#24292E"> activeItem.id) </span><span style="color:#D73A49">:</span><span style="color:#D73A49"> -</span><span style="color:#005CC5">1</span><span style="color:#24292E">;</span></span>
 <span class="line"><span style="color:#D73A49">  const</span><span style="color:#005CC5"> index</span><span style="color:#D73A49"> =</span><span style="color:#24292E"> rawIndex </span><span style="color:#D73A49">===</span><span style="color:#D73A49"> -</span><span style="color:#005CC5">1</span><span style="color:#D73A49"> ?</span><span style="color:#005CC5"> 1</span><span style="color:#D73A49"> :</span><span style="color:#24292E"> rawIndex </span><span style="color:#D73A49">+</span><span style="color:#005CC5"> 1</span><span style="color:#24292E">;</span></span>
-<span class="line"><span style="color:#D73A49">  const</span><span style="color:#005CC5"> settings</span><span style="color:#D73A49"> =</span></span>
-<span class="line"><span style="color:#24292E">    activeItem </span><span style="color:#D73A49">&#x26;&#x26;</span><span style="color:#24292E"> activeItem.id </span><span style="color:#D73A49">in</span><span style="color:#005CC5"> SHOT_SETTINGS</span></span>
-<span class="line"><span style="color:#D73A49">      ?</span><span style="color:#005CC5"> SHOT_SETTINGS</span><span style="color:#24292E">[activeItem.id </span><span style="color:#D73A49">as</span><span style="color:#6F42C1"> PortfolioId</span><span style="color:#24292E">]</span></span>
-<span class="line"><span style="color:#D73A49">      :</span><span style="color:#005CC5"> SHOT_SETTINGS</span><span style="color:#24292E">.vows;</span></span>
+<span class="line"><span style="color:#D73A49">  const</span><span style="color:#005CC5"> settings</span><span style="color:#D73A49"> =</span><span style="color:#24292E"> activeItem </span><span style="color:#D73A49">?</span><span style="color:#005CC5"> SHOT_SETTINGS</span><span style="color:#24292E">[activeItem.id] </span><span style="color:#D73A49">:</span><span style="color:#005CC5"> SHOT_SETTINGS</span><span style="color:#24292E">.vows;</span></span>
 <span class="line"></span>
 <span class="line"><span style="color:#D73A49">  if</span><span style="color:#24292E"> (</span><span style="color:#D73A49">!</span><span style="color:#24292E">activeItem </span><span style="color:#D73A49">||</span><span style="color:#D73A49"> !</span><span style="color:#24292E">settings) {</span></span>
 <span class="line"><span style="color:#D73A49">    return</span><span style="color:#005CC5"> null</span><span style="color:#24292E">;</span></span>
@@ -3406,6 +3402,7 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#E1E4E8">} </span><span style="color:#F97583">as</span><span style="color:#F97583"> const</span><span style="color:#E1E4E8">;</span></span>
 <span class="line"></span>
 <span class="line"><span style="color:#F97583">type</span><span style="color:#B392F0"> PortfolioItem</span><span style="color:#F97583"> =</span><span style="color:#B392F0"> CardStackItem</span><span style="color:#F97583"> &#x26;</span><span style="color:#E1E4E8"> {</span></span>
+<span class="line"><span style="color:#FFAB70">  id</span><span style="color:#F97583">:</span><span style="color:#B392F0"> PortfolioId</span><span style="color:#E1E4E8">;</span></span>
 <span class="line"><span style="color:#FFAB70">  image</span><span style="color:#F97583">:</span><span style="color:#79B8FF"> string</span><span style="color:#E1E4E8">;</span></span>
 <span class="line"><span style="color:#FFAB70">  title</span><span style="color:#F97583">:</span><span style="color:#79B8FF"> string</span><span style="color:#E1E4E8">;</span></span>
 <span class="line"><span style="color:#FFAB70">  tagline</span><span style="color:#F97583">:</span><span style="color:#79B8FF"> string</span><span style="color:#E1E4E8">;</span></span>
@@ -3530,10 +3527,7 @@ export default function PhotographerPortfolio() {
 <span class="line"><span style="color:#F97583">  const</span><span style="color:#E1E4E8"> { </span><span style="color:#79B8FF">activeItem</span><span style="color:#E1E4E8"> } </span><span style="color:#F97583">=</span><span style="color:#B392F0"> useCardStack</span><span style="color:#E1E4E8">&#x3C;</span><span style="color:#B392F0">PortfolioItem</span><span style="color:#E1E4E8">>();</span></span>
 <span class="line"><span style="color:#F97583">  const</span><span style="color:#79B8FF"> rawIndex</span><span style="color:#F97583"> =</span><span style="color:#E1E4E8"> activeItem </span><span style="color:#F97583">?</span><span style="color:#79B8FF"> PORTFOLIO</span><span style="color:#E1E4E8">.</span><span style="color:#B392F0">findIndex</span><span style="color:#E1E4E8">((</span><span style="color:#FFAB70">item</span><span style="color:#E1E4E8">) </span><span style="color:#F97583">=></span><span style="color:#E1E4E8"> item.id </span><span style="color:#F97583">===</span><span style="color:#E1E4E8"> activeItem.id) </span><span style="color:#F97583">:</span><span style="color:#F97583"> -</span><span style="color:#79B8FF">1</span><span style="color:#E1E4E8">;</span></span>
 <span class="line"><span style="color:#F97583">  const</span><span style="color:#79B8FF"> index</span><span style="color:#F97583"> =</span><span style="color:#E1E4E8"> rawIndex </span><span style="color:#F97583">===</span><span style="color:#F97583"> -</span><span style="color:#79B8FF">1</span><span style="color:#F97583"> ?</span><span style="color:#79B8FF"> 1</span><span style="color:#F97583"> :</span><span style="color:#E1E4E8"> rawIndex </span><span style="color:#F97583">+</span><span style="color:#79B8FF"> 1</span><span style="color:#E1E4E8">;</span></span>
-<span class="line"><span style="color:#F97583">  const</span><span style="color:#79B8FF"> settings</span><span style="color:#F97583"> =</span></span>
-<span class="line"><span style="color:#E1E4E8">    activeItem </span><span style="color:#F97583">&#x26;&#x26;</span><span style="color:#E1E4E8"> activeItem.id </span><span style="color:#F97583">in</span><span style="color:#79B8FF"> SHOT_SETTINGS</span></span>
-<span class="line"><span style="color:#F97583">      ?</span><span style="color:#79B8FF"> SHOT_SETTINGS</span><span style="color:#E1E4E8">[activeItem.id </span><span style="color:#F97583">as</span><span style="color:#B392F0"> PortfolioId</span><span style="color:#E1E4E8">]</span></span>
-<span class="line"><span style="color:#F97583">      :</span><span style="color:#79B8FF"> SHOT_SETTINGS</span><span style="color:#E1E4E8">.vows;</span></span>
+<span class="line"><span style="color:#F97583">  const</span><span style="color:#79B8FF"> settings</span><span style="color:#F97583"> =</span><span style="color:#E1E4E8"> activeItem </span><span style="color:#F97583">?</span><span style="color:#79B8FF"> SHOT_SETTINGS</span><span style="color:#E1E4E8">[activeItem.id] </span><span style="color:#F97583">:</span><span style="color:#79B8FF"> SHOT_SETTINGS</span><span style="color:#E1E4E8">.vows;</span></span>
 <span class="line"></span>
 <span class="line"><span style="color:#F97583">  if</span><span style="color:#E1E4E8"> (</span><span style="color:#F97583">!</span><span style="color:#E1E4E8">activeItem </span><span style="color:#F97583">||</span><span style="color:#F97583"> !</span><span style="color:#E1E4E8">settings) {</span></span>
 <span class="line"><span style="color:#F97583">    return</span><span style="color:#79B8FF"> null</span><span style="color:#E1E4E8">;</span></span>

--- a/app/demo/library/hero/photographer-portfolio.tsx
+++ b/app/demo/library/hero/photographer-portfolio.tsx
@@ -76,6 +76,7 @@ const HERO_TONE = {
 } as const;
 
 type PortfolioItem = CardStackItem & {
+  id: PortfolioId;
   image: string;
   title: string;
   tagline: string;
@@ -200,10 +201,7 @@ function PrintCaption() {
   const { activeItem } = useCardStack<PortfolioItem>();
   const rawIndex = activeItem ? PORTFOLIO.findIndex((item) => item.id === activeItem.id) : -1;
   const index = rawIndex === -1 ? 1 : rawIndex + 1;
-  const settings =
-    activeItem && activeItem.id in SHOT_SETTINGS
-      ? SHOT_SETTINGS[activeItem.id as PortfolioId]
-      : SHOT_SETTINGS.vows;
+  const settings = activeItem ? SHOT_SETTINGS[activeItem.id] : SHOT_SETTINGS.vows;
 
   if (!activeItem || !settings) {
     return null;

--- a/app/demo/library/hero/photographer-portfolio.tsx
+++ b/app/demo/library/hero/photographer-portfolio.tsx
@@ -3,11 +3,7 @@
 import "@fontsource-variable/instrument-sans";
 import { type CSSProperties, type ReactNode, type RefObject, useRef, useState } from "react";
 
-import CardStack, {
-  CARD_STACK_MASK_IDS,
-  type CardStackItem,
-  useCardStack,
-} from "@/animata/card/card-stack";
+import CardStack, { type CardStackItem, useCardStack } from "@/animata/card/card-stack";
 import TrailingImage from "@/animata/image/trailing-image";
 import SplitReveal from "@/animata/preloader/split-reveal";
 import { MapPinIcon } from "@/components/ui/map-pin";
@@ -79,48 +75,48 @@ const HERO_TONE = {
   ink: "text-black",
 } as const;
 
-const PORTFOLIO: CardStackItem[] = [
+type PortfolioItem = CardStackItem & {
+  image: string;
+  title: string;
+  tagline: string;
+};
+
+const PORTFOLIO: PortfolioItem[] = [
   {
     id: "vows",
     image: lummi(LUMMI_ASSETS.portfolio.vows),
     title: "Vows",
     tagline: "Cliffside ceremony",
-    maskId: CARD_STACK_MASK_IDS[0],
   },
   {
     id: "ceremony",
     image: lummi(LUMMI_ASSETS.portfolio.ceremony),
     title: "Ceremony",
     tagline: "Church exit",
-    maskId: CARD_STACK_MASK_IDS[0],
   },
   {
     id: "reception",
     image: lummi(LUMMI_ASSETS.portfolio.reception),
     title: "Reception",
     tagline: "Evening dance",
-    maskId: CARD_STACK_MASK_IDS[0],
   },
   {
     id: "candid",
     image: lummi(LUMMI_ASSETS.portfolio.candid),
     title: "Candid",
     tagline: "Real laughter",
-    maskId: CARD_STACK_MASK_IDS[0],
   },
   {
     id: "florals",
     image: lummi(LUMMI_ASSETS.portfolio.florals),
     title: "Florals",
     tagline: "Bouquet detail",
-    maskId: CARD_STACK_MASK_IDS[0],
   },
   {
     id: "festival",
     image: lummi(LUMMI_ASSETS.portfolio.festival),
     title: "Event",
     tagline: "Summer festival",
-    maskId: CARD_STACK_MASK_IDS[0],
   },
 ];
 
@@ -201,7 +197,7 @@ function ViewfinderFrame() {
 }
 
 function PrintCaption() {
-  const { activeItem } = useCardStack();
+  const { activeItem } = useCardStack<PortfolioItem>();
   const rawIndex = activeItem ? PORTFOLIO.findIndex((item) => item.id === activeItem.id) : -1;
   const index = rawIndex === -1 ? 1 : rawIndex + 1;
   const settings =
@@ -244,36 +240,34 @@ const STACK_PEEK = "aspect-[8/1]";
 
 function PrintStack() {
   return (
-    <CardStack.Frame className="absolute inset-0 overflow-visible">
-      <CardStack.LiveRegion />
-      <CardStack.Trigger aria-label="Show next photo" className="absolute inset-0 block text-left">
-        <CardStack.Viewport className="absolute inset-0 overflow-visible !min-h-0 pt-[14%] sm:pt-0">
-          <CardStack.List>
-            {(item, index, layer) => (
-              <CardStack.Card
-                key={item.id}
-                layer={layer}
-                stackIndex={index}
-                className="!inset-x-0 !top-0 !h-fit !w-full gap-0 overflow-visible rounded-none !bg-transparent p-0 shadow-none ring-0"
-              >
-                <figure className="relative aspect-[4/5] w-full overflow-hidden bg-black/5">
-                  <img
-                    src={item.image}
-                    alt={`${PHOTOGRAPHER.studio} — ${item.title}`}
-                    width={PRINT_WIDTH}
-                    height={PRINT_HEIGHT}
-                    decoding="async"
-                    draggable={false}
-                    className="size-full object-cover object-center"
-                  />
-                  {index === 0 ? <ViewfinderFrame /> : null}
-                </figure>
-              </CardStack.Card>
-            )}
-          </CardStack.List>
-        </CardStack.Viewport>
-      </CardStack.Trigger>
-    </CardStack.Frame>
+    <section className="absolute inset-0 overflow-visible" aria-label="Photo stack">
+      <CardStack.Viewport className="absolute inset-0 overflow-visible pt-[14%] sm:pt-0">
+        <CardStack.List>
+          {(item: PortfolioItem, index, layer) => (
+            <CardStack.Card
+              key={item.id}
+              layer={layer}
+              stackIndex={index}
+              className="!inset-x-0 !top-0 !h-fit !w-full overflow-visible rounded-none p-0 shadow-none ring-0"
+            >
+              <figure className="relative aspect-[4/5] w-full overflow-hidden bg-black/5">
+                <img
+                  src={item.image}
+                  alt={`${PHOTOGRAPHER.studio} — ${item.title}`}
+                  width={PRINT_WIDTH}
+                  height={PRINT_HEIGHT}
+                  decoding="async"
+                  draggable={false}
+                  className="size-full object-cover object-center"
+                />
+                {index === 0 ? <ViewfinderFrame /> : null}
+              </figure>
+            </CardStack.Card>
+          )}
+        </CardStack.List>
+      </CardStack.Viewport>
+      <CardStack.Trigger full aria-label="Show next photo" />
+    </section>
   );
 }
 

--- a/app/demo/library/shared/card-stack-people.ts
+++ b/app/demo/library/shared/card-stack-people.ts
@@ -1,6 +1,6 @@
-import { CARD_STACK_MASK_IDS, type CardStackItem } from "@/animata/card/card-stack";
+import { CARD_STACK_MASK_IDS, type CardStackProfileItem } from "@/animata/card/card-stack-profile";
 
-export const DEMO_PEOPLE: CardStackItem[] = [
+export const DEMO_PEOPLE: CardStackProfileItem[] = [
   {
     id: "maya",
     image:
@@ -132,7 +132,7 @@ export const CANDIDATE_META: Record<string, { role: string; stage: string; skill
   },
 };
 
-export const LOOKBOOK_ITEMS: CardStackItem[] = [
+export const LOOKBOOK_ITEMS: CardStackProfileItem[] = [
   {
     id: "shell",
     image: "https://images.unsplash.com/photo-1556821840-3a63f95609a7?auto=format&w=800&q=80",
@@ -175,7 +175,7 @@ export const LOOKBOOK_ITEMS: CardStackItem[] = [
   },
 ];
 
-export const GUEST_ITEMS: CardStackItem[] = DEMO_PEOPLE.map((person) => ({
+export const GUEST_ITEMS: CardStackProfileItem[] = DEMO_PEOPLE.map((person) => ({
   ...person,
   tagline: person.tagline.split(" · ")[0] ?? person.tagline,
 }));

--- a/app/demo/library/shared/profile-stack-card.tsx
+++ b/app/demo/library/shared/profile-stack-card.tsx
@@ -27,7 +27,9 @@ export function ProfileStackCard({
       layer={layer}
       showMetrics={showMetrics}
       className={cardClassName}
-      footerTrailing={<ArrowRight aria-hidden className="ml-auto size-6 shrink-0 text-black/40" />}
+      footerTrailing={
+        <ArrowRight aria-hidden className="ml-auto size-6 shrink-0 text-muted-foreground" />
+      }
     />
   );
 }

--- a/app/demo/library/shared/profile-stack-card.tsx
+++ b/app/demo/library/shared/profile-stack-card.tsx
@@ -1,15 +1,12 @@
 "use client";
 
-import { ArrowRight, Heart, MessageCircle } from "lucide-react";
+import { ArrowRight } from "lucide-react";
 
-import CardStack, {
-  type CardStackItem,
-  type CardStackLayerMotion,
-} from "@/animata/card/card-stack";
-import { cn } from "@/lib/utils";
+import CardStack, { type CardStackLayerMotion } from "@/animata/card/card-stack";
+import { CardStackProfileCard, type CardStackProfileItem } from "@/animata/card/card-stack-profile";
 
 interface ProfileStackCardProps {
-  item: CardStackItem;
+  item: CardStackProfileItem;
   index: number;
   layer: CardStackLayerMotion;
   cardClassName?: string;
@@ -24,35 +21,13 @@ export function ProfileStackCard({
   showMetrics = true,
 }: ProfileStackCardProps) {
   return (
-    <CardStack.Card
-      key={item.id}
+    <CardStackProfileCard
+      item={item}
+      index={index}
       layer={layer}
-      stackIndex={index}
-      className={cn(
-        "bg-linear-to-br from-[#f5efe6] via-[#faf8f5] to-white ring-white/20",
-        "dark:from-pink-950 dark:via-card dark:to-card dark:ring-border/60",
-        cardClassName,
-      )}
-    >
-      <CardStack.Header>
-        <CardStack.Avatar src={item.image} />
-        <CardStack.Meta title={item.title} tagline={item.tagline} />
-      </CardStack.Header>
-
-      <CardStack.Media src={item.image} alt={`Portrait of ${item.title}`} maskId={item.maskId} />
-
-      {showMetrics ? (
-        <CardStack.Footer>
-          <CardStack.Metric icon={Heart} label="Likes" value={item.counts?.like ?? 0} />
-          <CardStack.Metric
-            icon={MessageCircle}
-            label="Comments"
-            value={item.counts?.comment ?? 0}
-            className="ms-1"
-          />
-          <ArrowRight aria-hidden className="ml-auto size-6 shrink-0 text-black/40" />
-        </CardStack.Footer>
-      ) : null}
-    </CardStack.Card>
+      showMetrics={showMetrics}
+      className={cardClassName}
+      footerTrailing={<ArrowRight aria-hidden className="ml-auto size-6 shrink-0 text-black/40" />}
+    />
   );
 }

--- a/config/docs.ts
+++ b/config/docs.ts
@@ -85,6 +85,11 @@ const sidebarNav: SidebarNavItem[] = [
         items: [],
       },
       {
+        title: "Changelog",
+        href: "/docs/contributing/changelog",
+        items: [],
+      },
+      {
         title: "Category glyph tiles",
         href: "/docs/contributing/category-glyphs",
         items: [],

--- a/content/docs/card/card-stack.mdx
+++ b/content/docs/card/card-stack.mdx
@@ -1,6 +1,6 @@
 ---
 title: Card Stack
-description: Click-through card stack with SVG photo masks. The deck loops; cards shuffle in one motion.
+description: Click-through card stack. The deck loops; cards shuffle in one motion.
 labels: ["requires interaction", "click"]
 author: hari
 ---
@@ -13,7 +13,7 @@ author: hari
 
 <RegistryInstall category="card" name="card-stack" />
 
-The registry item installs `card-stack.tsx` and `components/shapes/card-stack-mask-defs.tsx`.
+The registry item installs `card-stack.tsx`.
 
 ### Manual
 
@@ -21,19 +21,7 @@ The registry item installs `card-stack.tsx` and `components/shapes/card-stack-ma
 <Step>Install dependencies</Step>
 
 ```bash
-npm install motion lucide-react
-```
-
-<Step>Create the mask definitions</Step>
-
-Photos use CSS `mask-image` pointing at SVG `<mask>` ids. Render a hidden 0×0 SVG once per stack (`CardStack.Masks`) so those ids exist in the document.
-
-```bash
-mkdir -p components/shapes && touch components/shapes/card-stack-mask-defs.tsx
-```
-
-```jsx file=<rootDir>/components/shapes/card-stack-mask-defs.tsx
-
+npm install motion
 ```
 
 <Step>Create the component</Step>
@@ -50,77 +38,105 @@ mkdir -p components/animata/card && touch components/animata/card/card-stack.tsx
 
 ## Usage
 
-Build the stack from `CardStack.*` parts. Pass `items` with stable `id`s, set `depth` (1–3 visible cards), and render each card in `CardStack.List`.
+`CardStack` is bare bones: rotation state, layered motion, and advance controls. You bring the card markup and styling.
+
+Pass `items` with stable `id`s, set `depth` (1–3 visible cards), and render each card in `CardStack.List`. Extend the item type with whatever fields your UI needs.
 
 ```tsx
-import { Heart, MessageCircle } from "lucide-react";
-import CardStack, { CARD_STACK_MASK_IDS, type CardStackItem } from "@/animata/card/card-stack";
+import CardStack, { type CardStackItem } from "@/animata/card/card-stack";
 
-const items: CardStackItem[] = [
-  {
-    id: "hari",
-    image: "/hari.jpg",
-    title: "Hari Lamichhane",
-    tagline: "Software Engineer",
-    counts: { like: 142, comment: 23 },
-    maskId: CARD_STACK_MASK_IDS[0],
-  },
-  // …more items
+type Person = CardStackItem & { name: string; role: string };
+
+const items: Person[] = [
+  { id: "hari", name: "Hari", role: "Engineer" },
+  // …
 ];
 
 <CardStack items={items} depth={3}>
-  <CardStack.Frame className="relative mx-auto w-full max-w-sm overflow-hidden">
-    <CardStack.Masks />
-    <CardStack.LiveRegion />
-
-    <CardStack.Trigger>
-      <CardStack.Viewport>
-        <CardStack.List>
-          {(item, index, layer) => (
-            <CardStack.Card key={item.id} layer={layer} stackIndex={index}>
-              <CardStack.Header>
-                <CardStack.Avatar src={item.image} />
-                <CardStack.Meta title={item.title} tagline={item.tagline} />
-              </CardStack.Header>
-
-              <CardStack.Media
-                src={item.image}
-                alt={`Portrait of ${item.title}`}
-                maskId={item.maskId}
-              />
-
-              <CardStack.Footer>
-                <CardStack.Metric icon={Heart} label="Likes" value={item.counts?.like ?? 0} />
-                <CardStack.Metric icon={MessageCircle} label="Comments" value={item.counts?.comment ?? 0} />
-              </CardStack.Footer>
-            </CardStack.Card>
-          )}
-        </CardStack.List>
-      </CardStack.Viewport>
-    </CardStack.Trigger>
-  </CardStack.Frame>
+  <section className="relative mx-auto w-full max-w-sm">
+    <CardStack.Viewport className="min-h-96">
+      <CardStack.List>
+        {(item, index, layer) => (
+          <CardStack.Card key={item.id} layer={layer} stackIndex={index} className="rounded-2xl bg-card p-4 shadow-lg">
+            <p className="font-medium">{item.name}</p>
+            <p className="text-sm text-muted-foreground">{item.role}</p>
+            {index === 0 ? (
+              <CardStack.Trigger aria-label="Show next card">Next</CardStack.Trigger>
+            ) : null}
+          </CardStack.Card>
+        )}
+      </CardStack.List>
+    </CardStack.Viewport>
+  </section>
 </CardStack>
 ```
 
-`CardStack.Trigger` is a `<button>`. Click anywhere on the stack to advance. Hook `onItemsChange` on the root if you want the rotated array. Inside custom children, `useCardStack()` exposes `activeItem`, `advance`, and layer presets.
+`CardStack.Trigger` defaults to a real `<button>`. Wrap an icon or label and place it where you want. Only put it on the front card (`index === 0`) so back cards stay inert.
 
-Each card gets a mask from `CARD_STACK_MASK_IDS`: `ellipse-1`, `flower-14`, `flower-1`, or `misc-5`. `CardStack.Media` takes `aspect`: `square`, `4/5`, `3/4`, `16/10`, or `fill`.
+For click-anywhere advance, pass `full` and render the trigger as a sibling after `CardStack.Viewport` inside a `relative` container:
+
+```tsx
+<section className="relative ...">
+  <CardStack.Viewport>...</CardStack.Viewport>
+  <CardStack.Trigger full aria-label="Show next card" />
+</section>
+```
+
+Hook `onItemsChange` on the root if you want the rotated array. `useCardStack()` exposes `activeItem`, `advance`, and layer presets.
+
+The Storybook preview composes a profile card demo on top of the stack (masked photos, header, metrics). That layout lives in the story source — copy and adapt it, or build your own card shell inside `CardStack.Card`.
+
+## Props
+
+<PropsTable title="CardStack">
+  <PropsTable.Row prop="items" type="T[]">
+    Array of items with stable `id` fields. Extend `CardStackItem` with any fields your card UI needs.
+  </PropsTable.Row>
+  <PropsTable.Row prop="depth" type="number" default="3">
+    Visible cards in the stack (1–3).
+  </PropsTable.Row>
+  <PropsTable.Row prop="autoplay" type="boolean" default="false">
+    Auto-advance when the tab is visible.
+  </PropsTable.Row>
+  <PropsTable.Row prop="autoplayInterval" type="number" default="4500">
+    Milliseconds between autoplay steps.
+  </PropsTable.Row>
+  <PropsTable.Row prop="onItemsChange" type="(items: T[]) => void">
+    Called after each rotation with the reordered array.
+  </PropsTable.Row>
+</PropsTable>
+
+<PropsTable title="CardStack.Trigger">
+  <PropsTable.Row prop="full" type="boolean" default="false">
+    When true, renders an absolute inset-0 overlay for click-anywhere advance. When false, renders a real `button` for a discrete control (icon, label, etc.).
+  </PropsTable.Row>
+  <PropsTable.Row prop="aria-label" type="string" default='"Show next card"'>
+    Accessible name. Required for the `full` overlay (no visible label).
+  </PropsTable.Row>
+</PropsTable>
 
 ## How it works
 
 The root holds the full `items` array but only renders the first `depth` entries. On advance, the front item moves to the back. Same cards, infinite loop, no full remount.
 
-`CardStack.List` uses `AnimatePresence` with `mode="sync"`. Click and the front card exits (`y: "125%"`, `scale: 0.96`) while the cards behind move up into the next layer at the same time. One shuffle, not exit-then-enter.
+`CardStack.List` uses `AnimatePresence` with `mode="sync"`. Click and the front card exits while the cards behind move up into the next layer at the same time. One shuffle, not exit-then-enter.
 
 Stacking order comes from Motion `zIndex`, not Tailwind `z-*`: front at 20, middle at 5, back at 0. On exit the front card jumps to 30 so it slides out over the stack rising underneath.
 
-Only one shuffle runs at a time. Extra clicks during the animation are dropped. Nothing queues up and keeps playing after you stop clicking.
+Only one shuffle runs at a time. Extra clicks during the animation are dropped.
 
 The back slot peeks in from a smaller offset when a card first becomes visible. Cards moving up from the middle use `initial={false}` so they tween from where they already are instead of popping in again.
 
-`CardStack.Masks` renders `CardStackMaskDefs`, a hidden SVG. Photos reference its `<mask>` ids via `mask-image: url(#cardstack_mask_…)`. One defs instance per page; duplicate ids break masking.
+With `prefers-reduced-motion`, rotation is instant and durations go to zero.
 
-`CardStack.LiveRegion` announces the active card. Cards are `motion.article` with `aria-roledescription`. Metrics keep visible counts but label them in `sr-only` text. With `prefers-reduced-motion`, rotation is instant and durations go to zero.
+## Changelog
+
+### 2026-06-12
+
+- Trimmed the registry component to stack mechanics only: `CardStack`, `Viewport`, `List`, `Card`, and `Trigger`. You supply card markup and styling; `CardStackItem` is `{ id: string }` plus whatever fields your UI needs.
+- Moved profile card UI (SVG masks, header, avatar, media, metrics) out of the registry bundle into the Storybook demo composition (`card-stack-profile.tsx` in the repo, not shipped via CLI).
+- Added `full` on `CardStack.Trigger`: default is a real `<button>` for a discrete control; `full` renders an absolute inset-0 overlay for click-anywhere advance inside a `relative` container.
+- Fixed invalid HTML from wrapping card flow content in a `<button>`.
 
 ## Credits
 

--- a/content/docs/card/index.mdx
+++ b/content/docs/card/index.mdx
@@ -5,3 +5,11 @@ author: sudhashrestha
 ---
 
 <CategoryIndex category="card" />
+
+## Recent changes
+
+| Date | Component | Change |
+| --- | --- | --- |
+| 2026-06 | [Card Stack](/docs/card/card-stack) | Bare-bones stack API; profile UI in Storybook demo; `Trigger` `full` overlay |
+| 2026-06 | [Card Spread](/docs/card/card-spread) | Throw-on-click easing; Safari spread jitter fix |
+| 2026-06 | [Collab Card](/docs/card/collab-card) | New — multiplayer presence card with animated cursors |

--- a/content/docs/changelog/2026-06.mdx
+++ b/content/docs/changelog/2026-06.mdx
@@ -1,10 +1,10 @@
 ---
 title: June 2026
-description: Stacked Sections, widget glance polish, Card Spread and Collab Card, and catalog cleanup.
+description: Stacked Sections, widget glance polish, Card Spread, Collab Card, Card Stack API trim, and catalog cleanup.
 date: 2026-06-01
 ---
 
-Added Stacked Sections for pinned chapter scroll stories. Wave 1 widgets got Apple-style type hierarchy and props-driven demos. Card Spread was rebuilt for deck, peek, and throw-on-click motion. Four oversized widgets left the public catalog, and the internal widget standards doc was removed from contributing.
+Added Stacked Sections for pinned chapter scroll stories. Wave 1 widgets got Apple-style type hierarchy and props-driven demos. Card Spread was rebuilt for deck, peek, and throw-on-click motion. Card Stack was trimmed to bare-bones stack mechanics with profile UI moved to the Storybook demo. Four oversized widgets left the public catalog, and the internal widget standards doc was removed from contributing.
 
 ## New components
 
@@ -77,6 +77,10 @@ Added Stacked Sections for pinned chapter scroll stories. Wave 1 widgets got App
   <ChangeLogEntry href="/docs/card/collab-card">
     <h3>Collab Card</h3>
     <p>Bento-sized multiplayer feature card with live presence, a Figma-style selection frame, and animated teammate cursors — reskin with props for Notion, Plane, or your own co-editing story.</p>
+  </ChangeLogEntry>
+  <ChangeLogEntry href="/docs/card/card-stack">
+    <h3>Card Stack</h3>
+    <p>Trimmed the component to bare-bones stack mechanics (`CardStack`, `Viewport`, `List`, `Card`, `Trigger`). Profile card UI — masks, header, media, metrics — moved to the Storybook demo composition. Added `full` on `Trigger` for click-anywhere overlay vs discrete button.</p>
   </ChangeLogEntry>
 </ChangeLogComponents>
 

--- a/content/docs/changelog/index.mdx
+++ b/content/docs/changelog/index.mdx
@@ -4,13 +4,15 @@ description: What's changed in Animata, month by month.
 toc: false
 ---
 
+Site-wide release overview. Each month links to a full write-up; component-level history lives on category index pages and individual docs. See [how we write changelogs](/docs/contributing/changelog) for the four-tier process.
+
 New components, bug fixes, and infrastructure changes, going back to the beta launch in June 2024.
 
 ## Recent releases
 
 ### [June 2026](/docs/changelog/2026-06)
 
-[Stacked Sections](/docs/scroll/stacked-sections), Wave 1 widget glance polish, [Card Spread](/docs/card/card-spread) throw motion, and catalog cleanup for published widgets only.
+[Stacked Sections](/docs/scroll/stacked-sections), Wave 1 widget glance polish, [Card Spread](/docs/card/card-spread) throw motion, [Card Stack](/docs/card/card-stack) API trim, and catalog cleanup for published widgets only.
 
 ### [May 2026](/docs/changelog/2026-05)
 
@@ -22,7 +24,7 @@ New components, bug fixes, and infrastructure changes, going back to the beta la
 
 | Month | Highlights |
 |---|---|
-| [June 2026](/docs/changelog/2026-06) | Stacked Sections, widget glance polish, Card Spread, unpublished four oversized widgets |
+| [June 2026](/docs/changelog/2026-06) | Stacked Sections, widget polish, Card Spread, Card Stack API trim, unpublished four oversized widgets |
 | [May 2026](/docs/changelog/2026-05) | Tailwind 4.3, Boids Ecosystem, Sibling Focus Nav, live demos, docs typography |
 | [April 2026](/docs/changelog/2026-04) | 19 text animation presets, shadcn registry, announcement ribbon, site revamp |
 | [March 2026](/docs/changelog/2026-03) | Next.js 16, Tailwind v4, Storybook 10, Biome |

--- a/content/docs/changelog/index.mdx
+++ b/content/docs/changelog/index.mdx
@@ -12,7 +12,7 @@ New components, bug fixes, and infrastructure changes, going back to the beta la
 
 ### [June 2026](/docs/changelog/2026-06)
 
-[Stacked Sections](/docs/scroll/stacked-sections), Wave 1 widget glance polish, [Card Spread](/docs/card/card-spread) throw motion, [Card Stack](/docs/card/card-stack) API trim, and catalog cleanup for published widgets only.
+[Stacked Sections](/docs/scroll/stacked-sections), polished Wave 1 widget glance affordances, added throw motion to [Card Spread](/docs/card/card-spread), trimmed the [Card Stack](/docs/card/card-stack) API, and cleaned up the catalog to published widgets only.
 
 ### [May 2026](/docs/changelog/2026-05)
 
@@ -24,7 +24,7 @@ New components, bug fixes, and infrastructure changes, going back to the beta la
 
 | Month | Highlights |
 |---|---|
-| [June 2026](/docs/changelog/2026-06) | Stacked Sections, widget polish, Card Spread, Card Stack API trim, unpublished four oversized widgets |
+| [June 2026](/docs/changelog/2026-06) | Stacked Sections, polished Wave 1 widgets, Card Spread throw motion, trimmed Card Stack API, unpublished four oversized widgets |
 | [May 2026](/docs/changelog/2026-05) | Tailwind 4.3, Boids Ecosystem, Sibling Focus Nav, live demos, docs typography |
 | [April 2026](/docs/changelog/2026-04) | 19 text animation presets, shadcn registry, announcement ribbon, site revamp |
 | [March 2026](/docs/changelog/2026-03) | Next.js 16, Tailwind v4, Storybook 10, Biome |

--- a/content/docs/contributing/changelog.mdx
+++ b/content/docs/contributing/changelog.mdx
@@ -1,0 +1,129 @@
+---
+title: Changelog
+description: Four tiers of release notes, from site overview to per-component history.
+date: 2026-06-12
+---
+
+We write release notes at four levels. Same change, different amount of detail depending on where someone lands. If you ship something users will notice, update every tier that applies.
+
+## The four tiers
+
+| Tier | File | Length | Purpose |
+| --- | --- | --- | --- |
+| 1 — Site overview | `content/docs/changelog/index.mdx` | One line per month | What shipped; link to the monthly page |
+| 2 — Monthly release | `content/docs/changelog/YYYY-MM.mdx` | Paragraph + component cards | The month's story; new / improved / docs |
+| 3 — Category index | `content/docs/{category}/index.mdx` | One table row per change | History for that category only |
+| 4 — Component doc | `content/docs/{category}/{name}.mdx` | Dated bullets | Full history for people using that component |
+
+Write top-down: nail the one-liner (tier 1), flesh it out in the monthly file (tier 2), add a row on the category index (tier 3), put the nitty-gritty on the component page (tier 4).
+
+## Tier 1 — Site overview
+
+File: `content/docs/changelog/index.mdx`
+
+Two sections. **Recent releases** holds the two newest months: one sentence each, links to anything worth calling out. **All releases** is a table of every month with a short highlight.
+
+No component cards. No implementation notes. If someone only reads this page, they should know what month to open next.
+
+```mdx
+### [June 2026](/docs/changelog/2026-06)
+
+[Stacked Sections](/docs/scroll/stacked-sections), widget glance polish, and Card Stack API trim.
+
+| Month | Highlights |
+| --- | --- |
+| [June 2026](/docs/changelog/2026-06) | Stacked Sections, widget polish, Card Stack trim |
+```
+
+New month file? Put it in **Recent releases** and bump the older of the two into **All releases**.
+
+## Tier 2 — Monthly release
+
+File: `content/docs/changelog/YYYY-MM.mdx` (new file when the calendar month turns)
+
+Frontmatter:
+
+```yaml
+---
+title: Month YYYY
+description: One-line summary of the main themes.
+date: YYYY-MM-01
+---
+```
+
+Start with a short paragraph about what the month was about. Not a bullet list.
+
+Then group entries:
+
+- New components — `<ChangeLogComponents>` with one `<ChangeLogEntry href="…">` per component
+- Improved components — same for updates and fixes worth mentioning
+- Documentation — optional; site-wide doc or infra stuff
+
+Each entry gets an `<h3>` and one paragraph: what it is, when you'd reach for it, anything odd about the implementation. More than tier 1 or 3, less than tier 4.
+
+Don't forget `config/docs.ts` under Changelog (newest month first).
+
+## Tier 3 — Category index
+
+File: `content/docs/{category}/index.mdx`
+
+Below `<CategoryIndex />`, add a **Recent changes** section. Table only.
+
+| Date | Component | Change |
+| --- | --- | --- |
+| 2026-06 | [Card Stack](/docs/card/card-stack) | Bare-bones stack API; profile UI moved to Storybook demo |
+| 2026-06 | [Card Spread](/docs/card/card-spread) | Throw easing; fixed Safari jitter on spread |
+
+Date is `YYYY-MM`, matching the monthly file you touched. Component links to the doc. Change is a short phrase; tier 4 has the rest.
+
+Only rows for that category. New components and real updates both count. If the table gets stale after ~6 months, trim old rows or fold them into an "Earlier" note.
+
+## Tier 4 — Component doc
+
+File: `content/docs/{category}/{name}.mdx`
+
+`## Changelog` near the bottom, above **Credits**. Newest date first. Bullets, past tense. Mention tradeoffs when there are any.
+
+```mdx
+## Changelog
+
+### 2026-06-12
+
+- Trimmed the public API to stack mechanics only (`CardStack`, `Viewport`, `List`, `Card`, `Trigger`). Profile card UI (masks, header, media, metrics) lives in the Storybook demo composition, not the registry bundle.
+- Added `full` on `CardStack.Trigger`: default is a discrete `<button>`; `full` renders an absolute inset-0 overlay for click-anywhere advance.
+- Fixed invalid markup from wrapping card flow content in a `<button>`.
+
+### 2026-06-04
+
+- Initial publish.
+```
+
+First publish can be just "Initial publish." You still want tier 3 and tier 4 once the component doc exists, even if tier 2 already covered the launch.
+
+## What warrants an entry
+
+| Action | Tier 1 | Tier 2 | Tier 3 | Tier 4 |
+| --- | --- | --- | --- | --- |
+| New component | Yes — mention in month summary | Yes — New components | Yes — table row | Yes — initial publish |
+| User-visible update / fix | If it shapes the month | Yes — Improved components | Yes — table row | Yes — dated bullets |
+| API or behavior break | Yes | Yes | Yes | Yes — call out migration |
+| Landing / docs-only site change | Yes | Yes — Documentation | No | No |
+| Major dependency upgrade | Yes | Yes — prose | No | No |
+| Dependency patch bumps | No | No | No | No |
+| CI / Actions only | No | No | No | No |
+| Typo in docs | No | No | No | No |
+
+## Writing style
+
+Past tense. "Added X", not "We're excited to announce X." No emojis, no ✨ 🛠 🐛 prefixes.
+
+Tier 2: say what the thing does and when you'd use it, not just its name. Tier 4: what changed, why, migration notes if someone has to do work. Registry URLs: `https://animata.design/r/{category}/{name}.json` when install matters. Not bare `npx shadcn add component-name`.
+
+## Checklist
+
+Shipping a notable component change:
+
+1. Tier 2 — entry in the current `YYYY-MM.mdx` (new month + `config/docs.ts` if needed)
+2. Tier 1 — `changelog/index.mdx` if the summary or recent table is wrong now
+3. Tier 3 — row on `content/docs/{category}/index.mdx`
+4. Tier 4 — dated section on the component MDX

--- a/content/docs/contributing/components.mdx
+++ b/content/docs/contributing/components.mdx
@@ -92,24 +92,19 @@ Your prose here…
 </Steps>
 ````
 
-### Changelog section
+### Changelog
 
-When you make a notable change to an existing component (behavior, API, a fix worth knowing, or a
-deliberate tradeoff), add a `## Changelog` section near the bottom of its doc, grouped by date
-(newest first). Keep entries short and concrete: say what changed and why, and call out tradeoffs.
+Notable component changes use [four tiers of release notes](/docs/contributing/changelog). For the component doc (tier 4), add `## Changelog` near the bottom, grouped by date (newest first):
 
 ```mdx
 ## Changelog
 
-### 2026-06-04
+### 2026-06-12
 
-- Dropped `getBoundingClientRect`; lane count is now clipped via CSS. Tradeoff: fixed lane count
-  instead of one computed from the width.
-- Centered the field so it crops evenly on both edges.
+- What changed, why, and any tradeoff or migration note.
 ```
 
-This is per-component history, separate from the site-wide [changelog](/docs/changelog), which
-still gets an entry when a component is first published.
+Also update the monthly release file (tier 2), the category index table (tier 3), and the site changelog index (tier 1) when the change warrants it — see the [changelog guide](/docs/contributing/changelog) for the checklist.
 
 ## Social (OG) image
 

--- a/content/docs/contributing/index.mdx
+++ b/content/docs/contributing/index.mdx
@@ -18,6 +18,8 @@ If you want to contribute design or inspiration to Animata, you can create a new
 
 You can contribute to the documentation by suggesting improvements, fixing typos, adding examples, or even making it easier to understand. We use [MDX](https://mdxjs.com/) to write documentation.
 
+Release notes follow a [four-tier changelog process](/docs/contributing/changelog) — site overview, monthly release, category index table, and per-component history.
+
 ## Contributing code
 
 ### Contributing components
@@ -33,3 +35,5 @@ Full-page compositions live at `/demo`. If you are building or extending a demo 
 ### Contributing bug fixes & enhancements
 
 If you want to contribute code to Animata, you can read the [contributing guidelines](/docs/contributing/guidelines) to get started. The guidelines will help you understand what to keep in mind while contributing to the project.
+
+User-visible fixes and updates should follow the [changelog guide](/docs/contributing/changelog) (monthly release, category index, and component doc).

--- a/scripts/validate-registry-install.js
+++ b/scripts/validate-registry-install.js
@@ -34,11 +34,8 @@ const INSTALL_FIXTURES = [
     id: "doc-bundled-shapes",
     label: "mdx bundled file refs + shape imports",
     item: "card/card-stack.json",
-    expectFiles: [
-      "components/animata/card/card-stack.tsx",
-      "components/shapes/card-stack-mask-defs.tsx",
-    ],
-    expectDeps: ["lucide-react", "motion"],
+    expectFiles: ["components/animata/card/card-stack.tsx"],
+    expectDeps: ["motion"],
   },
   {
     id: "co-located-shared",


### PR DESCRIPTION
Trigger full prop, and changelog tiers

Strip Card Stack to stack mechanics only. Profile UI moves to a demo module. Document the four-tier changelog process and sync entries for the API change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Click-anywhere card advancement via a new full-mode Trigger
  * Dedicated profile-style card components and demo wrappers

* **Refactor**
  * Card Stack API trimmed and generalized for custom item types
  * Landing and demo usages updated to use the profile stack composition

* **Bug Fixes**
  * Fixed invalid HTML from wrapping flow content in a button

* **Documentation**
  * Updated Card Stack docs and site changelogs; introduced a four-tier release-notes process
<!-- end of auto-generated comment: release notes by coderabbit.ai -->